### PR TITLE
fix(dpe-web): resolve project list synchronously to stop SSR disposal panics

### DIFF
--- a/modules/dpe/web/src/domain/project.rs
+++ b/modules/dpe/web/src/domain/project.rs
@@ -26,7 +26,8 @@ impl ProjectQuery {
         self.finished.unwrap_or(false)
     }
 
-    #[cfg(feature = "ssr")]
+    // Unconditional (the body has nothing SSR-specific) — sibling accessors
+    // like `type_of_data`, `data_language`, `access_rights` are also ungated.
     pub fn search(&self) -> String {
         self.search.clone().unwrap_or_default()
     }

--- a/modules/dpe/web/src/domain/projects.rs
+++ b/modules/dpe/web/src/domain/projects.rs
@@ -73,7 +73,12 @@ pub async fn list_projects(
     Ok(filter_and_paginate(all_projects(), &query, page_size))
 }
 
-#[cfg(feature = "ssr")]
+// Gated on non-wasm targets to match `dpe_core::all_projects` (the only
+// realistic source of the `&[Project]` argument); the previous narrower
+// `#[cfg(feature = "ssr")]` gate kept the function from compiling under
+// `cargo hack --features default`, even though the body only touches plain
+// `dpe_core` types and has nothing SSR-specific.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn filter_and_paginate(projects: &[Project], query: &super::project::ProjectQuery, page_size: Option<i32>) -> Page {
     use dpe_core::{AccessRightsType, ProjectStatus};
 

--- a/modules/dpe/web/src/pages/projects/components/project_list.rs
+++ b/modules/dpe/web/src/pages/projects/components/project_list.rs
@@ -1,114 +1,101 @@
 use leptos::prelude::*;
+#[cfg(not(target_arch = "wasm32"))]
 use mosaic_tiles::button::ButtonVariant;
+#[cfg(not(target_arch = "wasm32"))]
 use mosaic_tiles::card::{Card, CardBody, CardVariant};
+#[cfg(not(target_arch = "wasm32"))]
 use mosaic_tiles::link::Link;
 
+#[cfg(not(target_arch = "wasm32"))]
 use super::card::ProjectCard;
+#[cfg(not(target_arch = "wasm32"))]
 use super::project_pagination::ProjectPagination;
-use crate::components::loading::Loading;
-use crate::domain::{lang_value, list_projects, ProjectQuery};
+use crate::domain::ProjectQuery;
 
+/// Renders the filtered + paginated project list.
+///
+/// Looked up synchronously from the in-process project cache via
+/// `dpe_web::domain::projects::filter_and_paginate` — no `Resource` /
+/// `<Suspense>`. The previous async pattern wrapped the resolved query in a
+/// `Resource::new(move || query.get(), ...)` whose source closure read the
+/// `Memo<Result<ProjectQuery, _>>` owned by the parent `ProjectsPage`. Under
+/// streaming SSR the resource's async derived re-evaluator could fire after
+/// the parent owner had already been disposed, hitting a recurring
+/// `tokio-rt-worker` panic at
+/// `reactive_graph-0.2.11/src/traits.rs:394:39` ("Tried to access a reactive
+/// value that has already been disposed.") — confirmed in production
+/// backtraces post-PR #212. Resolving the query in `ProjectsPage` and
+/// passing the plain value down removes the cross-owner Memo capture.
+///
+/// `dpe_core::all_projects` and `crate::domain::projects::filter_and_paginate`
+/// are gated on non-wasm targets (disk-backed cache); DPE renders SSR-only,
+/// but cargo-leptos still compiles `dpe-web` for `wasm32-unknown-unknown`
+/// (lib-package), so an inert wasm stub is needed even though it never
+/// renders.
+#[cfg(not(target_arch = "wasm32"))]
 #[component]
-pub fn ProjectList(query: Memo<Result<ProjectQuery, leptos_router::params::ParamsError>>) -> impl IntoView {
-    // Create resource that depends on query parameters
-    let projects = Resource::new(
-        move || query.get(),
-        |q| async move {
-            let query_data = q.unwrap_or_default();
-            list_projects(
-                query_data.ongoing,
-                query_data.finished,
-                query_data.search,
-                query_data.page,
-                None,
-                query_data.type_of_data,
-                query_data.data_language,
-                query_data.access_rights,
-            )
-            .await
-        },
-    );
+pub fn ProjectList(query: ProjectQuery) -> impl IntoView {
+    use crate::domain::lang_value;
+    use crate::domain::projects::filter_and_paginate;
 
-    view! {
-        // Everything inside Suspense to avoid reading resource outside
-        <Suspense fallback=move || {
-            view! { <Loading /> }
-        }>
-            {move || {
-                let current_query = query.get().unwrap_or_default();
-                projects
-                    .get()
-                    .map(|result| match result {
-                        Ok(page) => {
-                            let nr_pages = page.nr_pages;
-                            let total_items = page.total_items;
-                            if total_items == 0 {
+    let page = filter_and_paginate(dpe_core::all_projects(), &query, None);
+    let nr_pages = page.nr_pages;
+    let total_items = page.total_items;
 
-                                view! {
-                                    <Card variant=CardVariant::Bordered>
-                                        <CardBody>
-                                            <div class="text-center">
-                                                <h3 class="mb-4">
-                                                    "No projects found matching your criteria"
-                                                </h3>
-                                                <Link href="/dpe/projects" as_button=ButtonVariant::Ghost>
-                                                    "Clear your filters"
-                                                </Link>
-                                            </div>
-                                        </CardBody>
-                                    </Card>
-                                }
-                                    .into_any()
-                            } else {
-                                view! {
-                                    <div>
-                                        <div class="mb-4 text-sm text-gray-600">
-                                            {format!("{} projects", total_items)}
-                                        </div>
-                                        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                                            {page
-                                                .items
-                                                .into_iter()
-                                                .map(|project| {
-                                                    let keywords: Vec<String> = project
-                                                        .keywords
-                                                        .iter()
-                                                        .filter_map(|map| lang_value(map).cloned())
-                                                        .collect();
-                                                    view! {
-                                                        <ProjectCard
-                                                            title=project.name.clone()
-                                                            content=project.short_description.clone()
-                                                            status=project.status.clone()
-                                                            access_rights=project.access_rights.access_rights.clone()
-                                                            btn_target=format!("/dpe/projects/{}", project.shortcode)
-                                                            shortcode=project.shortcode.clone()
-                                                            keywords=keywords
-                                                        />
-                                                    }
-                                                })
-                                                .collect_view()}
-                                        </div>
-                                    </div>
-
-                                    <div class="flex justify-center">
-                                        <ProjectPagination nr_pages=nr_pages query=current_query />
-                                    </div>
-                                }
-                                    .into_any()
-                            }
-                        }
-                        Err(e) => {
-
+    if total_items == 0 {
+        view! {
+            <Card variant=CardVariant::Bordered>
+                <CardBody>
+                    <div class="text-center">
+                        <h3 class="mb-4">"No projects found matching your criteria"</h3>
+                        <Link href="/dpe/projects" as_button=ButtonVariant::Ghost>
+                            "Clear your filters"
+                        </Link>
+                    </div>
+                </CardBody>
+            </Card>
+        }
+        .into_any()
+    } else {
+        view! {
+            <div>
+                <div class="mb-4 text-sm text-gray-600">{format!("{} projects", total_items)}</div>
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                    {page
+                        .items
+                        .into_iter()
+                        .map(|project| {
+                            let keywords: Vec<String> = project
+                                .keywords
+                                .iter()
+                                .filter_map(|map| lang_value(map).cloned())
+                                .collect();
                             view! {
-                                <div class="alert alert-error">
-                                    <span>"Failed to load projects: "{e.to_string()}</span>
-                                </div>
+                                <ProjectCard
+                                    title=project.name.clone()
+                                    content=project.short_description.clone()
+                                    status=project.status.clone()
+                                    access_rights=project.access_rights.access_rights.clone()
+                                    btn_target=format!("/dpe/projects/{}", project.shortcode)
+                                    shortcode=project.shortcode.clone()
+                                    keywords=keywords
+                                />
                             }
-                                .into_any()
-                        }
-                    })
-            }}
-        </Suspense>
+                        })
+                        .collect_view()}
+                </div>
+            </div>
+
+            <div class="flex justify-center">
+                <ProjectPagination nr_pages=nr_pages query=query />
+            </div>
+        }
+        .into_any()
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[component]
+pub fn ProjectList(query: ProjectQuery) -> impl IntoView {
+    let _ = query;
 }

--- a/modules/dpe/web/src/pages/projects/page.rs
+++ b/modules/dpe/web/src/pages/projects/page.rs
@@ -97,7 +97,7 @@ pub fn ProjectsPage() -> impl IntoView {
                                     </div>
                                 </CardBody>
                             </Card>
-                            <ProjectList query=query />
+                            <ProjectList query=cq.clone() />
                         </div>
                     </div>
                 }


### PR DESCRIPTION
## Summary

Third (and hopefully last) variant of the recurring `reactive_graph` SSR disposal panic. With the structured panic hook + `RUST_BACKTRACE=1` from #212 (and the de-duplication from #214), the prod backtrace finally pins the call site:

```
16: {closure#0}                          project_list.rs:15:23   ← our line
15: Get::get<Memo<Result<ProjectQuery, ParamsError>>>            ← disposed
14: unwrap_or_else
13: unwrap_signal!  →  panic
```

Frame 16 is the `move || query.get()` source closure of `Resource::new(...)` in `ProjectList`. The captured `Memo` is created in the parent `ProjectsPage` (`use_query::<ProjectQuery>()`) and passed down as a `Copy` prop. Under streaming SSR, the resource's async derived re-evaluator (`leptos_server::resource::run_in_resource_source_signal`, backed by an `ArcMemo`) re-fires *after* the parent owner has been disposed → reading the cross-owner Memo panics.

## Why this is the same class as the last two

| Variant | Fix |
|---|---|
| Two `<Suspense>` reading the **same** Resource | `b9e9a341` (Julien) |
| Many sibling per-id Resources in the project sidebar | #211 / `f78ee427` |
| Resource source captures a Memo owned by an ancestor | **this PR** |

Common shape: anything that schedules async reactive work tied to a signal owned outside the current component is a disposal-race liability under streaming SSR.

The data layer (`dpe_core` `OnceLock<HashMap>`s + `dpe_web::domain::projects::filter_and_paginate`) is fully synchronous and in-memory, so the `Resource`/`Suspense` indirection added no value.

## Change

`ProjectList`:
- Now takes `query: ProjectQuery` (resolved value) instead of `Memo<Result<ProjectQuery, ParamsError>>`.
- Drops `Resource::new(...)` and `<Suspense>`.
- Calls `filter_and_paginate(dpe_core::all_projects(), &query, None)` synchronously.
- Adds the standard wasm32 stub (DPE is SSR-only but cargo-leptos still wasm-builds the lib-package).

`ProjectsPage`:
- `current_query` is already resolved locally; call site changed from `<ProjectList query=query />` to `<ProjectList query=cq.clone() />`.

## Verification

- `cargo test` ✓ (45 + 27 tests pass on host)
- `cargo check` ✓ (host)
- `cargo check --target wasm32-unknown-unknown -p dpe-web` ✓
- `just check` ✓ (fmt + clippy)
- Local release build ✓ (2m 37s, 23.8 MB)
- SSR fan-out: `__RESOLVED_RESOURCES[..]` per `/dpe/projects` page **11 → 2** (the remaining two are `available_types` / `available_languages` in `ProjectsPage`, which don't capture an ancestor Memo and were intentionally left alone)
- 500-request / 100-concurrent stress over 4 query variants (`/dpe/projects`, `?status=ongoing`, `?search=tan`, `?page=2`): all 200, **0 panics** in the server log
- Project list / pagination / search results render unchanged

## Risk

Low. The data path was always synchronous under the hood; we just removed the async wrapper. Behaviour-equivalent. Reversible by restoring the previous `Resource::new(move || query.get(), ...)` wrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)