### PR TITLE
ci: fix nightly fuzz workflow failures

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   fuzz:
@@ -27,6 +26,9 @@ jobs:
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
 
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+
       - name: Install cargo-fuzz
         run: cargo binstall cargo-fuzz -y
 
@@ -41,10 +43,10 @@ jobs:
       - name: Run fuzzer (10 min budget)
         working-directory: modules/dpe/server
         run: |
-          cargo +nightly fuzz run ${{ matrix.target }} -- \
+          cargo +nightly fuzz run ${{ matrix.target }} \
+            --target x86_64-unknown-linux-gnu -- \
             -max_total_time=600 \
             -max_len=4096
-        continue-on-error: true
         id: fuzz
 
       - name: Upload corpus as artifact
@@ -56,48 +58,10 @@ jobs:
           retention-days: 30
 
       - name: Upload crash artifacts
-        if: failure() || steps.fuzz.outcome == 'failure'
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: fuzz-crashes-${{ matrix.target }}
           path: modules/dpe/server/fuzz/artifacts/${{ matrix.target }}
           retention-days: 90
 
-      - name: Create issue on crash
-        if: failure() || steps.fuzz.outcome == 'failure'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const target = '${{ matrix.target }}';
-            const artifactsDir = `modules/dpe/server/fuzz/artifacts/${target}`;
-
-            let crashFiles = [];
-            try {
-              crashFiles = fs.readdirSync(artifactsDir)
-                .filter(f => f.startsWith('crash-') || f.startsWith('oom-'));
-            } catch (e) {
-              // No artifacts directory
-            }
-
-            const body = [
-              `## Fuzz crash detected in \`${target}\``,
-              '',
-              `**Workflow run:** ${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
-              `**Target:** \`${target}\``,
-              `**Crash files found:** ${crashFiles.length}`,
-              '',
-              'Download the crash artifacts from the workflow run to reproduce locally:',
-              '```bash',
-              `cd modules/dpe/server`,
-              `cargo +nightly fuzz run ${target} <crash-file>`,
-              '```',
-            ].join('\n');
-
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `Fuzz crash: ${target}`,
-              body,
-              labels: ['bug', 'fuzz'],
-            });


### PR DESCRIPTION
## Motivation

The nightly fuzz workflow has failed on every run since it was created, never actually executing the fuzzer.

## Summary

- Fix three cascading issues preventing the fuzz workflow from running
- Make crashes visible by failing the workflow instead of silently passing

## Key Changes

### Install cargo-binstall
- Added `cargo-bins/cargo-binstall@main` action step before `cargo binstall cargo-fuzz`, matching the pattern used in `check.yml` and `build-dpe` composite action

### Use GNU target for ASAN compatibility
- Added `--target x86_64-unknown-linux-gnu` to the fuzz command since ASAN is incompatible with statically linked musl libc

### Crash visibility
- Removed `continue-on-error: true` so the workflow goes red on crashes
- Crash artifacts are still uploaded via `if: failure()`

### Remove broken issue-creation step
- Removed the `github-script` step that attempted to create GitHub Issues (Issues are disabled on this repo, returning HTTP 410)
- Removed the now-unnecessary `issues: write` permission

## Challenges and Decisions

### Three cascading failures masked each other
**Problem:** The workflow appeared to have one failure (missing cargo-binstall), but fixing that revealed a second (ASAN/musl incompatibility), and analysing the `continue-on-error` behaviour revealed a third (silent failures).
**Solution:** Fixed iteratively — triggered `workflow_dispatch` after each fix to verify before moving to the next issue.

### Silent passes vs. visible failures
**Problem:** The original workflow used `continue-on-error: true` on the fuzzer step, meaning crashes would show as green. Combined with the broken issue-creation step, crashes would go completely unnoticed.
**Solution:** Removed `continue-on-error` so the workflow fails visibly. Crash artifacts are still uploaded for investigation.

## Gotchas

- `cargo-fuzz` uses ASAN by default, which requires dynamic linking. Always use `x86_64-unknown-linux-gnu` (not musl) for fuzz targets on CI.
- `cargo-binstall` is not pre-installed on GitHub runners — use the `cargo-bins/cargo-binstall@main` action before any `cargo binstall` calls.

## Test Plan

- [x] Trigger `workflow_dispatch` on branch — both fuzz targets compile and run successfully