### PR TITLE
fix(dpe): produce useful panic backtraces in production

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,11 @@ proptest = "1"
 codegen-units = 1
 lto = true
 opt-level = 'z'
+# Keep DWARF line tables so panic backtraces in production show file:line.
+# Cheap (~10-20% binary size, no runtime cost) and required for the panic
+# hook in dpe-server to produce actionable stacktraces — paired with
+# `RUST_BACKTRACE=1` in modules/dpe/Dockerfile.
+debug = "line-tables-only"
 
 # WASM-optimized release profile for mosaic-playground (Leptos islands + WASM)
 [profile.wasm-release]

--- a/modules/dpe/Dockerfile
+++ b/modules/dpe/Dockerfile
@@ -13,6 +13,11 @@ COPY site /app/site
 COPY data /app/server/data
 
 ENV RUST_LOG="info"
+# Enable backtrace capture for the structured panic hook in dpe-server.
+# Without this, `Backtrace::capture()` returns `BacktraceStatus::Disabled`
+# and panic logs lose the call site — paired with `debug = "line-tables-only"`
+# in the release profile so symbols and file:line make it into the backtrace.
+ENV RUST_BACKTRACE="1"
 ENV LEPTOS_OUTPUT_NAME="dpe"
 ENV LEPTOS_SITE_ROOT="site"
 ENV LEPTOS_SITE_PKG_DIR="pkg"


### PR DESCRIPTION
## Summary

Two-line fix so the next production panic gives us an actionable stack trace instead of `\"disabled backtrace\"`.

## Why

The structured panic hook landed in c712106a routes panics through `tracing::error!`, but production logs still look like:

```
{"level":"ERROR","fields":{"message":"thread panicked",
 "exception.message":"Tried to access a reactive value that has already been disposed.",
 "exception.stacktrace":"disabled backtrace",
 ...
 "code.filepath":"reactive_graph-0.2.11/src/traits.rs","code.lineno":394}}
```

Two reasons:

1. The hook uses `Backtrace::capture()`, which respects \`RUST_BACKTRACE\`. The reviewer's inline comment explicitly invited operators to opt in at incident time. We are at incident time — disposal panics are still reaching prod after #211 / f78ee427, and without the call site we'd be guessing again.
2. The release profile had no \`debug\` setting (default = false), so even with the env var any captured backtrace would be unsymbolicated.

## Changes

- \`modules/dpe/Dockerfile\`: \`ENV RUST_BACKTRACE=\"1\"\`.
- \`Cargo.toml\` \`[profile.release]\`: \`debug = \"line-tables-only\"\`.

Together these turn the next panic into a stack trace with file:line in our own code, so we can target the actual `.get()` site.

## Cost

- Backtrace capture on every panic: negligible (we are not in a fast path here).
- Line tables in release: binary went 23.8 MB locally; expected ~10-20% growth, no runtime cost.
- Both are reversible — set \`RUST_BACKTRACE=0\` or drop the \`debug\` line if anything regresses.

## Verification

- \`cargo build -p dpe-server --release\` ✓ (\`Finished release profile [optimized + debuginfo] in 3m 48s\`)
- Binary size acceptable (23.8 MB)

## Follow-up

Once one panic with a real stack trace shows up in Grafana, we get the line in our own code that's calling \`.get()\` on a disposed reactive value, and the next PR can fix it surgically. If panics drop to zero before then, even better — close this and revert if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)