### PR TITLE
fix(dpe-server): only call default panic hook on structured-emission failure

### DIFF
--- a/modules/dpe/server/src/main.rs
+++ b/modules/dpe/server/src/main.rs
@@ -402,19 +402,21 @@ fn validate(data_dir: PathBuf) -> ExitCode {
 }
 
 /// Install a panic hook that emits panics as structured `tracing::error!`
-/// events (in addition to the default stderr behaviour), so production panics
-/// are captured by the same OTel pipeline as the rest of the logs. Field names
-/// follow the OTel semconv for exceptions (`exception.message`,
-/// `exception.stacktrace`, `exception.r#type`, `thread.name`) so panic events
-/// share Grafana Sift / Loki query surface with `RecordException` events
-/// emitted by instrumented spans.
+/// events, so production panics are captured by the same OTel pipeline as
+/// the rest of the logs. Field names follow the OTel semconv for exceptions
+/// (`exception.message`, `exception.stacktrace`, `exception.r#type`,
+/// `thread.name`) so panic events share Grafana Sift / Loki query surface
+/// with `RecordException` events emitted by instrumented spans.
+///
+/// The default stderr hook is only invoked as a fallback when the structured
+/// emission itself panics (e.g. OTel exporter in a degraded state). Under
+/// normal operation each panic produces exactly one log line — no duplicate
+/// stderr backtrace.
 fn install_tracing_panic_hook() {
     let default_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
-        // Best-effort structured emission. If the subscriber itself panics
-        // (e.g. OTel exporter buffer full), swallow the second panic so the
-        // default stderr hook below still runs.
-        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // Best-effort structured emission.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let message = info.payload_as_str().unwrap_or("<non-string panic payload>");
             let thread = std::thread::current();
             let thread_name = thread.name().unwrap_or("<unnamed>");
@@ -444,9 +446,11 @@ fn install_tracing_panic_hook() {
             }
         }));
 
-        // Always call the default hook so panics keep appearing on stderr too,
-        // even if the structured emission above was suppressed.
-        default_hook(info);
+        // Fall back to the default stderr hook only if the structured emission
+        // itself panicked, so the panic is never silently swallowed.
+        if result.is_err() {
+            default_hook(info);
+        }
     }));
 }
 


### PR DESCRIPTION
## Summary

Stop emitting every production panic twice (structured Grafana log **+** full stderr backtrace).

The structured panic hook installed in c712106a unconditionally called the saved default hook after the `tracing::error!` emission. With `RUST_BACKTRACE=1` set in the Dockerfile (PR #212), the std default hook prints the full backtrace to stderr — so every panic produces a multi-line stderr block in addition to the structured Loki/Grafana entry. Noisy and redundant.

## Change

Capture the `Result` from the existing `catch_unwind` around the structured emission and only fall through to the default hook on `Err`. So:

- **Normal operation:** one structured log line per panic (with the backtrace in `exception.stacktrace`). No stderr noise.
- **Degraded path** (structured emission itself panicked, e.g. OTel exporter in a bad state): the default stderr hook still fires, so panics are never silently swallowed.

3 LOC of behaviour change inside the existing hook — no new dependencies, no API change.

## Verification

- `just check` ✓ (fmt + clippy)

## Risk

Low. The fallback path is preserved for the case it actually matters (structured-emission failure). Reversible by swapping the conditional back to unconditional if anything regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)