### PR TITLE
chore: local LGTM observability targets and worktreeinclude

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+.env
+.claude/settings.local.json
+CLAUDE.local.md

--- a/docs/src/dpe/observability.md
+++ b/docs/src/dpe/observability.md
@@ -13,24 +13,22 @@ Trace correlation between server and client uses the W3C `traceparent` standard:
 
 ## Local Observability Stack
 
-Run the Grafana LGTM (Loki, Grafana, Tempo, Mimir) all-in-one container:
+Run the Grafana LGTM (Loki, Grafana, Tempo, Mimir) all-in-one container alongside DPE:
 
 ```bash
 # Terminal 1: Start local LGTM stack
-docker run --rm -p 3000:3000 -p 4317:4317 -p 4318:4318 -p 4040:4040 grafana/otel-lgtm
+just lgtm-up
 
-# Terminal 2: Run DPE with OTel enabled
-OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
-OTEL_SERVICE_NAME=dpe \
-OTEL_RESOURCE_ATTRIBUTES="service.namespace=dpe,service.version=0.2.1,deployment.environment=dev" \
-PYROSCOPE_ENDPOINT=http://localhost:4040 \
-just watch-dpe
+# Terminal 2: Run DPE with OTel enabled (exports to localhost:4317)
+just watch-dpe-otel
 
 # Terminal 3: Generate traffic
 curl http://localhost:4000/projects
 curl http://localhost:4000/oai?verb=Identify
 curl http://localhost:4000/healthz
 ```
+
+`watch-dpe-otel` sets `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`, and `PYROSCOPE_ENDPOINT` for you. Run `just --list` to see the underlying commands.
 
 ## Navigating Grafana Locally
 

--- a/justfile
+++ b/justfile
@@ -142,9 +142,28 @@ run-docker-mosaic-playground:
 # DPE targets
 ###################
 
+# Verify daisyui is installed in modules/dpe/node_modules — Tailwind needs it at build time
+[private]
+_check-dpe-node-modules:
+    @test -d modules/dpe/node_modules/daisyui || { echo >&2 "error: modules/dpe/node_modules/daisyui not found — run 'just install-requirements' or 'pnpm -C modules/dpe install'"; exit 1; }
+
 # Start the DPE with hot reload
 [group('dpe')]
-watch-dpe:
+watch-dpe: _check-dpe-node-modules
+    cargo leptos watch --project=dpe -- serve
+
+# Start the Grafana LGTM (Loki, Grafana, Tempo, Mimir) all-in-one container for local observability
+[group('dpe')]
+lgtm-up:
+    docker run --rm -p 3000:3000 -p 4317:4317 -p 4318:4318 -p 4040:4040 grafana/otel-lgtm
+
+# Start the DPE with hot reload, exporting traces/metrics/logs to a local LGTM stack (run `just lgtm-up` in another terminal first)
+[group('dpe')]
+watch-dpe-otel: _check-dpe-node-modules
+    OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
+    OTEL_SERVICE_NAME=dpe \
+    OTEL_RESOURCE_ATTRIBUTES="service.namespace=dpe,service.version={{ CARGO_VERSION }},deployment.environment=dev" \
+    PYROSCOPE_ENDPOINT=http://localhost:4040 \
     cargo leptos watch --project=dpe -- serve
 
 # Build Docker image for DPE


### PR DESCRIPTION
## Motivation

Running DPE against a local Grafana LGTM stack required remembering a four-line `OTEL_*` env-var prelude and a long `docker run` line, both copied from `docs/src/dpe/observability.md`. Easy to mistype, and the docs hardcoded `service.version=0.2.1` which is now stale.

Separately, fresh git worktrees for this repo don't get the user's local files (`CLAUDE.local.md`, `.claude/settings.local.json`, `.env`), so each worktree starts without project context. And building DPE in a fresh worktree fails late inside `cargo leptos watch` with `Can't resolve 'daisyui'` because `pnpm install` hasn't been run — the failure happens after a full Rust compile (~70s wasted).

## Summary

- `just lgtm-up` and `just watch-dpe-otel` for one-command local observability.
- `.worktreeinclude` so future Claude Code worktrees inherit local files.
- Fast-fail on missing `daisyui` before `cargo leptos` runs.

## Key Changes

### justfile
- New `[group('dpe')] lgtm-up` runs `grafana/otel-lgtm` with the four ports DPE needs (3000, 4317, 4318, 4040).
- New `[group('dpe')] watch-dpe-otel` runs `cargo leptos watch` with `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES`, and `PYROSCOPE_ENDPOINT` set. `service.version` now uses `{{ CARGO_VERSION }}` so it stays in sync with `Cargo.toml`.
- Private `_check-dpe-node-modules` recipe used as a dependency of both `watch-dpe` and `watch-dpe-otel`. Fails fast with: `error: modules/dpe/node_modules/daisyui not found — run 'just install-requirements' or 'pnpm -C modules/dpe install'`.

### .worktreeinclude
- New file listing `.env`, `.claude/settings.local.json`, `CLAUDE.local.md`. Same pattern as `dasch-swiss/dsp-api@2a1dae44`.

### docs/src/dpe/observability.md
- Replaced the inline docker/env-var snippet with `just lgtm-up` / `just watch-dpe-otel`. Drops the stale `service.version=0.2.1`.

## Challenges and Decisions

### Auto-install vs. fast-fail on missing daisyui
**Problem:** `cargo leptos watch` only invokes Tailwind after compiling Rust, so a missing `daisyui` is reported ~70s into the build.
**Tried:** Auto-running `pnpm install` from the recipe.
**Solution:** Explicit fail with instructions. `watch-*` should not have hidden side-effects on `node_modules`; surfacing the missing dep is enough.

### service.version source
**Problem:** Docs hardcoded `0.2.1`; current Cargo version is `0.5.3`.
**Solution:** Use the existing `CARGO_VERSION` just-variable (already populated from `cargo metadata`).

## Gotchas

- The `/projects` and `/oai?verb=Identify` URLs still in the observability docs are 404 in the current build — only `/` and `/telemetry.js` produce traces today. Out of scope for this PR; flagging for a follow-up.
- LGTM ports overlap with other Grafana-style stacks. If `lgtm-up` errors on port bind, check `lsof -nP -iTCP:3000 -sTCP:LISTEN` for stragglers.
- `.worktreeinclude` only copies files that exist locally — `.env` is listed even though this repo doesn't currently have one, mirroring the `dsp-api` precedent so it works if/when one is added.

## Test Plan

- [x] `just --check --fmt --unstable` passes
- [x] `just _check-dpe-node-modules` succeeds when `daisyui` present, fails with exit 1 and clear message when missing
- [x] `just lgtm-up` boots, OTLP gRPC listens on `:4317`, Grafana on `:3000`
- [x] `just watch-dpe-otel` builds and serves DPE on `:4000`; `service.name=dpe` traces appear in Tempo (`GET /` root spans), Loki has `service_name`/`service_namespace`/`deployment_environment` resource labels, Mimir receives metrics
- [ ] Reviewer: spin up a fresh worktree to confirm `.worktreeinclude` copies the listed files