### PR TITLE
fix(dpe): match project shortcodes case-insensitively

### DIFF
--- a/modules/dpe/server/src/fragments.rs
+++ b/modules/dpe/server/src/fragments.rs
@@ -706,6 +706,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handler_lowercase_shortcode_for_uppercase_project_returns_ok() {
+        // Project 080C exists in the test data with an uppercase 'C'.
+        // Requesting it with a lowercase 'c' should still resolve.
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/dpe/projects/080c/tab/overview")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), AxumStatusCode::OK);
+    }
+
+    #[tokio::test]
     async fn handler_sse_html_contains_aria_attributes() {
         let app = test_app();
         let response = app

--- a/modules/dpe/web/src/domain/projects.rs
+++ b/modules/dpe/web/src/domain/projects.rs
@@ -589,18 +589,22 @@ pub async fn get_project(shortcode: String) -> Result<Option<Project>, ServerFnE
     use std::fs;
     use std::path::PathBuf;
 
-    use dpe_core::{all_projects, get_data_dir, CollectionRef};
+    use dpe_core::{get_data_dir, CollectionRef};
 
-    // Look up the base project from the in-memory cache — no disk scan needed.
-    let Some(base) = all_projects().iter().find(|p| p.shortcode == shortcode) else {
+    // Look up the base project from the in-memory cache — case-insensitive,
+    // so e.g. /dpe/projects/080c resolves to the project stored as 080C.
+    let Some(base) = dpe_core::project_cache::project_by_shortcode(&shortcode) else {
         return Ok(None);
     };
     let mut project = base.clone();
+    let canonical_shortcode = project.shortcode.clone();
 
-    // Resolve clusters from the in-memory cache (reverse lookup).
+    // Resolve clusters from the in-memory cache (reverse lookup). Compare
+    // case-insensitively so cluster files referencing a different case still
+    // resolve to the same project.
     project.clusters = dpe_core::cluster_cache::all_clusters()
         .iter()
-        .filter(|raw| raw.projects.iter().any(|p| p == &shortcode))
+        .filter(|raw| raw.projects.iter().any(|p| p.eq_ignore_ascii_case(&canonical_shortcode)))
         .map(|raw| raw.clone().into_ref())
         .collect();
 


### PR DESCRIPTION
## Summary

- The SSR project page (`/dpe/projects/{id}`) and the tab fragment handler both compared shortcodes with `==`, so `/dpe/projects/080c` rendered "Project Not Found" even though `080C` exists in the data.
- The JSON API and the underlying `project_cache::project_by_shortcode` already normalised to uppercase, so `/dpe/api/v1/projects/080c` did work — making the inconsistency user-visible.
- Routes the SSR / fragment-handler lookup through the same case-insensitive cache, and uses `eq_ignore_ascii_case` for the cluster reverse-lookup.

Path literal segments (`/dpe/projects`, `/dpe/about`) remain case-sensitive, matching standard HTTP conventions.

## Test plan

- [x] New tower-based integration test (`handler_lowercase_shortcode_for_uppercase_project_returns_ok`) hits `/dpe/projects/080c/tab/overview` (canonical: `080C`) and asserts 200. Verified red-before / green-after.
- [x] `just check`
- [x] `just test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)