### PR TITLE
fix(dpe-web): point access rights filter info link to new dasch.swiss page (DEV-6223)

### DIFF
--- a/modules/dpe/web/src/pages/projects/components/project_filters_content.rs
+++ b/modules/dpe/web/src/pages/projects/components/project_filters_content.rs
@@ -38,7 +38,7 @@ pub fn ProjectFiltersContent(
                 <FilterCheckboxGroup
                     title="Access Rights".to_string()
                     items=access_rights_items
-                    info_href="https://dasch.swiss/knowledge-hub/fundamentals-copyright-licenses"
+                    info_href="https://dasch.swiss/knowledge-hub/fundamentals-access-rights"
                     info_tooltip="Access rights define how openly the data can be accessed. Learn more here."
                 />
             </div>


### PR DESCRIPTION
Fixes DEV-6223

## Motivation
The info icon next to the "Access Rights" filter on the projects page pointed to the copyright/licenses knowledge-hub page, which is the wrong topic. A dedicated knowledge-hub page about access rights now exists and is the correct destination.

## Summary
- Change `info_href` on the "Access Rights" `FilterCheckboxGroup` from `…/fundamentals-copyright-licenses` to `…/fundamentals-access-rights`.

## Key Changes
### dpe-web — projects filter
- `modules/dpe/web/src/pages/projects/components/project_filters_content.rs`: update the `info_href` prop value. The accompanying `info_tooltip` text remains accurate (and now matches the destination page's topic more precisely).

## Challenges and Decisions
N/A — single-line URL change.

## Gotchas
None.

## Test Plan
- [x] `just check` passes (fmt + clippy)
- [x] `just test` passes (no snapshot or unit test references the URL)
- [ ] On the deployed preview, click the info icon next to "Access Rights" on `/dpe/projects` and confirm the link opens https://dasch.swiss/knowledge-hub/fundamentals-access-rights