### PR TITLE
feat(playground): Add documentation system for design system components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
  "basic-toml",
  "memchr",
  "proc-macro2",
- "pulldown-cmark",
+ "pulldown-cmark 0.13.0",
  "quote",
  "rustc-hash",
  "serde",
@@ -532,6 +532,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cba6ae63eb948698e300f645f87c70f76630d505f23b8907cf1e193ee85048c1"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1045,6 +1054,7 @@ dependencies = [
  "datastar",
  "futures",
  "maud",
+ "pulldown-cmark 0.12.2",
  "serde",
  "tokio",
  "tokio-stream",
@@ -1101,6 +1111,19 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
@@ -1109,6 +1132,12 @@ dependencies = [
  "memchr",
  "unicase",
 ]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quote"
@@ -1758,6 +1787,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,3 +46,4 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 url = { version = "2", features = ["serde"] }
 uuid = { version = "1.2.2", features = ["v7"] }
+pulldown-cmark = "0.12"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -19,6 +19,13 @@
 
 - [DSP Design System](./design_system/overview.md)
 - [Component Architecture](./design_system/component_architecture.md)
+- [Components]()
+  - [Button](./design_system/components/button.md)
+  - [Banner](./design_system/components/banner.md)
+  - [Link](./design_system/components/link.md)
+  - [Shell](./design_system/components/shell.md)
+  - [Tag](./design_system/components/tag.md)
+  - [Tile](./design_system/components/tile.md)
 
 # Fundamentals
 

--- a/docs/src/design_system/components/banner.md
+++ b/docs/src/design_system/components/banner.md
@@ -1,0 +1,34 @@
+# Banner
+
+Banner component with multiple display variants for highlighting important information.
+
+## Usage Guidelines
+
+The banner component should only be used on landing pages etc. as a prominent way to display a core message.
+Use the appropriate variant based on the content structure and emphasis needed.
+
+## Variants
+
+- Accent Only
+- With Prefix
+- With Suffix
+- Full
+
+The banner is structured as follows:
+The first line is an optional prefix, the second line - which is of larger font size - is the main message, and the third line is an optional suffix.
+
+## Accessibility Notes
+
+- Semantic HTML structure ensures proper screen reader navigation
+- High contrast colors meet WCAG AA standards
+- Text is properly structured for assistive technologies
+
+<!-- TODO: verify this -->
+
+## Implementation Status
+
+✅ Fully functional - complete implementation with all variants
+
+## Design Notes
+
+None

--- a/docs/src/design_system/components/button.md
+++ b/docs/src/design_system/components/button.md
@@ -1,0 +1,36 @@
+# Button
+
+Interactive button component for user actions.
+
+## Usage Guidelines
+
+Use buttons to trigger actions, submit forms, or navigate to different sections of the application. Choose the appropriate variant based on the action's importance and context.
+
+## Variants
+
+### Primary
+The primary button is used for the most important action on a page. Use sparingly - typically only one primary button per page or section.
+
+### Secondary
+Secondary buttons are used for less important actions that still need emphasis. They can be used multiple times on a page.
+
+### Outline
+Outline buttons are used for tertiary actions or when you need a lighter visual treatment while maintaining accessibility.
+
+## Accessibility Notes
+
+<!-- TODO -->
+
+Section missing...
+
+## Implementation Status
+
+🚧 Functional but incomplete - styling verification needed, missing accessibility features
+
+## Design Notes
+
+The button component follows Carbon Design System patterns with DSP brand customizations. Spacing and typography align with the design system tokens.
+
+### Button vs. Link
+
+Use buttons for actions that trigger changes or submit data. Use links for navigation to other pages or sections. Buttons should not be used for navigation purposes.

--- a/docs/src/design_system/components/link.md
+++ b/docs/src/design_system/components/link.md
@@ -1,0 +1,33 @@
+# Link
+
+Link component for navigation and external links.
+
+## Usage Guidelines
+
+Use links for navigation between pages, sections, or external resources. The link component provides consistent styling across the application.
+
+## Variants
+
+### Default
+Standard link styling with brand colors and hover states. Suitable for all link use cases.
+
+## Accessibility Notes
+
+- Proper semantic HTML anchor tags
+- Clear focus indicators for keyboard navigation
+- Sufficient color contrast for readability
+- External links include appropriate indicators
+
+## Implementation Status
+
+✅ Functional - currently using Carbon Web Components as temporary implementation
+
+## Design Notes
+
+Currently implemented using Carbon Web Components via CDN. This provides Carbon-styled links with brand colors and hover states. Will be migrated to native Maud implementation following the component architecture patterns.
+
+### Link vs. Button
+
+Use links for navigation purposes. Use buttons for actions that trigger changes or submit data. Links should not be used for actions that modify state or submit forms.
+
+<!-- TODO: what about button-styled links? -->

--- a/docs/src/design_system/components/shell.md
+++ b/docs/src/design_system/components/shell.md
@@ -1,0 +1,36 @@
+# Shell
+
+Application shell component providing navigation and layout wrapper.
+
+## Usage Guidelines
+
+Use the shell component as the main application wrapper. It provides consistent navigation, theme management, and layout structure across the application.
+
+## Variants
+
+### Default
+Complete application shell with navigation header, search functionality, and theme toggle.
+
+## Features
+
+- **Responsive Navigation**: Adapts to different screen sizes
+- **Search Functionality**: Integrated search with accessibility features
+- **Theme Toggle**: Light/dark theme switching with persistence
+- **Side Navigation**: Collapsible sidebar navigation
+- **Accessible ARIA Labels**: Full accessibility support
+
+## Accessibility Notes
+
+- Comprehensive ARIA labels and roles
+- Keyboard navigation support
+- Screen reader optimized structure
+- Focus management for modal states
+- High contrast theme support
+
+## Implementation Status
+
+✅ Fully functional with advanced features
+
+## Design Notes
+
+Currently implemented using Carbon Web Components via CDN. Provides advanced features including responsive navigation, search functionality, and theme management. The shell serves as the primary application wrapper and maintains consistent layout across different pages.

--- a/docs/src/design_system/components/tag.md
+++ b/docs/src/design_system/components/tag.md
@@ -1,0 +1,33 @@
+# Tag
+
+Tag component with different color variants for categorization and labeling.
+
+## Usage Guidelines
+
+Use tags to categorize content, show status, or provide quick visual identification. Choose colors that align with your content's meaning and maintain consistency across the application.
+
+## Variants
+
+### Gray
+Default neutral tag for general categorization and labeling.
+
+### Blue
+Blue tag for information, links, or primary category identification.
+
+### Green
+Green tag for success states, completed items, or positive categorization.
+
+## Accessibility Notes
+
+- Semantic HTML structure
+- Sufficient color contrast for all variants
+- Screen reader compatible text
+- Clear visual differentiation between variants
+
+## Implementation Status
+
+🚧 Functional but incomplete - missing variants and attributes
+
+## Design Notes
+
+Currently implemented using Carbon Web Components via CDN. Provides colored labels with brand-aligned styling and dynamic script loading. Will be extended to include additional variants and attributes as needed.

--- a/docs/src/design_system/components/tile.md
+++ b/docs/src/design_system/components/tile.md
@@ -1,0 +1,30 @@
+# Tile
+
+Tile component with base and clickable variants for content containers.
+
+## Usage Guidelines
+
+Use tiles to group related content in a visually distinct container. Choose the clickable variant when the entire tile should be interactive.
+
+## Variants
+
+### Base
+Static content container for displaying information without interaction.
+
+### Clickable
+Interactive tile that responds to user interaction. Use when the entire tile should be clickable.
+
+## Accessibility Notes
+
+- Proper semantic HTML structure
+- Keyboard navigation support for clickable variant
+- Clear focus indicators
+- Screen reader compatible content structure
+
+## Implementation Status
+
+🚧 Functional but incomplete - styling verification needed, missing accessibility features
+
+## Design Notes
+
+The tile component serves as a content container accepting arbitrary Markup. Custom test IDs are supported for testing. The clickable variant includes proper interaction states and accessibility features.

--- a/modules/design_system/playground/Cargo.toml
+++ b/modules/design_system/playground/Cargo.toml
@@ -25,6 +25,7 @@ tower-http.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true
+pulldown-cmark.workspace = true
 
 [[bin]]
 name = "playground-server"

--- a/modules/design_system/playground/assets/css/playground.css
+++ b/modules/design_system/playground/assets/css/playground.css
@@ -165,17 +165,178 @@ body {
 
 .documentation-content {
     flex: 1;
-    padding: var(--spacing-05);
+    padding: var(--spacing-05) 2rem;
     overflow-y: auto;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+/* Typography hierarchy */
+.documentation-content h1 {
+    font-size: 2rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    color: var(--text-primary);
+    border-bottom: 2px solid var(--border-subtle);
+    padding-bottom: 0.5rem;
+}
+
+.documentation-content h2 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+    color: var(--text-primary);
 }
 
 .documentation-content h3 {
-    margin-bottom: var(--spacing-04);
+    font-size: 1.25rem;
+    font-weight: 500;
+    margin-top: 1.5rem;
+    margin-bottom: 0.75rem;
+    color: var(--text-primary);
+}
+
+.documentation-content h4 {
+    font-size: 1.125rem;
+    font-weight: 500;
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
     color: var(--text-primary);
 }
 
 .documentation-content p {
-    margin-bottom: var(--spacing-04);
+    margin-bottom: 1rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    font-size: 0.875rem;
+}
+
+/* Lists */
+.documentation-content ul,
+.documentation-content ol {
+    margin-bottom: 1rem;
+    padding-left: 1.5rem;
+    list-style-type: disc;
+}
+
+.documentation-content ul {
+    list-style-type: disc;
+}
+
+.documentation-content ol {
+    list-style-type: decimal;
+}
+
+.documentation-content li {
+    margin-bottom: 0.5rem;
     color: var(--text-secondary);
     line-height: 1.5;
+    font-size: 0.875rem;
+    display: list-item;
+}
+
+.documentation-content li::marker {
+    color: var(--text-primary);
+    font-weight: bold;
+}
+
+/* Code blocks */
+.documentation-content code {
+    background: var(--background-secondary);
+    padding: 0.125rem 0.25rem;
+    border-radius: 3px;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.8125rem;
+    color: var(--text-primary);
+}
+
+.documentation-content pre {
+    background: var(--background-secondary);
+    padding: 1rem;
+    border-radius: 6px;
+    overflow-x: auto;
+    margin-bottom: 1rem;
+    border: 1px solid var(--border-subtle);
+}
+
+.documentation-content pre code {
+    background: none;
+    padding: 0;
+    border-radius: 0;
+    font-size: 0.8125rem;
+}
+
+/* Emphasis and strong text */
+.documentation-content em {
+    font-style: italic;
+    color: var(--text-secondary);
+}
+
+.documentation-content strong {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+/* Status indicators */
+.documentation-content p:has(em:only-child) {
+    font-style: italic;
+    opacity: 0.8;
+    text-align: center;
+    margin: 2rem 0;
+}
+
+/* Blockquotes */
+.documentation-content blockquote {
+    border-left: 4px solid var(--link-color);
+    padding-left: 1rem;
+    margin: 1rem 0;
+    color: var(--text-secondary);
+    font-style: italic;
+}
+
+/* Tables */
+.documentation-content table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1rem;
+}
+
+.documentation-content th,
+.documentation-content td {
+    padding: 0.5rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border-subtle);
+}
+
+.documentation-content th {
+    font-weight: 600;
+    color: var(--text-primary);
+    background: var(--background-secondary);
+}
+
+.documentation-content td {
+    color: var(--text-secondary);
+}
+
+/* Links */
+.documentation-content a {
+    color: var(--link-color);
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    transition: all 0.2s ease;
+}
+
+.documentation-content a:hover {
+    color: var(--link-hover-color);
+    border-bottom-color: var(--link-hover-color);
+}
+
+/* Spacing adjustments */
+.documentation-content > *:first-child {
+    margin-top: 0;
+}
+
+.documentation-content > *:last-child {
+    margin-bottom: 0;
 }

--- a/modules/design_system/playground/assets/js/playground.js
+++ b/modules/design_system/playground/assets/js/playground.js
@@ -31,7 +31,7 @@ class PlaygroundController {
         this.tabButtons.forEach(button => {
             button.addEventListener('click', (e) => {
                 const tabName = e.target.dataset.tab;
-                this.switchTab(tabName);
+                this.switchTab(tabName, true);
             });
         });
 
@@ -45,6 +45,7 @@ class PlaygroundController {
         const urlParams = new URLSearchParams(window.location.search);
         const variant = urlParams.get('variant');
         const theme = urlParams.get('theme');
+        const view = urlParams.get('view') || 'component';
 
         if (variant && this.variantSelect) {
             this.variantSelect.value = variant;
@@ -55,6 +56,9 @@ class PlaygroundController {
             // Update theme on the main HTML element
             document.documentElement.classList.toggle('dark', theme === 'dark');
         }
+
+        // Sync tab state with URL (without triggering URL update)
+        this.switchTab(view, false);
 
         this.updateIframe();
     }
@@ -86,7 +90,7 @@ class PlaygroundController {
         this.iframe.src = iframeUrl.toString();
     }
 
-    switchTab(tabName) {
+    switchTab(tabName, updateURL = true) {
         // Update tab buttons
         this.tabButtons.forEach(button => {
             if (button.dataset.tab === tabName) {
@@ -104,6 +108,11 @@ class PlaygroundController {
                 content.classList.remove('active');
             }
         });
+
+        // Update URL to persist tab state only when user interacts
+        if (updateURL) {
+            this.updateParameter('view', tabName);
+        }
     }
 }
 

--- a/modules/design_system/playground/src/playground/components.rs
+++ b/modules/design_system/playground/src/playground/components.rs
@@ -1,10 +1,10 @@
+use crate::playground::docs_parser;
+
 #[derive(Debug, Clone)]
 pub struct ComponentInfo {
     pub name: String,
     pub route_name: String,
     pub variants: Vec<ComponentVariant>,
-    pub supports_theme: bool,
-    pub description: String,
 }
 
 #[derive(Debug, Clone)]
@@ -14,6 +14,76 @@ pub struct ComponentVariant {
     pub is_default: bool,
 }
 
+#[derive(Debug, Clone)]
+pub struct ComponentSpec {
+    pub name: &'static str,
+    pub route_name: &'static str,
+    pub variants: &'static [ComponentVariantSpec],
+    pub doc_file: &'static str,
+}
+
+#[derive(Debug, Clone)]
+pub struct ComponentVariantSpec {
+    pub name: &'static str,
+    pub value: &'static str,
+    pub is_default: bool,
+}
+
+const COMPONENTS: &[ComponentSpec] = &[
+    ComponentSpec {
+        name: "Button",
+        route_name: "button",
+        variants: &[
+            ComponentVariantSpec { name: "Primary", value: "primary", is_default: true },
+            ComponentVariantSpec { name: "Secondary", value: "secondary", is_default: false },
+            ComponentVariantSpec { name: "Outline", value: "outline", is_default: false },
+        ],
+        doc_file: "button.md",
+    },
+    ComponentSpec {
+        name: "Banner",
+        route_name: "banner",
+        variants: &[
+            ComponentVariantSpec { name: "Accent Only", value: "accent_only", is_default: true },
+            ComponentVariantSpec { name: "With Prefix", value: "with_prefix", is_default: false },
+            ComponentVariantSpec { name: "With Suffix", value: "with_suffix", is_default: false },
+            ComponentVariantSpec { name: "Full", value: "full", is_default: false },
+        ],
+        doc_file: "banner.md",
+    },
+    ComponentSpec {
+        name: "Link",
+        route_name: "link",
+        variants: &[ComponentVariantSpec { name: "Default", value: "default", is_default: true }],
+        doc_file: "link.md",
+    },
+    ComponentSpec {
+        name: "Shell",
+        route_name: "shell",
+        variants: &[ComponentVariantSpec { name: "Default", value: "default", is_default: true }],
+        doc_file: "shell.md",
+    },
+    ComponentSpec {
+        name: "Tag",
+        route_name: "tag",
+        variants: &[
+            ComponentVariantSpec { name: "Gray", value: "gray", is_default: true },
+            ComponentVariantSpec { name: "Blue", value: "blue", is_default: false },
+            ComponentVariantSpec { name: "Green", value: "green", is_default: false },
+        ],
+        doc_file: "tag.md",
+    },
+    ComponentSpec {
+        name: "Tile",
+        route_name: "tile",
+        variants: &[
+            ComponentVariantSpec { name: "Base", value: "base", is_default: true },
+            ComponentVariantSpec { name: "Clickable", value: "clickable", is_default: false },
+        ],
+        doc_file: "tile.md",
+    },
+];
+
 impl ComponentInfo {
     pub fn get_default_variant(&self) -> Option<&ComponentVariant> {
         self.variants.iter().find(|v| v.is_default)
@@ -21,124 +91,20 @@ impl ComponentInfo {
 }
 
 pub fn get_all_components() -> Vec<ComponentInfo> {
-    vec![
-        ComponentInfo {
-            name: "Button".to_string(),
-            route_name: "button".to_string(),
-            variants: vec![
-                ComponentVariant {
-                    name: "Primary".to_string(),
-                    value: "primary".to_string(),
-                    is_default: true,
-                },
-                ComponentVariant {
-                    name: "Secondary".to_string(),
-                    value: "secondary".to_string(),
-                    is_default: false,
-                },
-                ComponentVariant {
-                    name: "Outline".to_string(),
-                    value: "outline".to_string(),
-                    is_default: false,
-                },
-            ],
-            supports_theme: true,
-            description: "Interactive button component".to_string(),
-        },
-        ComponentInfo {
-            name: "Banner".to_string(),
-            route_name: "banner".to_string(),
-            variants: vec![
-                ComponentVariant {
-                    name: "Accent Only".to_string(),
-                    value: "accent_only".to_string(),
-                    is_default: true,
-                },
-                ComponentVariant {
-                    name: "With Prefix".to_string(),
-                    value: "with_prefix".to_string(),
-                    is_default: false,
-                },
-                ComponentVariant {
-                    name: "With Suffix".to_string(),
-                    value: "with_suffix".to_string(),
-                    is_default: false,
-                },
-                ComponentVariant {
-                    name: "Full".to_string(),
-                    value: "full".to_string(),
-                    is_default: false,
-                },
-            ],
-            supports_theme: true,
-            description: "Banner component with multiple display variants".to_string(),
-        },
-        ComponentInfo {
-            name: "Link".to_string(),
-            route_name: "link".to_string(),
-            variants: vec![ComponentVariant {
-                name: "Default".to_string(),
-                value: "default".to_string(),
-                is_default: true,
-            }],
-            supports_theme: true,
-            description: "Link component".to_string(),
-        },
-        ComponentInfo {
-            name: "Shell".to_string(),
-            route_name: "shell".to_string(),
-            variants: vec![ComponentVariant {
-                name: "Default".to_string(),
-                value: "default".to_string(),
-                is_default: true,
-            }],
-            supports_theme: true,
-            description: "Application shell component".to_string(),
-        },
-        ComponentInfo {
-            name: "Tag".to_string(),
-            route_name: "tag".to_string(),
-            variants: vec![
-                ComponentVariant {
-                    name: "Gray".to_string(),
-                    value: "gray".to_string(),
-                    is_default: true,
-                },
-                ComponentVariant {
-                    name: "Blue".to_string(),
-                    value: "blue".to_string(),
-                    is_default: false,
-                },
-                ComponentVariant {
-                    name: "Green".to_string(),
-                    value: "green".to_string(),
-                    is_default: false,
-                },
-            ],
-            supports_theme: true,
-            description: "Tag component with different color variants".to_string(),
-        },
-        ComponentInfo {
-            name: "Tile".to_string(),
-            route_name: "tile".to_string(),
-            variants: vec![
-                ComponentVariant {
-                    name: "Base".to_string(),
-                    value: "base".to_string(),
-                    is_default: true,
-                },
-                ComponentVariant {
-                    name: "Clickable".to_string(),
-                    value: "clickable".to_string(),
-                    is_default: false,
-                },
-            ],
-            supports_theme: true,
-            description: "Tile component with base and clickable variants".to_string(),
-        },
-    ]
+    COMPONENTS
+        .iter()
+        .filter_map(|spec| {
+            docs_parser::load_component_documentation(spec)
+                .ok()
+                .map(|doc| doc.to_component_info())
+        })
+        .collect()
 }
 
 pub fn get_component_by_name(name: &str) -> Option<ComponentInfo> {
     get_all_components().into_iter().find(|c| c.route_name == name)
+}
+
+pub fn get_component_spec_by_route_name(route_name: &str) -> Option<&ComponentSpec> {
+    COMPONENTS.iter().find(|spec| spec.route_name == route_name.to_lowercase())
 }

--- a/modules/design_system/playground/src/playground/docs_parser.rs
+++ b/modules/design_system/playground/src/playground/docs_parser.rs
@@ -1,0 +1,72 @@
+use std::path::Path;
+
+use pulldown_cmark::{html, Parser};
+
+use crate::playground::components;
+
+#[derive(Debug, Clone)]
+pub struct ComponentDocumentationFrontmatter {
+    pub name: String,
+    pub route_name: String,
+    pub variants: Vec<ComponentVariantFrontmatter>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ComponentVariantFrontmatter {
+    pub name: String,
+    pub value: String,
+    pub is_default: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ComponentDocumentation {
+    pub frontmatter: ComponentDocumentationFrontmatter,
+    pub content_html: String,
+}
+
+impl ComponentDocumentation {
+    pub fn to_component_info(&self) -> components::ComponentInfo {
+        components::ComponentInfo {
+            name: self.frontmatter.name.clone(),
+            route_name: self.frontmatter.route_name.clone(),
+            variants: self
+                .frontmatter
+                .variants
+                .iter()
+                .map(|v| components::ComponentVariant {
+                    name: v.name.clone(),
+                    value: v.value.clone(),
+                    is_default: v.is_default,
+                })
+                .collect(),
+        }
+    }
+}
+
+pub fn load_component_documentation(
+    spec: &components::ComponentSpec,
+) -> Result<ComponentDocumentation, std::io::Error> {
+    let docs_path = Path::new("docs/src/design_system/components").join(spec.doc_file);
+
+    let content = std::fs::read_to_string(&docs_path)?;
+
+    let frontmatter = ComponentDocumentationFrontmatter {
+        name: spec.name.to_string(),
+        route_name: spec.route_name.to_string(),
+        variants: spec
+            .variants
+            .iter()
+            .map(|v| ComponentVariantFrontmatter {
+                name: v.name.to_string(),
+                value: v.value.to_string(),
+                is_default: v.is_default,
+            })
+            .collect(),
+    };
+
+    let parser = Parser::new(&content);
+    let mut content_html = String::new();
+    html::push_html(&mut content_html, parser);
+
+    Ok(ComponentDocumentation { frontmatter, content_html })
+}

--- a/modules/design_system/playground/src/playground/mod.rs
+++ b/modules/design_system/playground/src/playground/mod.rs
@@ -1,4 +1,5 @@
 pub mod components;
+pub mod docs_parser;
 pub mod error;
 pub mod iframe;
 pub mod parameters;

--- a/modules/design_system/playground/src/playground/parameters.rs
+++ b/modules/design_system/playground/src/playground/parameters.rs
@@ -10,6 +10,8 @@ pub struct PlaygroundParams {
     pub variant: Option<String>,
     #[serde(default)]
     pub theme: Theme,
+    #[serde(default)]
+    pub view: ViewMode,
 }
 
 fn default_component() -> String {
@@ -24,11 +26,28 @@ pub enum Theme {
     Dark,
 }
 
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ViewMode {
+    #[default]
+    Component,
+    Documentation,
+}
+
 impl std::fmt::Display for Theme {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Theme::Light => write!(f, "light"),
             Theme::Dark => write!(f, "dark"),
+        }
+    }
+}
+
+impl std::fmt::Display for ViewMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ViewMode::Component => write!(f, "component"),
+            ViewMode::Documentation => write!(f, "documentation"),
         }
     }
 }
@@ -67,6 +86,7 @@ impl PlaygroundParams {
         }
 
         params.push(format!("theme={}", self.theme));
+        params.push(format!("view={}", self.view));
 
         params.join("&")
     }

--- a/modules/design_system/playground/src/playground/shell.rs
+++ b/modules/design_system/playground/src/playground/shell.rs
@@ -2,26 +2,29 @@ use axum::extract::Query;
 use axum::http::StatusCode;
 use maud::{html, Markup};
 
-use crate::playground::components::get_all_components;
+use crate::playground::components::{get_all_components, ComponentInfo};
 use crate::playground::parameters::PlaygroundParams;
 use crate::playground::templates::{
     render_component_controls, render_component_sidebar, render_component_tabs, render_page_shell,
 };
 
-fn render_shell_content(
-    components: &[crate::playground::components::ComponentInfo],
-    current_component: &str,
-    current_component_info: &crate::playground::components::ComponentInfo,
-    current_variant: &str,
-    current_theme: &str,
-    current_params: &str,
-) -> Markup {
+struct ShellData<'a> {
+    components: &'a [ComponentInfo],
+    current_component: &'a str,
+    current_component_info: &'a ComponentInfo,
+    current_variant: &'a str,
+    current_theme: &'a str,
+    current_view: &'a str,
+    current_params: &'a str,
+}
+
+fn render_shell_content(data: &ShellData) -> Markup {
     html! {
         div class="playground-layout" {
-            (render_component_sidebar(components, current_component))
+            (render_component_sidebar(data.components, data.current_component, data.current_params))
             main class="playground-main" {
-                (render_component_controls(current_component_info, current_variant, current_theme))
-                (render_component_tabs(&format!("/iframe?{}", current_params), current_component_info))
+                (render_component_controls(data.current_component_info, data.current_variant, data.current_theme))
+                (render_component_tabs(&format!("/iframe?{}", data.current_params), data.current_component_info, data.current_view))
             }
         }
         script src="/playground-assets/js/playground.js" {}
@@ -32,10 +35,23 @@ fn render_shell_content(
 pub async fn shell(Query(playground_params): Query<PlaygroundParams>) -> Result<Markup, (StatusCode, Markup)> {
     let all_components = get_all_components();
 
-    // Get current component info, default to button if not found
+    // Get current component info, with fallback for missing documentation
     let current_component_info = playground_params
         .get_component_info()
-        .unwrap_or_else(|| get_all_components().into_iter().find(|c| c.route_name == "button").unwrap());
+        .or_else(|| all_components.iter().find(|c| c.route_name == "button").cloned())
+        .or_else(|| all_components.first().cloned())
+        .unwrap_or_else(|| {
+            eprintln!(
+                "Warning: No component documentation found for '{}'",
+                playground_params.component
+            );
+            // Create a fallback component info
+            ComponentInfo {
+                name: playground_params.component.clone(),
+                route_name: playground_params.component.clone(),
+                variants: vec![],
+            }
+        });
 
     let current_variant = playground_params.variant.as_ref().cloned().unwrap_or_else(|| {
         current_component_info
@@ -44,24 +60,24 @@ pub async fn shell(Query(playground_params): Query<PlaygroundParams>) -> Result<
             .unwrap_or_else(|| "default".to_string())
     });
 
-    let current_theme = format!("{}", playground_params.theme);
+    let current_theme = playground_params.theme.to_string();
+    let current_view = playground_params.view.to_string();
     let current_params = playground_params.to_query_string();
 
-    let content = render_shell_content(
-        &all_components,
-        &playground_params.component,
-        &current_component_info,
-        &current_variant,
-        &current_theme,
-        &current_params,
-    );
+    let shell_data = ShellData {
+        components: &all_components,
+        current_component: &playground_params.component,
+        current_component_info: &current_component_info,
+        current_variant: &current_variant,
+        current_theme: &current_theme,
+        current_view: &current_view,
+        current_params: &current_params,
+    };
 
-    let html_markup = render_page_shell(
+    Ok(render_page_shell(
         &current_theme,
         "DSP Design System Playground",
         "/playground-assets/css/playground.css",
-        content,
-    );
-
-    Ok(html_markup)
+        render_shell_content(&shell_data),
+    ))
 }


### PR DESCRIPTION
- Create docs parser to extract component documentation from markdown files
- Add component parameter system for dynamic examples
- Generate documentation pages for banner, button, link, shell, tag, and tile components
- Enhance playground UI with improved styling and navigation
- Integrate mdBook documentation structure with playground interface