### PR TITLE
fix(mosaic/tiles): harden tailwind download with status check and retries

### DIFF
--- a/modules/mosaic/tiles/build.rs
+++ b/modules/mosaic/tiles/build.rs
@@ -40,20 +40,48 @@ fn bundle_css(input: PathBuf, mut output: &File) {
 }
 
 fn download_file(download_url: &str, file_path: &PathBuf) {
-    File::create(file_path).expect("Error creating file");
-
-    let mut file = File::options().append(true).open(file_path).expect("Error opening file");
+    const MAX_ATTEMPTS: u32 = 3;
 
     let client = reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(3600))
         .build()
         .expect("Error building client");
 
-    let response = client.get(download_url).send().expect("Error getting response");
+    let mut last_error: String = String::from("no attempts made");
 
-    let content = response.bytes().expect("Error getting bytes from response");
+    for attempt in 1..=MAX_ATTEMPTS {
+        let result = client
+            .get(download_url)
+            .send()
+            .map_err(|e| format!("request failed: {e}"))
+            .and_then(|response| {
+                let status = response.status();
+                if !status.is_success() {
+                    return Err(format!("HTTP {status} for {download_url}"));
+                }
+                response.bytes().map_err(|e| format!("reading body failed: {e}"))
+            });
 
-    file.write_all(&content).expect("Error writing to file");
+        match result {
+            Ok(content) => {
+                let mut file = File::create(file_path).expect("Error creating file");
+                file.write_all(&content).expect("Error writing to file");
+                return;
+            }
+            Err(e) => {
+                last_error = e;
+                println!(
+                    "cargo:warning=Download attempt {attempt}/{MAX_ATTEMPTS} for {download_url} failed: {last_error}"
+                );
+            }
+        }
+
+        if attempt < MAX_ATTEMPTS {
+            std::thread::sleep(std::time::Duration::from_secs(2u64.pow(attempt - 1)));
+        }
+    }
+
+    panic!("Failed to download {download_url} after {MAX_ATTEMPTS} attempts. Last error: {last_error}");
 }
 
 fn run_tailwind(tailwind_path: Option<&Path>, bundle_path: &PathBuf, singlestage_path: &PathBuf) -> Result<(), ()> {


### PR DESCRIPTION
## Summary

- `download_file` in `modules/mosaic/tiles/build.rs` now validates HTTP status, retries up to 3 times with exponential backoff (1s, 2s), and only writes the file on success.
- Each failed attempt is reported via `cargo:warning=…` so transient retries are visible in CI logs.

## Why

CI on `main` failed today (runs [26458763138](https://github.com/dasch-swiss/dsp-repository/actions/runs/26458763138), [26458763139](https://github.com/dasch-swiss/dsp-repository/actions/runs/26458763139)) with:

```
Filename: tailwindcss-linux-x64
Expected Checksum:
Calculated Checksum: 0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5
Checksum mismatch!
```

The same commit had passed earlier on its PR branch and again immediately after on the release-please PR — so the network blip was transient. Root cause: `download_file` never inspected `response.status()`. Any non-2xx body (error page, redirect HTML, partial body) was written to disk verbatim, which then caused both files to be corrupted and the parser to emit an empty expected checksum.

The new code fails fast with a clear message if the network actually misbehaves, and absorbs short-lived blips automatically.

## Test plan

- [x] `just check` (fmt + clippy)
- [ ] CI green on this PR
- [ ] Manual: tailwind binary still downloads correctly on a fresh build

🤖 Generated with [Claude Code](https://claude.com/claude-code)