### PR TITLE
fix(dpe-server): remove duplicated attributions and legalInfo on 0854 and 083B

### DIFF
--- a/modules/dpe/server/data/projects/083B_commode.json
+++ b/modules/dpe/server/data/projects/083B_commode.json
@@ -30,17 +30,6 @@
             "authorship": [
                 "CALCULATED"
             ]
-        },
-        {
-            "license": {
-                "licenseIdentifier": "CC BY-NC-SA 4.0",
-                "licenseDate": "2025-01-28",
-                "licenseURI": "https://creativecommons.org/licenses/by-nc-sa/4.0/"
-            },
-            "copyrightHolder": "Canonicity, Obscenity, and the Making of Modern Chaucer (COMMode): An Investigation of the Transmission and Audiences of The Canterbury Tales from 1700 to 2020",
-            "authorship": [
-                "CALCULATED"
-            ]
         }
     ],
     "dataManagementPlan": "not accessible",
@@ -100,30 +89,6 @@
         }
     ],
     "attributions": [
-        {
-            "contributor": "person-260",
-            "contributorType": [
-                "Applicant"
-            ]
-        },
-        {
-            "contributor": "person-261",
-            "contributorType": [
-                "Employee"
-            ]
-        },
-        {
-            "contributor": "person-262",
-            "contributorType": [
-                "Employee"
-            ]
-        },
-        {
-            "contributor": "person-263",
-            "contributorType": [
-                "Employee"
-            ]
-        },
         {
             "contributor": "person-260",
             "contributorType": [

--- a/modules/dpe/server/data/projects/0854_daschland.json
+++ b/modules/dpe/server/data/projects/0854_daschland.json
@@ -30,17 +30,6 @@
             "authorship": [
                 "CALCULATED"
             ]
-        },
-        {
-            "license": {
-                "licenseIdentifier": "CC BY 4.0",
-                "licenseDate": "2025-02-01",
-                "licenseURI": "https://creativecommons.org/licenses/by/4.0/"
-            },
-            "copyrightHolder": "Alice in DaSCHland",
-            "authorship": [
-                "CALCULATED"
-            ]
         }
     ],
     "dataManagementPlan": "not accessible",
@@ -147,18 +136,6 @@
         }
     ],
     "attributions": [
-        {
-            "contributor": "person-336",
-            "contributorType": [
-                "Contributor"
-            ]
-        },
-        {
-            "contributor": "person-337",
-            "contributorType": [
-                "Contributor"
-            ]
-        },
         {
             "contributor": "person-336",
             "contributorType": [


### PR DESCRIPTION
Fixes DEV-6605

## Motivation
Project `0854` (Alice in DaSCHland) showed duplicated contributors on its page. Investigation found this is a **real data-duplication bug**, not a display artifact — and it also affected `083B` (COMMode). In both projects the `legalInfo` license block was doubled too. The shared pattern traces to the v1→v2 metadata migration doubling these arrays (related to #157 / #162), not manual data entry.

## Summary
- Deduplicated `attributions` and `legalInfo` in `0854_daschland.json` and `083B_commode.json`.
- Diff is removals-only; entry order and byte-formatting preserved.

## Key Changes
### Project data
- `0854_daschland.json`: `attributions` `[336, 337, 336, 337]` → `[336, 337]`; `legalInfo` 2 identical CC BY 4.0 blocks → 1.
- `083B_commode.json`: `attributions` `[260,261,262,263]×2` → first four; `legalInfo` 2 identical CC BY-NC-SA 4.0 blocks → 1.

## Challenges and Decisions
### Distinguishing real duplicates from legitimate dual-licensing
**Problem:** A full sweep surfaced three more projects with `legalInfo` length 2 — `0840_metzger`, `0866_nietzsche-me`, `0867_nietzsche-dm`.
**Solution:** Their two `legalInfo` entries hold **different** licenses (e.g. CC BY-NC-ND + CC BY) — legitimate dual-licensing, left untouched. Only byte-identical blocks were treated as duplicates, which limited the fix to `0854` and `083B`. Persons were also checked for the same real person under two IDs (by name/email) — none found.

## Gotchas
- Do **not** "fix" `0840`, `0866`, `0867` — their two licenses are intentionally different.
- This PR fixes the data only. It does not stop recurrence on the next migration/ingest — see the follow-up issue for a proposed duplicate-detection guard in the `dpe-server validate` subcommand.

## Test Plan
- [x] `just validate-data` passes (83 projects, 413 persons, all valid).
- [x] `git diff` is removals-only (58 deletions, 0 insertions) — no reformatting.
- [x] Post-fix sweep: `0854` attributions=2/unique=2, legalInfo=1; `083B` attributions=4/unique=4, legalInfo=1; control projects unchanged.