### PR TITLE
fix: Make project lookup by shortcode case-insensitive (quick fix)

### DIFF
--- a/modules/dpe/core/src/project_cache.rs
+++ b/modules/dpe/core/src/project_cache.rs
@@ -25,10 +25,10 @@ pub fn project_by_shortcode(shortcode: &str) -> Option<&'static Project> {
         all_projects()
             .iter()
             .enumerate()
-            .map(|(i, p)| (p.shortcode.clone(), i))
+            .map(|(i, p)| (p.shortcode.to_uppercase(), i))
             .collect()
     });
-    index.get(shortcode).map(|&i| &all_projects()[i])
+    index.get(&shortcode.to_uppercase()).map(|&i| &all_projects()[i])
 }
 
 fn load_all_projects() -> Vec<Project> {


### PR DESCRIPTION
Really this would require a value class for all shortcodes with a boundary check at instantiation, but this is quick fix