### PR TITLE
fix(dpe-server): add dsp-app data link to nietzsche-me (DEV-6293)

### DIFF
--- a/modules/dpe/server/data/projects/0866_nietzsche-me.json
+++ b/modules/dpe/server/data/projects/0866_nietzsche-me.json
@@ -12,6 +12,7 @@
     "startDate": "2017-04-01",
     "endDate": "2021-12-31",
     "url": [
+        "https://app.dasch.swiss/project/bduDoIi8ShmgHXOAten_Ww",
         "https://nietzsche.philhist.unibas.ch"
     ],
     "howToCite": "Der späte Nietzsche. Digitale Manuskriptedition (2021). DaSCH. https://ark.dasch.swiss/ark:/72163/1/0866.",


### PR DESCRIPTION
## Summary

The `nietzsche-me` project (shortcode `0866`) is now live on dsp-app at
https://app.dasch.swiss/project/bduDoIi8ShmgHXOAten_Ww. This prepends
the dsp-app project URL to the `url` array on the project entry so the
DPE project page surfaces the link to the live data (same ordering as
the biz / 0828 entry).

## Change

On `modules/dpe/server/data/projects/0866_nietzsche-me.json`:
- `url[0]` → `https://app.dasch.swiss/project/bduDoIi8ShmgHXOAten_Ww` (new)
- `url[1]` → `https://nietzsche.philhist.unibas.ch` (was `url[0]`)

## Linear

[DEV-6293](https://linear.app/dasch/issue/DEV-6293)

## Test plan
- [x] JSON parses cleanly
- [ ] Reviewer verifies both links render on the DPE project page for 0866 after deploy

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>