### PR TITLE
fix(dpe-server): correct metadata JSON API path from v1 to v2

### DIFF
--- a/modules/dpe/server/src/main.rs
+++ b/modules/dpe/server/src/main.rs
@@ -158,8 +158,8 @@ async fn serve() -> ExitCode {
         .route("/dpe/oai", get(dpe_api_oai::oai_handler))
         .route("/dpe/projects/{id}/tab/{tab}", get(fragments::tab_fragment_handler))
         .route("/dpe/projects/search", get(fragments::search_fragment_handler))
-        .route("/dpe/api/v1/projects", get(fragments::projects_json_handler))
-        .route("/dpe/api/v1/projects/{id}", get(fragments::project_json_handler))
+        .route("/dpe/api/v2/projects", get(fragments::projects_json_handler))
+        .route("/dpe/api/v2/projects/{id}", get(fragments::project_json_handler))
         .leptos_routes(&leptos_options, routes, {
             let leptos_options = leptos_options.clone();
             let fathom_site_id = fathom_site_id.clone();


### PR DESCRIPTION
## Summary

- Renames the JSON metadata endpoints from `/dpe/api/v1/projects` (and `/dpe/api/v1/projects/{id}`) to `/dpe/api/v2/...`.
- These endpoints return data in the **v2** metadata format, so the URL path was misleading.

## Breaking change

This is a breaking change for consumers of the public endpoint. Known consumers:

- `dasch-swiss-website` — a companion PR is in flight to update the URLs used there. The two need to be coordinated at deployment time.

## Test plan

- [x] `just check` (fmt + clippy + wasm check)
- [ ] Verify the website PR lands and is deployed in tandem with this one

🤖 Generated with [Claude Code](https://claude.com/claude-code)