### PR TITLE
feat (design-system/playground): Add button to display component iframe in separate tab

### DIFF
--- a/modules/design_system/playground/assets/css/playground.css
+++ b/modules/design_system/playground/assets/css/playground.css
@@ -118,6 +118,37 @@ body {
     color: var(--text-primary);
 }
 
+.open-in-new-tab-btn {
+    margin-left: auto;
+    padding: 0.5rem 1rem;
+    background: var(--link-color);
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-weight: 500;
+    transition: all 0.2s ease;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.open-in-new-tab-btn:hover {
+    background: var(--link-hover-color);
+}
+
+.open-in-new-tab-btn:focus {
+    outline: 2px solid var(--link-color);
+    outline-offset: 2px;
+}
+
+.open-in-new-tab-btn::after {
+    content: "↗";
+    font-size: 0.75rem;
+    font-weight: bold;
+}
+
 .playground-tabs {
     display: flex;
     border-bottom: 1px solid var(--border-subtle);

--- a/modules/design_system/playground/src/playground/shell.rs
+++ b/modules/design_system/playground/src/playground/shell.rs
@@ -19,12 +19,13 @@ struct ShellData<'a> {
 }
 
 fn render_shell_content(data: &ShellData) -> Markup {
+    let iframe_src = format!("/iframe?{}", data.current_params);
     html! {
         div class="playground-layout" {
             (render_component_sidebar(data.components, data.current_component, data.current_params))
             main class="playground-main" {
-                (render_component_controls(data.current_component_info, data.current_variant, data.current_theme))
-                (render_component_tabs(&format!("/iframe?{}", data.current_params), data.current_component_info, data.current_view))
+                (render_component_controls(data.current_component_info, data.current_variant, data.current_theme, &iframe_src))
+                (render_component_tabs(&iframe_src, data.current_component_info, data.current_view))
             }
         }
         script src="/playground-assets/js/playground.js" {}

--- a/modules/design_system/playground/src/playground/templates.rs
+++ b/modules/design_system/playground/src/playground/templates.rs
@@ -93,6 +93,7 @@ pub fn render_component_controls(
     component_info: &components::ComponentInfo,
     current_variant: &str,
     current_theme: &str,
+    iframe_src: &str,
 ) -> Markup {
     html! {
         div class="playground-controls" {
@@ -111,6 +112,11 @@ pub fn render_component_controls(
                 select id="theme-select" data-param="theme" {
                     option value="light" selected[current_theme == "light"] { "Light" }
                     option value="dark" selected[current_theme == "dark"] { "Dark" }
+                }
+            }
+            div class="parameter-group" {
+                button class="open-in-new-tab-btn" onclick=(format!("window.open('{}', '_blank')", iframe_src)) title="Open component preview in new tab" {
+                    "Open Component"
                 }
             }
         }


### PR DESCRIPTION
# Add "Open Component" button to Design System Playground

### TL;DR

Added a new button to open component previews in a new tab from the Design System Playground.

### What changed?

- Added CSS styles for a new `.open-in-new-tab-btn` button with appropriate hover and focus states
- Modified the component controls to include the new "Open Component" button
- Refactored the iframe source URL generation to avoid duplication
- The button opens the current component preview in a new browser tab

### How to test?

1. Navigate to the Design System Playground
2. Select any component
3. Click the new "Open Component" button in the controls section
4. Verify that the component preview opens in a new browser tab

### Why make this change?

This enhancement improves the developer experience by allowing users to view component previews in a dedicated tab, which provides more screen space and better isolation for testing and reviewing components.

It also enables quick access to the link where the component can be viewed in isolation, which helps AI agents viewing the component.