### PR TITLE
fix(dpe-web): eliminate remaining Resource::new sites on projects routes

### DIFF
--- a/modules/dpe/server/src/fragments.rs
+++ b/modules/dpe/server/src/fragments.rs
@@ -60,10 +60,7 @@ pub async fn tab_fragment_handler(
     }
 
     // Load project data
-    let project = get_project(id.clone())
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-        .ok_or(StatusCode::NOT_FOUND)?;
+    let project = get_project(&id).ok_or(StatusCode::NOT_FOUND)?;
 
     // If publications tab requested but project has no publications, return 404
     let has_publications_tab = has_publications(&project);
@@ -73,13 +70,7 @@ pub async fn tab_fragment_handler(
 
     // Load contributors if needed
     let contributors = if tab == "contributors" {
-        match get_contributors(project.attributions.clone()).await {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::warn!(shortcode = %id, error = %e, "failed to load contributors");
-                vec![]
-            }
-        }
+        get_contributors(project.attributions.clone())
     } else {
         vec![]
     };
@@ -242,8 +233,6 @@ pub async fn search_fragment_handler(
             None,                 // data_language
             None,                 // access_rights
         )
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
     };
 
     let html = render_search_results(&search, &results);

--- a/modules/dpe/web/src/domain/contributors.rs
+++ b/modules/dpe/web/src/domain/contributors.rs
@@ -1,10 +1,18 @@
+// Sync, in-memory contributor resolver.
+//
+// Previously a `#[server]` async fn used by `Resource::new(..)` in
+// `ProjectLoader`; the resulting reactive node panicked under streaming SSR
+// in `<Suspense>::dry_resolve`. The body was always synchronous (just hashmap
+// lookups against `dpe_core::contributors`), so we expose it as a plain
+// `pub fn` gated on non-wasm and call it directly from the page component
+// and the SSE fragment handler.
+
 pub use dpe_core::contributors::ResolvedContributor;
+#[cfg(not(target_arch = "wasm32"))]
 use dpe_core::project::Attribution;
 
-#[leptos::server]
-pub async fn get_contributors(
-    attributions: Vec<Attribution>,
-) -> Result<Vec<ResolvedContributor>, leptos::server_fn::error::ServerFnError> {
+#[cfg(not(target_arch = "wasm32"))]
+pub fn get_contributors(attributions: Vec<Attribution>) -> Vec<ResolvedContributor> {
     use dpe_core::contributors::{load_organization, load_person};
 
     let mut result = Vec::with_capacity(attributions.len());
@@ -31,5 +39,5 @@ pub async fn get_contributors(
             }
         }
     }
-    Ok(result)
+    result
 }

--- a/modules/dpe/web/src/domain/mod.rs
+++ b/modules/dpe/web/src/domain/mod.rs
@@ -7,7 +7,9 @@ pub mod project;
 pub mod projects;
 
 // Re-export all core domain types for backward compatibility
-// Re-export server functions and ProjectQuery from local modules
+// Re-export sync helpers (formerly `#[server]` server functions, now plain
+// `pub fn` gated on non-wasm) and ProjectQuery from local modules.
+#[cfg(not(target_arch = "wasm32"))]
 pub use contributors::get_contributors;
 pub use dpe_core::project::Publication;
 // Re-export record::Pid (ARK-based) as the default Pid — it's the more commonly used one.
@@ -25,4 +27,5 @@ pub use dpe_core::{
 #[cfg(feature = "ssr")]
 pub use dpe_core::{FsProjectRepository, FsRecordRepository};
 pub use project::ProjectQuery;
+#[cfg(not(target_arch = "wasm32"))]
 pub use projects::{get_project, list_data_languages, list_projects, list_type_of_data};

--- a/modules/dpe/web/src/domain/projects.rs
+++ b/modules/dpe/web/src/domain/projects.rs
@@ -1,8 +1,23 @@
-use dpe_core::{Page, Project};
-use leptos::prelude::*;
+// Project-list domain helpers.
+//
+// These were previously `#[server]` async fns (Leptos server functions). DPE
+// has no WASM client, so the server-fn indirection just exposed reactive
+// `Resource::new(..)` panic surfaces in `<Suspense>::dry_resolve` under
+// streaming SSR. The bodies are pure synchronous reads of the in-memory
+// project cache (`dpe_core::all_projects`), so we expose them as plain `pub fn`
+// gated on non-wasm — matching the cfg of `dpe_core::all_projects` itself —
+// and call them directly from page components and fragment handlers.
+//
+// `dpe-web` is still compiled for `wasm32-unknown-unknown` by cargo-leptos
+// (lib-package), but DPE renders SSR-only and the wasm output never executes;
+// gating on non-wasm avoids dragging the disk-backed cache into the wasm
+// build.
 
-#[server]
-pub async fn list_type_of_data() -> Result<Vec<String>, ServerFnError> {
+#[cfg(not(target_arch = "wasm32"))]
+use dpe_core::{Page, Project};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn list_type_of_data() -> Vec<String> {
     use std::collections::HashSet;
 
     use dpe_core::all_projects;
@@ -15,11 +30,11 @@ pub async fn list_type_of_data() -> Result<Vec<String>, ServerFnError> {
     }
     let mut result: Vec<String> = types.into_iter().collect();
     result.sort();
-    Ok(result)
+    result
 }
 
-#[server]
-pub async fn list_data_languages() -> Result<Vec<(String, String)>, ServerFnError> {
+#[cfg(not(target_arch = "wasm32"))]
+pub fn list_data_languages() -> Vec<(String, String)> {
     use std::collections::HashSet;
 
     use dpe_core::{all_projects, language_display_name};
@@ -40,12 +55,12 @@ pub async fn list_data_languages() -> Result<Vec<(String, String)>, ServerFnErro
         })
         .collect();
     result.sort_by(|a, b| a.1.cmp(&b.1));
-    Ok(result)
+    result
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[allow(clippy::too_many_arguments)]
-#[server]
-pub async fn list_projects(
+pub fn list_projects(
     ongoing: Option<bool>,
     finished: Option<bool>,
     search: Option<String>,
@@ -54,7 +69,7 @@ pub async fn list_projects(
     type_of_data: Option<String>,
     data_language: Option<String>,
     access_rights: Option<String>,
-) -> Result<Page, ServerFnError> {
+) -> Page {
     use dpe_core::all_projects;
 
     use super::project::ProjectQuery;
@@ -70,7 +85,7 @@ pub async fn list_projects(
         dialog: None,
     };
 
-    Ok(filter_and_paginate(all_projects(), &query, page_size))
+    filter_and_paginate(all_projects(), &query, page_size)
 }
 
 // Gated on non-wasm targets to match `dpe_core::all_projects` (the only
@@ -584,8 +599,8 @@ mod tests {
     }
 }
 
-#[server]
-pub async fn get_project(shortcode: String) -> Result<Option<Project>, ServerFnError> {
+#[cfg(not(target_arch = "wasm32"))]
+pub fn get_project(shortcode: &str) -> Option<Project> {
     use std::fs;
     use std::path::PathBuf;
 
@@ -593,9 +608,7 @@ pub async fn get_project(shortcode: String) -> Result<Option<Project>, ServerFnE
 
     // Look up the base project from the in-memory cache — case-insensitive,
     // so e.g. /dpe/projects/080c resolves to the project stored as 080C.
-    let Some(base) = dpe_core::project_cache::project_by_shortcode(&shortcode) else {
-        return Ok(None);
-    };
+    let base = dpe_core::project_cache::project_by_shortcode(shortcode)?;
     let mut project = base.clone();
     let canonical_shortcode = project.shortcode.clone();
 
@@ -623,5 +636,5 @@ pub async fn get_project(shortcode: String) -> Result<Option<Project>, ServerFnE
         })
         .collect();
 
-    Ok(Some(project))
+    Some(project)
 }

--- a/modules/dpe/web/src/pages/project/page.rs
+++ b/modules/dpe/web/src/pages/project/page.rs
@@ -3,7 +3,6 @@ use leptos_meta::Title;
 use leptos_router::hooks::use_params_map;
 
 use super::project_loader::ProjectLoader;
-use crate::components::loading::Loading;
 
 #[component]
 pub fn ProjectPage() -> impl IntoView {
@@ -13,11 +12,7 @@ pub fn ProjectPage() -> impl IntoView {
     view! {
         <Title text=move || format!("Project {}", shortcode()) />
         <div class="min-h-100">
-            <Suspense fallback=move || {
-                view! { <Loading /> }
-            }>
-                <ProjectLoader shortcode=shortcode() />
-            </Suspense>
+            <ProjectLoader shortcode=shortcode() />
         </div>
     }
 }

--- a/modules/dpe/web/src/pages/project/project_loader.rs
+++ b/modules/dpe/web/src/pages/project/project_loader.rs
@@ -1,66 +1,56 @@
 use leptos::prelude::*;
 
-use crate::domain::{get_contributors, get_project};
+#[cfg(not(target_arch = "wasm32"))]
 use crate::pages::project::components::project_details::ProjectDetails;
 
-/// ProjectLoader component that handles loading and error states for project data.
+/// Renders project details for a given shortcode.
 ///
-/// This component creates a Resource to load project data based on a shortcode
-/// and handles all the different states (loading, success, not found, error) in one place.
+/// Looked up synchronously from the in-process project + contributor caches
+/// (`dpe_web::domain::projects::get_project` and
+/// `dpe_web::domain::contributors::get_contributors`) — no `Resource` /
+/// `<Suspense>`. The previous async pattern wrapped the project + contributor
+/// load in a `Resource::new(move || shortcode.clone(), ..)`; under streaming
+/// SSR the resource was visited by `<Suspense>::dry_resolve` while the
+/// owning scope was already being torn down, hitting the recurring
+/// `tokio-rt-worker` panic at
+/// `reactive_graph-0.2.11/src/traits.rs:394:39` ("Tried to access a reactive
+/// value that has already been disposed."). The data layer is fully
+/// in-memory and synchronous, so the `Resource` indirection added no value
+/// and all the lifecycle risk.
+///
+/// Like the sibling components in `pages/project/components/`, this is
+/// gated on non-wasm because `dpe_core::project_cache` and
+/// `dpe_core::contributors` are non-wasm. DPE renders SSR-only, but
+/// cargo-leptos still compiles `dpe-web` for `wasm32-unknown-unknown`
+/// (lib-package), so an inert wasm stub is needed even though it never
+/// renders.
+#[cfg(not(target_arch = "wasm32"))]
 #[component]
 pub fn ProjectLoader(
     /// The project shortcode to load
     shortcode: String,
 ) -> impl IntoView {
-    let shortcode_for_error = shortcode.clone();
+    use crate::domain::{get_contributors, get_project};
 
-    // Load project and contributors in a single resource so they resolve together.
-    let resource = Resource::new(
-        move || shortcode.clone(),
-        |shortcode| async move {
-            let proj = get_project(shortcode).await?;
-            let contributors = match &proj {
-                Some(p) => get_contributors(p.attributions.clone()).await.unwrap_or_default(),
-                None => vec![],
-            };
-            Ok::<_, leptos::server_fn::error::ServerFnError>((proj, contributors))
-        },
-    );
-
-    view! {
-        {move || {
-            resource
-                .get()
-                .map(|result| match result {
-                    Ok((Some(proj), contributors)) => {
-                        view! { <ProjectDetails proj=proj contributors=contributors /> }.into_any()
-                    }
-                    Ok((None, _)) => {
-                        view! {
-                            <div class="text-center py-12">
-                                <h1 class="font-display text-3xl font-bold mb-4">
-                                    "Project Not Found"
-                                </h1>
-                                <p class="text-lg">
-                                    "The project with shortcode " {shortcode_for_error.clone()}
-                                    " could not be found."
-                                </p>
-                            </div>
-                        }
-                            .into_any()
-                    }
-                    Err(e) => {
-                        view! {
-                            <div class="alert alert-error">
-                                <div>
-                                    <h1 class="font-display font-bold">"Error"</h1>
-                                    <p>"Failed to load project: " {e.to_string()}</p>
-                                </div>
-                            </div>
-                        }
-                            .into_any()
-                    }
-                })
-        }}
+    match get_project(&shortcode) {
+        Some(project) => {
+            let contributors = get_contributors(project.attributions.clone());
+            view! { <ProjectDetails proj=project contributors=contributors /> }.into_any()
+        }
+        None => view! {
+            <div class="text-center py-12">
+                <h1 class="font-display text-3xl font-bold mb-4">"Project Not Found"</h1>
+                <p class="text-lg">
+                    "The project with shortcode " {shortcode} " could not be found."
+                </p>
+            </div>
+        }
+        .into_any(),
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[component]
+pub fn ProjectLoader(shortcode: String) -> impl IntoView {
+    let _ = shortcode;
 }

--- a/modules/dpe/web/src/pages/projects/page.rs
+++ b/modules/dpe/web/src/pages/projects/page.rs
@@ -1,107 +1,115 @@
 use leptos::prelude::*;
+#[cfg(not(target_arch = "wasm32"))]
 use leptos_router::hooks::use_query;
+#[cfg(not(target_arch = "wasm32"))]
 use mosaic_tiles::card::{Card, CardBody, CardVariant};
 
+#[cfg(not(target_arch = "wasm32"))]
 use super::components::mobile_filters_button::MobileFiltersButton;
+#[cfg(not(target_arch = "wasm32"))]
 use super::components::project_filters::ProjectFilters;
+#[cfg(not(target_arch = "wasm32"))]
 use super::components::project_list::ProjectList;
+#[cfg(not(target_arch = "wasm32"))]
 use super::components::project_search_input::ProjectSearchInput;
-use crate::domain::{list_data_languages, list_type_of_data, ProjectQuery};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::domain::ProjectQuery;
 
+/// Projects index page.
+///
+/// Resolved synchronously from the in-memory project cache — no
+/// `Resource` / `<Suspense>`. The previous async pattern wrapped the
+/// type-of-data and data-language facet sources in
+/// `Resource::new(|| (), |_| async { list_..().await })`; under streaming
+/// SSR even those `()`-sourced resources were visited by
+/// `<Suspense>::dry_resolve`, hitting the recurring
+/// `tokio-rt-worker` panic at
+/// `reactive_graph-0.2.11/src/traits.rs:394:39` ("Tried to access a
+/// reactive value that has already been disposed."). The data layer is
+/// fully in-memory and synchronous, so the `Resource` indirection added
+/// no value and all the lifecycle risk.
+///
+/// `dpe_web::domain::list_type_of_data`, `list_data_languages`, and
+/// `ProjectQuery` accessors that read filter state are gated on non-wasm
+/// (matching the underlying caches); DPE renders SSR-only, but
+/// cargo-leptos still compiles `dpe-web` for `wasm32-unknown-unknown`
+/// (lib-package), so an inert wasm stub is needed even though it never
+/// renders.
+#[cfg(not(target_arch = "wasm32"))]
 #[component]
 pub fn ProjectsPage() -> impl IntoView {
+    use crate::domain::{list_data_languages, list_type_of_data};
+
     let query = use_query::<ProjectQuery>();
     let current_query = query.get().unwrap_or_default();
 
     let status_items = current_query.status_filter_items();
     let access_rights_items = current_query.access_rights_filter_items();
 
-    let available_types = Resource::new(|| (), |_| async { list_type_of_data().await });
-    let available_languages = Resource::new(|| (), |_| async { list_data_languages().await });
-
-    let cq = current_query.clone();
-
     let dialog_open = current_query.dialog.unwrap_or(false);
     let open_dialog_href = format!("/dpe/projects{}", current_query.clone().with_dialog(true).to_query_string());
     let close_dialog_href = format!("/dpe/projects{}", current_query.clone().with_dialog(false).to_query_string());
 
+    let type_of_data_selected = current_query.type_of_data();
+    let type_of_data_items: Vec<(String, bool, String)> = list_type_of_data()
+        .into_iter()
+        .map(|t| {
+            let checked = type_of_data_selected.contains(&t);
+            let href = format!("/dpe/projects{}", current_query.with_type_of_data_toggled(&t).to_query_string(),);
+            (t, checked, href)
+        })
+        .collect();
+
+    let data_language_selected = current_query.data_language();
+    let data_language_items: Vec<(String, bool, String)> = list_data_languages()
+        .into_iter()
+        .map(|(code, display)| {
+            let checked = data_language_selected.contains(&code);
+            let href = format!(
+                "/dpe/projects{}",
+                current_query.with_data_language_toggled(&code).to_query_string(),
+            );
+            (display, checked, href)
+        })
+        .collect();
+
     view! {
-        <Suspense>
-            {move || {
-                let status = status_items.clone();
-                let status_mobile = status_items.clone();
-                let access = access_rights_items.clone();
-                let access_mobile = access_rights_items.clone();
-                let open_href = open_dialog_href.clone();
-                let close_href = close_dialog_href.clone();
-                let type_of_data = cq.type_of_data();
-                let data_language = cq.data_language();
-                let type_of_data_items = available_types
-                    .get()
-                    .and_then(|r| r.ok())
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(|t| {
-                        let checked = type_of_data.contains(&t);
-                        let href = format!(
-                            "/dpe/projects{}",
-                            cq.with_type_of_data_toggled(&t).to_query_string(),
-                        );
-                        (t, checked, href)
-                    })
-                    .collect::<Vec<_>>();
-                let type_of_data_items_mobile = type_of_data_items.clone();
-                let data_language_items = available_languages
-                    .get()
-                    .and_then(|r| r.ok())
-                    .unwrap_or_default()
-                    .into_iter()
-                    .map(|(code, display)| {
-                        let checked = data_language.contains(&code);
-                        let href = format!(
-                            "/dpe/projects{}",
-                            cq.with_data_language_toggled(&code).to_query_string(),
-                        );
-                        (display, checked, href)
-                    })
-                    .collect::<Vec<_>>();
-                let data_language_items_mobile = data_language_items.clone();
-                view! {
-                    <div class="flex gap-4">
-                        <div class="hidden lg:block lg:w-72 2xl:w-80 flex-shrink-0">
-                            <ProjectFilters
-                                status_items=status
-                                type_of_data_items=type_of_data_items
-                                data_language_items=data_language_items
-                                access_rights_items=access
-                            />
+        <div class="flex gap-4">
+            <div class="hidden lg:block lg:w-72 2xl:w-80 flex-shrink-0">
+                <ProjectFilters
+                    status_items=status_items.clone()
+                    type_of_data_items=type_of_data_items.clone()
+                    data_language_items=data_language_items.clone()
+                    access_rights_items=access_rights_items.clone()
+                />
+            </div>
+            <div class="flex-1 flex flex-col gap-2">
+                <Card variant=CardVariant::Bordered class="overflow-visible">
+                    <CardBody>
+                        <div class="flex gap-4">
+                            <div class="flex-1">
+                                <ProjectSearchInput />
+                            </div>
+                            <div class="lg:hidden">
+                                <MobileFiltersButton
+                                    status_items=status_items
+                                    type_of_data_items=type_of_data_items
+                                    data_language_items=data_language_items
+                                    access_rights_items=access_rights_items
+                                    dialog_open=dialog_open
+                                    open_dialog_href=open_dialog_href
+                                    close_dialog_href=close_dialog_href
+                                />
+                            </div>
                         </div>
-                        <div class="flex-1 flex flex-col gap-2">
-                            <Card variant=CardVariant::Bordered class="overflow-visible">
-                                <CardBody>
-                                    <div class="flex gap-4">
-                                        <div class="flex-1">
-                                            <ProjectSearchInput />
-                                        </div>
-                                        <div class="lg:hidden">
-                                            <MobileFiltersButton
-                                                status_items=status_mobile
-                                                type_of_data_items=type_of_data_items_mobile
-                                                data_language_items=data_language_items_mobile
-                                                access_rights_items=access_mobile
-                                                dialog_open=dialog_open
-                                                open_dialog_href=open_href
-                                                close_dialog_href=close_href
-                                            />
-                                        </div>
-                                    </div>
-                                </CardBody>
-                            </Card>
-                            <ProjectList query=cq.clone() />
-                        </div>
-                    </div>
-                }
-            }}
-        </Suspense>
+                    </CardBody>
+                </Card>
+                <ProjectList query=current_query />
+            </div>
+        </div>
     }
 }
+
+#[cfg(target_arch = "wasm32")]
+#[component]
+pub fn ProjectsPage() -> impl IntoView {}

--- a/modules/mosaic/tiles/src/components/icon/mod.rs
+++ b/modules/mosaic/tiles/src/components/icon/mod.rs
@@ -80,9 +80,22 @@ pub fn Icon(
     #[prop(optional, into)]
     class: MaybeProp<String>,
 ) -> impl IntoView {
+    // Read the class once at component creation rather than from inside a
+    // `move ||` closure. All 101 call sites in this repo pass either no
+    // `class` or a static string literal — none feed in a reactive signal —
+    // so the wrapping closure only added a reactive subscription that turned
+    // every `<Icon>` into a node visited by `<Suspense>::dry_resolve`. Under
+    // streaming SSR that walk could fire after the owning scope had already
+    // been disposed, hitting the recurring `tokio-rt-worker` panic at
+    // `reactive_graph-0.2.11/src/traits.rs:394:39`. The actual panic surface
+    // for DPE was eliminated by removing the `<Suspense>` boundaries on the
+    // projects routes; this is a defensive cleanup that removes the
+    // closure regardless of where Icon is rendered (e.g. mosaic-playground
+    // islands).
+    let class_str = format!("icon {}", class.get_untracked().unwrap_or_default());
     view! {
         <svg
-            class=move || format!("icon {}", class.get().unwrap_or_default())
+            class=class_str
             xmlns="http://www.w3.org/2000/svg"
             viewBox=icon.view_box
             fill="currentColor"


### PR DESCRIPTION
## Summary

Production logs on 0.5.2 still showed the recurring `tokio-rt-worker` panic at `reactive_graph-0.2.11/src/traits.rs:394:39` (\"Tried to access a reactive value that has already been disposed.\") even after #211 (sidebar fanout) and #216 (project list). Backtraces pointed at two new frames:

1. `<Suspense>::dry_resolve` walking the `available_types` / `available_languages` resources in `ProjectsPage` — even with a unit `|| ()` source.
2. The same dry_resolve walk hitting the reactive `class.get()` closure inside `mosaic-tiles::Icon` while rendered inside that `<Suspense>`.

The disposal-race anti-pattern is broader than what we previously documented: **any** reactive `get()` reachable from a `<Suspense>::dry_resolve` walk is a liability under streaming SSR, not just cross-owner Memo captures. DPE's data layer is fully synchronous in-memory, so the `Resource` / `<Suspense>` indirection adds no value and all the lifecycle risk.

### Commit 1 — `fix(dpe-web)`

Convert the four remaining `#[server]` async fns (`list_type_of_data`, `list_data_languages`, `list_projects`, `get_project`) and `get_contributors` to plain `pub fn` gated on non-wasm, matching the cfg of `dpe_core::all_projects`. Drop the two `<Suspense>` boundaries on `/dpe/projects` and `/dpe/projects/:id`. Update the SSE fragment handlers in `dpe-server` to call the sync helpers directly. After this commit no `Resource::new` / `<Suspense>` remains on the projects routes.

Same conversion shape as #211 (sidebar fanout) and #216 (project list).

### Commit 2 — `fix(mosaic-tiles)` (defensive follow-on)

`Icon::class` was read inside a `move ||` closure, which made every `<Icon>` a reactive node visited by `<Suspense>::dry_resolve`. All 101 call sites in this repo pass either no `class` or a static string literal — no reactive signals — so the closure only added panic risk. Read the class once eagerly at component creation. API and behaviour unchanged for all existing callers.

## Verification

- `just check` — passes (host + wasm32 lib build)
- `cargo check -p dpe-web --no-default-features --features default` — passes (the cargo-hack matrix that bit #216)
- `cargo check -p dpe-web --no-default-features` — passes
- `just test` — all suites green (including the snapshot tests in `dpe-server` that exercise `render_project_sidebar` / `render_project_tabs`)

## Test plan

- [ ] Stress-test the projects index and a project detail page locally; confirm no `__RESOLVED_RESOURCES` markers in HTML.
- [ ] Watch Grafana after deploy: the disposal panic from `traits.rs:394:39` should disappear, and per-request memory should drop further.
- [ ] Verify the projects list, filters, search dropdown, and tab fragments all still work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)