### PR TITLE
fix(dpe-server): avoid duplicate `message` key in browser-error logs

### DIFF
--- a/modules/dpe/server/src/telemetry_collector.rs
+++ b/modules/dpe/server/src/telemetry_collector.rs
@@ -191,14 +191,14 @@ fn process_signal(signal: &Signal) {
             let truncated_message: String = e.message.chars().take(256).collect();
             tracing::warn!(
                 kind = error_kind,
-                message = %truncated_message,
                 page_url,
                 trace_parent = ?trace_parent,
                 page_load_id = %e.page_load_id,
                 filename = ?e.filename,
                 lineno = ?e.lineno,
                 colno = ?e.colno,
-                "browser error"
+                "browser error: {}",
+                truncated_message
             );
         }
         Signal::LongAnimationFrame(loaf) => {


### PR DESCRIPTION
## Summary

The `tracing::warn!` call for browser errors in `telemetry_collector.rs` set both an explicit `message = %truncated_message` field and an implicit message string `"browser error"`. Both serialize to a `message` key in the JSON log output, producing a duplicate key. Grafana (and most JSON consumers) keep only one of them, so the actual error detail was lost — log entries showed `"browser error"` instead of e.g. `"Failed to load: https://repository.dasch.swiss/assets/images/0118.webp"`.

The fix inlines the truncated message into the format string and drops the explicit `message` field, so the single `message` value now reads `"browser error: Failed to load: …"`.

Example before:
```json
{"fields":{"message":"browser error","kind":"resource_error","message":"Failed to load: …"}}
```

Example after:
```json
{"fields":{"message":"browser error: Failed to load: …","kind":"resource_error"}}
```

## Test plan

- [x] `just check` passes
- [x] `cargo test -p dpe-server` passes (46/46)
- [ ] Verify in Grafana after deploy that browser-error log entries now show the full error detail in the `message` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)