### PR TITLE
data: update samaria-ivories metadata (DEV-6547)

### DIFF
--- a/modules/dpe/server/data/projects/0863_samaria-ivories.json
+++ b/modules/dpe/server/data/projects/0863_samaria-ivories.json
@@ -1,22 +1,22 @@
 {
     "id": "0863",
     "pid": "https://ark.dasch.swiss/ark:/72163/1/0863",
-    "name": "The Electronic Catalogue of the Samaria Ivory Artifacts and Related Material",
+    "name": "The Electronic Catalogue of the Samaria Ivory Carvings",
     "shortcode": "0863",
-    "officialName": "The Electronic Catalogue of the Samaria Ivory Artifacts and Related Material",
+    "officialName": "The Electronic Catalogue of the Samaria Ivory Carvings",
     "status": "Finished",
     "shortDescription": "\"Samaria Ivories\" provides access to a catalogue with color photographs of the entire assemblage of ivory carvings and related material that once decorated luxurious furniture of the Israelite elite.",
     "description": {
-        "en": "\"The Electronic Catalogue of the Samaria Ivory Artifacts and Related Material\" offers the first complete publication of the ivory carvings and related inlays and overlays that were excavated between 1908 and 1935 at Samaria, the capital of the kingdom of Israel in the 9th-8th centuries BCE. The catalogue accompanies a description, analysis, and reassessment of this material published in book form. The over 12,500 mostly very fragmentary items once decorated luxurious furniture, perhaps also other prestige goods. They constitute not only a substantial portion of the arts known from Iron Age Israel, but also the largest assemblage of elaborate Levantine ivory carvings of the Iron Age unearthed in the Levant itself rather than Assyrian cities, where the vast majority of this body of material came to light. Thus, the Samaria Ivories are significant for both the cultural history of ancient Israel and the study of Levantine ivory carvings of the Iron Age."
+        "en": "\"The Electronic Catalogue of the Samaria Ivory Carvings\" offers the first complete publication of the ivory carvings and related inlays and overlays that were excavated between 1908 and 1935 at Samaria, the capital of the kingdom of Israel in the 9th-8th centuries BCE. The catalogue accompanies a description, analysis, and reassessment of this material published in book form. The over 12,500 mostly very fragmentary items once decorated luxurious furniture, perhaps also other prestige goods. They constitute not only a substantial portion of the arts known from Iron Age Israel, but also the largest assemblage of elaborate Levantine ivory carvings of the Iron Age unearthed in the Levant itself rather than Assyrian cities, where the vast majority of this body of material came to light. Thus, the Samaria Ivories are significant for both the cultural history of ancient Israel and the study of Levantine ivory carvings of the Iron Age."
     },
     "startDate": "2002-04-01",
     "endDate": "2025-06-30",
     "url": [
         "MISSING"
     ],
-    "howToCite": "Suter (2026). The Electronic Catalogue of the Samaria Ivory Artifacts and Related Material (Samaria Ivories) [Database]. DaSCH. https://ark.dasch.swiss/ark:/72163/1/0863.",
+    "howToCite": "Suter (2026). The Electronic Catalogue of the Samaria Ivory Carvings (Samaria Ivories) [Database]. DaSCH. https://ark.dasch.swiss/ark:/72163/1/0863.",
     "accessRights": {
-        "accessRights": "Full Open Access"
+        "accessRights": "Embargoed Access"
     },
     "legalInfo": [
         {
@@ -25,7 +25,7 @@
                 "licenseDate": "2026-01-01",
                 "licenseURI": "https://creativecommons.org/licenses/by-nc-sa/4.0/"
             },
-            "copyrightHolder": "The Electronic Catalogue of the Samaria Ivory Artifacts and Related Material",
+            "copyrightHolder": "The Electronic Catalogue of the Samaria Ivory Carvings",
             "authorship": [
                 "CALCULATED"
             ]


### PR DESCRIPTION
Fixes DEV-6547

## Motivation

Rita Gautschy requested updates to the `samaria-ivories` (shortcode `0863`) project metadata so the ARKs resolve correctly when referenced in the open-access monograph being published in 2026. An embargo also now applies to the data until the accompanying book appears in 2027.

## Summary

- Renamed the project from "The Electronic Catalogue of the Samaria Ivory Artifacts and Related Material" to "The Electronic Catalogue of the Samaria Ivory Carvings" everywhere it appears on the project record.
- Set access rights to `Embargoed Access` (was `Full Open Access`). Must be flipped back to `Full Open Access` after the book publishes in 2027.

## Key Changes

### `modules/dpe/server/data/projects/0863_samaria-ivories.json`

- `name`, `officialName`, `copyrightHolder`, `howToCite` — title updated
- `description.en` — only the title in the opening quoted phrase changed; the rest of the description is preserved verbatim
- `accessRights.accessRights`: `Full Open Access` → `Embargoed Access`

## Challenges and Decisions

### Abstract: full replacement vs. title-only update
**Problem:** Rita's email contains an abstract that ends with `…`. It is identical to the first sentence of the existing description (with the new title), then trails off.
**Tried:** Replacing the entire description with just Rita's one-sentence version would have dropped substantial established content about the 12,500 fragments, the broader significance of the assemblage, etc.
**Solution:** Updated the title inside the description but preserved the rest of the existing text. The `…` is interpreted as "and the rest unchanged", consistent with the fact that Rita only specified a title change. If Rita actually wanted the shorter version, this is easy to revert.

### Originally targeted the wrong repository
**Problem:** The original Linear issue and Rita's email both refer to "dsp-meta" / "dsp-repository" without disambiguation. `dsp-meta` is the historical home for this kind of metadata.
**Tried:** Made the change in `dsp-meta` first and went as far as extending its `DraftAccessCondition` enum + both JSON schemas to add an `embargoed` variant (its enum only had `open` / `restricted` / `closed`). Push failed: `dsp-meta` was archived 2026-05-08.
**Solution:** Re-applied the data change here in `dsp-repository`, where DPE already supports the value as `AccessRightsType::EmbargoedAccess` (serialised as `"Embargoed Access"`). No code change needed in this repo — the schema is already capable.

## Gotchas

- **Embargo is not enforced** by this metadata alone. The label is informational; whatever surfaces the data to the public needs its own check. Coordinate with whoever serves the project page before deployment.
- **Calendar reminder needed** to flip `accessRights` back to `Full Open Access` when the book publishes in 2027. There is no automatic expiry on the `Embargoed Access` value.
- The `description.en` field still contains the longer marketing/scholarly description from before. If Rita actually intended the shorter, one-sentence-with-ellipsis version, revert the `description.en` change alone.
- The `legalInfo[0].copyrightHolder` field uses the project title as its value, which is a pre-existing pattern in this repo even though the title isn't technically a legal entity. I matched the existing convention rather than fixing it here.

## Test Plan

- [ ] `just check` — passes (clippy + leptosfmt + wasm32 check)
- [ ] `just test` — passes (workspace tests, including project-data parsing)
- [ ] Manual: open the project page locally with `just watch-dpe` and confirm the renamed title, updated citation, and "Embargoed Access" badge render correctly
- [ ] Confirm with Rita that the abstract interpretation (title change only, rest preserved) matches her intent