### PR TITLE
fix(mosaic/playground): upgrade base packages in runtime image to patch CVEs

### DIFF
--- a/modules/mosaic/playground/Dockerfile
+++ b/modules/mosaic/playground/Dockerfile
@@ -46,6 +46,7 @@ RUN cargo leptos build --release -vv
 FROM debian:bookworm-slim AS runtime
 WORKDIR /app
 RUN apt-get update -y \
+  && apt-get upgrade -y --no-install-recommends \
   && apt-get install -y --no-install-recommends openssl ca-certificates \
   && apt-get autoremove -y \
   && apt-get clean -y \


### PR DESCRIPTION
## Summary

- Add `apt-get upgrade -y --no-install-recommends` to the runtime stage of `modules/mosaic/playground/Dockerfile`.
- Picks up Debian security patches at image-build time, including the `gnutls28` fix `3.7.9-2+deb12u7`.

## Why

Docker Scout on PR #231 flagged 5 high-severity CVEs in the playground image, all in `gnutls28` (libgnutls30) on the `debian:bookworm-slim` base layer:

- CVE-2026-42009 — DTLS reorder DoS
- CVE-2026-33846 — DTLS heap buffer overflow
- CVE-2026-33845 — DTLS out-of-bounds read
- CVE-2026-42011 — name constraints bypass
- CVE-2026-42010 — RSA-PSK auth bypass

All are fixed in `3.7.9-2+deb12u7`, available via Debian's security archive but not yet baked into the `bookworm-slim` tag. The DPE image is unaffected because it uses `gcr.io/distroless/static-debian12:nonroot`.

The `mosaic-docker-publish` workflow rebuilds the image on every push to `main` affecting `modules/mosaic/**`, so the next merge picks up this patch and any future Debian security patches automatically.

## Trade-offs

- Builds are no longer perfectly reproducible because `apt-get upgrade` pulls "latest" for installed packages. For a base image with system packages, timely CVE coverage is the right trade.
- Long-term, migrating the playground runtime to distroless (like DPE) would eliminate this class of finding entirely. Worth tracking separately — the playground binary is currently glibc-linked rather than static musl, so the switch is non-trivial.

## Test plan

- [ ] CI green on this PR (Scout / Mosaic Playground should show 0 high)
- [ ] Manual: confirm image still starts and serves the playground after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)