### PR TITLE
ci: skip Cloud Run preview workflows on Dependabot PRs

### DIFF
--- a/.github/workflows/cloud-run-dpe-pull-request.yml
+++ b/.github/workflows/cloud-run-dpe-pull-request.yml
@@ -26,9 +26,13 @@ jobs:
   # --------------------------------------------------------------------------
   build:
     name: Build DPE
+    # Dependabot PRs are skipped because GitHub does not pass repository secrets
+    # to workflows triggered by `dependabot[bot]`, so the downstream GCP auth
+    # in deploy-preview would fail.
     if: >-
       github.event.action != 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -125,7 +129,8 @@ jobs:
   # --------------------------------------------------------------------------
   cleanup-preview:
     name: Clean up DPE preview
-    if: github.event.action == 'closed'
+    # Dependabot PRs never deploy a preview, so there is nothing to clean up.
+    if: github.event.action == 'closed' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Authenticate to Google Cloud

--- a/.github/workflows/cloud-run-mosaic-pull-request.yml
+++ b/.github/workflows/cloud-run-mosaic-pull-request.yml
@@ -27,9 +27,12 @@ jobs:
   # --------------------------------------------------------------------------
   deploy-preview:
     name: Build and deploy preview
+    # Dependabot PRs are skipped because GitHub does not pass repository secrets
+    # to workflows triggered by `dependabot[bot]`, so GCP auth would fail.
     if: >-
       github.event.action != 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -109,7 +112,8 @@ jobs:
   # --------------------------------------------------------------------------
   cleanup-preview:
     name: Clean up preview
-    if: github.event.action == 'closed'
+    # Dependabot PRs never deploy a preview, so there is nothing to clean up.
+    if: github.event.action == 'closed' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Authenticate to Google Cloud


### PR DESCRIPTION
## Summary

- Add `github.actor != 'dependabot[bot]'` to the `if:` guards on the deploy and cleanup jobs in `cloud-run-mosaic-pull-request.yml` and `cloud-run-dpe-pull-request.yml`.
- Both preview workflows now no-op on Dependabot PRs and report success instead of failing at the GCP auth step.

## Why

The Mosaic preview workflow has been failing on every Dependabot PR (e.g. [PR #229 run 26460706413](https://github.com/dasch-swiss/dsp-repository/actions/runs/26460706413/job/77907355286?pr=229)) with:

> the GitHub Action workflow must specify exactly one of "workload_identity_provider" or "credentials_json"! …By default, secrets are not passed to workflows triggered from forks, including Dependabot.

This is expected GitHub behavior: workflows triggered by `dependabot[bot]` do not have access to Actions secrets, so the GCP Workload Identity Federation inputs resolve to empty strings and the auth action errors out.

Dependability PRs only bump dependencies; the existing `check` and `test` workflows already cover them. A live preview adds no value and just produces a red check.

The DPE preview workflow has the same structure and would fail the same way the next time Dependabot opens a PR touching `modules/dpe/**`, so the guard is added there too for consistency.

## Test plan

- [ ] CI on this PR shows the preview workflows as skipped (or not-attempted) rather than failing
- [ ] Next Dependabot PR no longer surfaces the GCP auth failure
- [ ] Regular human PRs that touch `modules/mosaic/**` or `modules/dpe/**` still deploy previews

🤖 Generated with [Claude Code](https://claude.com/claude-code)