### PR TITLE
docs: Deploy docs to github pages

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,6 +38,7 @@ jobs:
           components: rustfmt
       - name: cargo fmt --check
         run: cargo fmt --check
+
   clippy:
     runs-on: ubuntu-latest
     name: clippy / ${{ matrix.toolchain }}
@@ -59,12 +60,13 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           components: clippy
       - run: cargo clippy -- -D warnings
-  doc:
+
+  rustdoc:
     # run docs generation on nightly rather than stable. This enables features like
     # https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html which allows an
     # API be documented as only available in some specific platforms.
     runs-on: ubuntu-latest
-    name: doc / nightly
+    name: rustdoc / nightly
     steps:
       - uses: actions/checkout@v4
         with:
@@ -75,6 +77,7 @@ jobs:
         run: cargo doc --no-deps --all-features
         env:
           RUSTDOCFLAGS: --cfg docsrs
+
   hack:
     # cargo-hack checks combinations of feature flags to ensure that features are all additive
     # which is required for feature unification
@@ -92,3 +95,16 @@ jobs:
       # --feature-powerset runs for every combination of features
       - name: cargo hack
         run: cargo hack --feature-powerset check
+
+  docs:
+    runs-on: ubuntu-latest
+    name: docs / stable
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: 'latest'
+      - run: mdbook build docs

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,32 @@
+name: deploy docs to github pages
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy docs to GitHub Pages
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: 'latest'
+      - name: Build Book
+        run: mdbook build docs
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/book

--- a/justfile
+++ b/justfile
@@ -89,5 +89,8 @@ docs-serve:
 docs-clean:
     mdbook clean docs
 
+docs-test:
+    mdbook test docs
+
 run-watch-playground:
     cargo watch -s 'cargo run --bin playground-server'


### PR DESCRIPTION
This pull request adds gh-actions to deploy docs to gh-pages.

### CI/CD Workflow Updates:

* [`.github/workflows/check.yml`](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428R41): Renamed and restructured the `doc` job to `rustdoc`, added a new `docs` job for building documentation using `mdBook`, and improved organization by introducing feature-specific sections (`rustfmt`, `clippy`, `hack`). [[1]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428R41) [[2]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L62-R69) [[3]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428R80) [[4]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428R98-R110)

* [`.github/workflows/gh-pages.yml`](diffhunk://#diff-c04119feaeffc2c216f069aec66797f2f839a2074287060698e3a2440dec8d45R1-R32): Added a new workflow for deploying documentation to GitHub Pages. This workflow builds the documentation using `mdBook` and publishes it to the `gh-pages` branch.

### Documentation Enhancements:

* [`justfile`](diffhunk://#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1R92-R94): Introduced a new `docs-test` command to run tests on the documentation using `mdBook`, complementing the existing `docs-clean` command.