### PR TITLE
feat(oai): add project and cluster set filters

### DIFF
--- a/modules/dpe/api-oai/src/handlers/get_record.rs
+++ b/modules/dpe/api-oai/src/handlers/get_record.rs
@@ -1,6 +1,6 @@
 //! Handler for the OAI-PMH GetRecord verb.
 
-use dpe_core::{Project, ProjectRepository, Record, RecordRepository};
+use dpe_core::{ClusterRaw, Project, ProjectRepository, Record, RecordRepository};
 
 use super::{build_error_response, OaiParams, SUPPORTED_PREFIXES};
 use crate::error::OaiError;
@@ -12,12 +12,13 @@ pub fn handle_get_record(
     params: &OaiParams,
     repo: &dyn ProjectRepository,
     record_repo: &dyn RecordRepository,
+    clusters: &[ClusterRaw],
 ) -> String {
     let result = require_identifier(params)
         .and_then(|id| require_metadata_prefix(params).map(|prefix| (id, prefix)))
         .and_then(|(id, prefix)| reject_unexpected_args(params).map(|_| (id, prefix)))
         .and_then(|(id, prefix)| resolve_entity(id, repo, record_repo).map(|oai| (id, prefix, oai)))
-        .map(|(id, prefix, oai)| build_response(id, prefix, oai));
+        .map(|(id, prefix, oai)| build_response(id, prefix, oai, clusters));
 
     result.unwrap_or_else(|err| build_error_response(err, Some("GetRecord")))
 }
@@ -74,10 +75,10 @@ fn resolve_entity(
     Err(OaiError::IdDoesNotExist)
 }
 
-fn build_response(identifier: &str, prefix: &str, entity: OaiEntity) -> String {
+fn build_response(identifier: &str, prefix: &str, entity: OaiEntity, clusters: &[ClusterRaw]) -> String {
     let oai_record: OaiRecord = match entity {
-        OaiEntity::Project(ref project) => to_oai_record(project, prefix),
-        OaiEntity::Record(ref record) => to_oai_record_from_record(record, prefix),
+        OaiEntity::Project(ref project) => to_oai_record(project, prefix, clusters),
+        OaiEntity::Record(ref record) => to_oai_record_from_record(record, prefix, clusters),
     };
 
     let mut builder = OaiXmlBuilder::new();
@@ -128,7 +129,7 @@ mod tests {
     #[test]
     fn missing_identifier_returns_bad_argument() {
         let params = make_params(None, Some("oai_dc"));
-        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty());
+        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty(), &[]);
         assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
         assert!(xml.contains("identifier argument is required"), "got: {}", xml);
         assert!(
@@ -141,7 +142,7 @@ mod tests {
     #[test]
     fn missing_metadata_prefix_returns_bad_argument() {
         let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), None);
-        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty());
+        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty(), &[]);
         assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
         assert!(xml.contains("metadataPrefix argument is required"), "got: {}", xml);
     }
@@ -149,14 +150,14 @@ mod tests {
     #[test]
     fn unsupported_metadata_prefix_returns_cannot_disseminate() {
         let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), Some("marc21"));
-        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty());
+        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty(), &[]);
         assert!(xml.contains("<error code=\"cannotDisseminateFormat\">"), "got: {}", xml);
     }
 
     #[test]
     fn unknown_id_not_in_either_repo_returns_id_does_not_exist() {
         let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/9999"), Some("oai_dc"));
-        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty());
+        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty(), &[]);
         assert!(xml.contains("<error code=\"idDoesNotExist\">"), "got: {}", xml);
     }
 
@@ -164,7 +165,7 @@ mod tests {
     fn unexpected_argument_returns_bad_argument() {
         let mut params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), Some("oai_dc"));
         params.set = Some("entityType:ResearchProject".to_string());
-        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty());
+        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty(), &[]);
         assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
     }
 
@@ -173,7 +174,7 @@ mod tests {
     #[test]
     fn golden_oai_dc_response() {
         let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), Some("oai_dc"));
-        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty());
+        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty(), &[]);
         let expected = golden("get_record_oai_dc.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -181,7 +182,7 @@ mod tests {
     #[test]
     fn golden_oai_datacite_response() {
         let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), Some("oai_datacite"));
-        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty());
+        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty(), &[]);
         let expected = golden("get_record_oai_datacite.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -194,7 +195,7 @@ mod tests {
             Some("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             Some("oai_dc"),
         );
-        let xml = handle_get_record(&params, &InMemoryProjectRepository::new(vec![]), &repo_with_record());
+        let xml = handle_get_record(&params, &InMemoryProjectRepository::new(vec![]), &repo_with_record(), &[]);
         let expected = golden("get_record_record_oai_dc.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -205,7 +206,7 @@ mod tests {
             Some("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             Some("oai_datacite"),
         );
-        let xml = handle_get_record(&params, &InMemoryProjectRepository::new(vec![]), &repo_with_record());
+        let xml = handle_get_record(&params, &InMemoryProjectRepository::new(vec![]), &repo_with_record(), &[]);
         let expected = golden("get_record_record_oai_datacite.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -215,14 +216,14 @@ mod tests {
     #[test]
     fn get_record_oai_dc_response_is_valid_oai_pmh() {
         let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), Some("oai_dc"));
-        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty());
+        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty(), &[]);
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 
     #[test]
     fn get_record_oai_datacite_response_is_valid_oai_pmh() {
         let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), Some("oai_datacite"));
-        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty());
+        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty(), &[]);
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 
@@ -232,7 +233,7 @@ mod tests {
             Some("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             Some("oai_dc"),
         );
-        let xml = handle_get_record(&params, &InMemoryProjectRepository::new(vec![]), &repo_with_record());
+        let xml = handle_get_record(&params, &InMemoryProjectRepository::new(vec![]), &repo_with_record(), &[]);
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 
@@ -242,7 +243,7 @@ mod tests {
             Some("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             Some("oai_datacite"),
         );
-        let xml = handle_get_record(&params, &InMemoryProjectRepository::new(vec![]), &repo_with_record());
+        let xml = handle_get_record(&params, &InMemoryProjectRepository::new(vec![]), &repo_with_record(), &[]);
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 }

--- a/modules/dpe/api-oai/src/handlers/list_identifiers.rs
+++ b/modules/dpe/api-oai/src/handlers/list_identifiers.rs
@@ -1,6 +1,6 @@
 //! Handler for the OAI-PMH ListIdentifiers verb.
 
-use dpe_core::{ProjectRepository, RecordRepository};
+use dpe_core::{ClusterRaw, ProjectRepository, RecordRepository};
 
 use super::{build_error_response, build_list_request_params, validate_list_params, OaiParams};
 use crate::xml::OaiXmlBuilder;
@@ -10,8 +10,9 @@ pub fn handle_list_identifiers(
     params: &OaiParams,
     repo: &dyn ProjectRepository,
     record_repo: &dyn RecordRepository,
+    clusters: &[ClusterRaw],
 ) -> String {
-    let (prefix, records) = match validate_list_params(params, repo, record_repo) {
+    let (prefix, records) = match validate_list_params(params, repo, record_repo, clusters) {
         Ok(result) => result,
         Err(err) => return build_error_response(err, Some("ListIdentifiers")),
     };
@@ -33,7 +34,8 @@ pub fn handle_list_identifiers(
 #[cfg(test)]
 mod tests {
     use super::super::test_utils::{
-        first_0803_record, golden, incunabula_project, normalize, InMemoryProjectRepository, InMemoryRecordRepository,
+        cluster_fixture, first_0803_record, golden, incunabula_project, normalize, InMemoryProjectRepository,
+        InMemoryRecordRepository,
     };
     use super::*;
 
@@ -55,7 +57,7 @@ mod tests {
     fn missing_metadata_prefix_returns_bad_argument() {
         let params = make_params(None);
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty());
+        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
         assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
         assert!(xml.contains("metadataPrefix argument is required"), "got: {}", xml);
     }
@@ -64,7 +66,7 @@ mod tests {
     fn unsupported_metadata_prefix_returns_cannot_disseminate() {
         let params = make_params(Some("marc21"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty());
+        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
         assert!(xml.contains("<error code=\"cannotDisseminateFormat\">"), "got: {}", xml);
     }
 
@@ -73,26 +75,67 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.resumption_token = Some("some-token".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty());
+        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
         assert!(xml.contains("<error code=\"badResumptionToken\">"), "got: {}", xml);
     }
 
     #[test]
-    fn unknown_set_returns_no_records_match() {
+    fn unknown_set_returns_bad_argument() {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("entityType:Unknown".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty());
+        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
+    }
+
+    #[test]
+    fn empty_project_cluster_set_returns_no_records_match() {
+        let mut params = make_params(Some("oai_dc"));
+        params.set = Some("entityType:ProjectCluster".to_string());
+        let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
+        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
         assert!(xml.contains("<error code=\"noRecordsMatch\">"), "got: {}", xml);
     }
 
     #[test]
-    fn cluster_set_with_no_clusters_returns_no_records_match() {
+    fn project_set_returns_only_record_identifiers() {
+        // ListIdentifiers honours project: sets identically to ListRecords (REQ-1.2).
         let mut params = make_params(Some("oai_dc"));
-        params.set = Some("entityType:ProjectCluster".to_string());
+        params.set = Some("project:0803".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty());
-        assert!(xml.contains("<error code=\"noRecordsMatch\">"), "got: {}", xml);
+        let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
+        let xml = handle_list_identifiers(&params, &repo, &record_repo, &[]);
+        assert!(
+            xml.contains("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
+            "record identifier should be present, got: {}",
+            xml
+        );
+        assert!(
+            !xml.contains("<identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>"),
+            "project entry should be absent (records only), got: {}",
+            xml
+        );
+    }
+
+    #[test]
+    fn cluster_set_returns_project_and_record_identifiers() {
+        // ListIdentifiers honours cluster: sets identically to ListRecords (REQ-2.3).
+        let mut params = make_params(Some("oai_dc"));
+        params.set = Some("cluster:cluster-001".to_string());
+        let clusters = vec![cluster_fixture("cluster-001", "EKWS", &["0803"])];
+        let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
+        let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
+        let xml = handle_list_identifiers(&params, &repo, &record_repo, &clusters);
+        assert!(
+            xml.contains("<identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>"),
+            "project entry should be present, got: {}",
+            xml
+        );
+        assert!(
+            xml.contains("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
+            "member record should be present, got: {}",
+            xml
+        );
     }
 
     #[test]
@@ -100,7 +143,7 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("entityType:Record".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty());
+        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
         assert!(xml.contains("<error code=\"noRecordsMatch\">"), "got: {}", xml);
     }
 
@@ -110,7 +153,7 @@ mod tests {
         params.set = Some("entityType:Record".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_identifiers(&params, &repo, &record_repo);
+        let xml = handle_list_identifiers(&params, &repo, &record_repo, &[]);
         assert!(
             xml.contains("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             "record identifier should be present, got: {}",
@@ -130,7 +173,7 @@ mod tests {
     fn golden_oai_dc_response() {
         let params = make_params(Some("oai_dc"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty());
+        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
         let expected = golden("list_identifiers_oai_dc.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -139,7 +182,7 @@ mod tests {
     fn golden_oai_datacite_response() {
         let params = make_params(Some("oai_datacite"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty());
+        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
         let expected = golden("list_identifiers_oai_datacite.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -149,7 +192,7 @@ mod tests {
         let params = make_params(Some("oai_dc"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_identifiers(&params, &repo, &record_repo);
+        let xml = handle_list_identifiers(&params, &repo, &record_repo, &[]);
         let expected = golden("list_identifiers_mixed_oai_dc.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -159,7 +202,7 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("entityType:Record".to_string());
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_identifiers(&params, &InMemoryProjectRepository::new(vec![]), &record_repo);
+        let xml = handle_list_identifiers(&params, &InMemoryProjectRepository::new(vec![]), &record_repo, &[]);
         let expected = golden("list_identifiers_record_only_oai_dc.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -170,7 +213,7 @@ mod tests {
     fn list_identifiers_oai_dc_response_is_valid_oai_pmh() {
         let params = make_params(Some("oai_dc"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty());
+        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 
@@ -178,7 +221,7 @@ mod tests {
     fn list_identifiers_oai_datacite_response_is_valid_oai_pmh() {
         let params = make_params(Some("oai_datacite"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty());
+        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 
@@ -187,7 +230,7 @@ mod tests {
         let params = make_params(Some("oai_dc"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_identifiers(&params, &repo, &record_repo);
+        let xml = handle_list_identifiers(&params, &repo, &record_repo, &[]);
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 
@@ -196,7 +239,7 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("entityType:Record".to_string());
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_identifiers(&params, &InMemoryProjectRepository::new(vec![]), &record_repo);
+        let xml = handle_list_identifiers(&params, &InMemoryProjectRepository::new(vec![]), &record_repo, &[]);
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 }

--- a/modules/dpe/api-oai/src/handlers/list_records.rs
+++ b/modules/dpe/api-oai/src/handlers/list_records.rs
@@ -1,6 +1,6 @@
 //! Handler for the OAI-PMH ListRecords verb.
 
-use dpe_core::{ProjectRepository, RecordRepository};
+use dpe_core::{ClusterRaw, ProjectRepository, RecordRepository};
 
 use super::{build_error_response, build_list_request_params, validate_list_params, OaiParams};
 use crate::xml::OaiXmlBuilder;
@@ -10,8 +10,9 @@ pub fn handle_list_records(
     params: &OaiParams,
     repo: &dyn ProjectRepository,
     record_repo: &dyn RecordRepository,
+    clusters: &[ClusterRaw],
 ) -> String {
-    let (prefix, records) = match validate_list_params(params, repo, record_repo) {
+    let (prefix, records) = match validate_list_params(params, repo, record_repo, clusters) {
         Ok(result) => result,
         Err(err) => return build_error_response(err, Some("ListRecords")),
     };
@@ -33,7 +34,8 @@ pub fn handle_list_records(
 #[cfg(test)]
 mod tests {
     use super::super::test_utils::{
-        first_0803_record, golden, incunabula_project, normalize, InMemoryProjectRepository, InMemoryRecordRepository,
+        cluster_fixture, first_0803_record, golden, incunabula_project, normalize, InMemoryProjectRepository,
+        InMemoryRecordRepository,
     };
     use super::*;
 
@@ -55,7 +57,7 @@ mod tests {
     fn missing_metadata_prefix_returns_bad_argument() {
         let params = make_params(None);
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty());
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
         assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
         assert!(xml.contains("metadataPrefix argument is required"), "got: {}", xml);
     }
@@ -64,7 +66,7 @@ mod tests {
     fn unsupported_metadata_prefix_returns_cannot_disseminate() {
         let params = make_params(Some("marc21"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty());
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
         assert!(xml.contains("<error code=\"cannotDisseminateFormat\">"), "got: {}", xml);
     }
 
@@ -73,25 +75,77 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.resumption_token = Some("some-token".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty());
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
         assert!(xml.contains("<error code=\"badResumptionToken\">"), "got: {}", xml);
     }
 
     #[test]
-    fn unknown_set_returns_no_records_match() {
+    fn unknown_set_returns_bad_argument() {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("entityType:Unknown".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty());
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
+    }
+
+    #[test]
+    fn empty_project_cluster_set_returns_no_records_match() {
+        // entityType:ProjectCluster is a known set that selects nothing today.
+        let mut params = make_params(Some("oai_dc"));
+        params.set = Some("entityType:ProjectCluster".to_string());
+        let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
         assert!(xml.contains("<error code=\"noRecordsMatch\">"), "got: {}", xml);
     }
 
     #[test]
-    fn cluster_set_with_no_clusters_returns_no_records_match() {
+    fn unknown_project_set_returns_bad_argument() {
         let mut params = make_params(Some("oai_dc"));
-        params.set = Some("entityType:ProjectCluster".to_string());
+        params.set = Some("project:9999".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty());
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
+    }
+
+    #[test]
+    fn unknown_cluster_set_returns_bad_argument() {
+        let mut params = make_params(Some("oai_dc"));
+        params.set = Some("cluster:cluster-999".to_string());
+        let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
+    }
+
+    #[test]
+    fn project_set_returns_only_that_projects_records() {
+        let mut params = make_params(Some("oai_dc"));
+        params.set = Some("project:0803".to_string());
+        let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
+        let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
+        let xml = handle_list_records(&params, &repo, &record_repo, &[]);
+        assert!(
+            xml.contains("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
+            "record identifier should be present, got: {}",
+            xml
+        );
+        assert!(
+            !xml.contains("oai:meta.dasch.swiss:ark:/72163/1/0803\""),
+            "project entry should be absent (records only), got: {}",
+            xml
+        );
+        assert!(
+            xml.contains("project:0803"),
+            "record header should carry project setSpec, got: {}",
+            xml
+        );
+    }
+
+    #[test]
+    fn project_set_real_project_no_records_returns_no_records_match() {
+        let mut params = make_params(Some("oai_dc"));
+        params.set = Some("project:0803".to_string());
+        let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
         assert!(xml.contains("<error code=\"noRecordsMatch\">"), "got: {}", xml);
     }
 
@@ -100,7 +154,7 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("entityType:Record".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty());
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
         assert!(xml.contains("<error code=\"noRecordsMatch\">"), "got: {}", xml);
     }
 
@@ -110,7 +164,7 @@ mod tests {
         params.set = Some("entityType:Record".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_records(&params, &repo, &record_repo);
+        let xml = handle_list_records(&params, &repo, &record_repo, &[]);
         assert!(
             xml.contains("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             "record identifier should be present, got: {}",
@@ -124,13 +178,70 @@ mod tests {
         assert!(xml.contains("entityType:Record"), "set spec should be Record, got: {}", xml);
     }
 
+    // ---- cluster set tests ----
+
+    #[test]
+    fn cluster_set_returns_project_entries_and_records() {
+        let mut params = make_params(Some("oai_dc"));
+        params.set = Some("cluster:cluster-001".to_string());
+        let clusters = vec![cluster_fixture("cluster-001", "EKWS", &["0803"])];
+        let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
+        let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
+        let xml = handle_list_records(&params, &repo, &record_repo, &clusters);
+        // project entry present (identifier closes with </identifier>)
+        assert!(
+            xml.contains("<identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>"),
+            "project entry should be present, got: {}",
+            xml
+        );
+        // record present
+        assert!(
+            xml.contains("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
+            "member record should be present, got: {}",
+            xml
+        );
+        assert!(
+            xml.contains("cluster:cluster-001"),
+            "headers should carry cluster setSpec, got: {}",
+            xml
+        );
+    }
+
+    #[test]
+    fn cluster_set_recordless_projects_still_returns_project_entries() {
+        // A known cluster whose member project exists but has no records is a
+        // success: the project entry is returned (asymmetry with project: sets).
+        let mut params = make_params(Some("oai_dc"));
+        params.set = Some("cluster:cluster-001".to_string());
+        let clusters = vec![cluster_fixture("cluster-001", "EKWS", &["0803"])];
+        let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &clusters);
+        assert!(
+            xml.contains("<identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>"),
+            "project entry should be present even with no records, got: {}",
+            xml
+        );
+        assert!(!xml.contains("<error"), "should be a success, got: {}", xml);
+    }
+
+    #[test]
+    fn cluster_set_no_matching_projects_returns_no_records_match() {
+        // Cluster exists but its listed shortcodes match no real project.
+        let mut params = make_params(Some("oai_dc"));
+        params.set = Some("cluster:cluster-001".to_string());
+        let clusters = vec![cluster_fixture("cluster-001", "EKWS", &["9999"])];
+        let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &clusters);
+        assert!(xml.contains("<error code=\"noRecordsMatch\">"), "got: {}", xml);
+    }
+
     // ---- golden tests ----
 
     #[test]
     fn golden_oai_dc_response() {
         let params = make_params(Some("oai_dc"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty());
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
         let expected = golden("list_records_oai_dc.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -139,7 +250,7 @@ mod tests {
     fn golden_oai_datacite_response() {
         let params = make_params(Some("oai_datacite"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty());
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
         let expected = golden("list_records_oai_datacite.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -149,7 +260,7 @@ mod tests {
         let params = make_params(Some("oai_dc"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_records(&params, &repo, &record_repo);
+        let xml = handle_list_records(&params, &repo, &record_repo, &[]);
         let expected = golden("list_records_mixed_oai_dc.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -159,7 +270,7 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("entityType:Record".to_string());
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_records(&params, &InMemoryProjectRepository::new(vec![]), &record_repo);
+        let xml = handle_list_records(&params, &InMemoryProjectRepository::new(vec![]), &record_repo, &[]);
         let expected = golden("list_records_record_only_oai_dc.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -170,7 +281,7 @@ mod tests {
     fn list_records_oai_dc_response_is_valid_oai_pmh() {
         let params = make_params(Some("oai_dc"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty());
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 
@@ -178,7 +289,7 @@ mod tests {
     fn list_records_oai_datacite_response_is_valid_oai_pmh() {
         let params = make_params(Some("oai_datacite"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty());
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 
@@ -187,7 +298,7 @@ mod tests {
         let params = make_params(Some("oai_dc"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_records(&params, &repo, &record_repo);
+        let xml = handle_list_records(&params, &repo, &record_repo, &[]);
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 
@@ -196,7 +307,7 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("entityType:Record".to_string());
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_records(&params, &InMemoryProjectRepository::new(vec![]), &record_repo);
+        let xml = handle_list_records(&params, &InMemoryProjectRepository::new(vec![]), &record_repo, &[]);
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 }

--- a/modules/dpe/api-oai/src/handlers/list_sets.rs
+++ b/modules/dpe/api-oai/src/handlers/list_sets.rs
@@ -1,11 +1,16 @@
 //! Handler for the OAI-PMH ListSets verb.
 
+use dpe_core::{ClusterRaw, ProjectRepository};
+
 use super::{build_error_response, OaiParams};
 use crate::error::OaiError;
 use crate::xml::OaiXmlBuilder;
 
 /// Handles the ListSets verb.
-pub fn handle_list_sets(params: &OaiParams) -> String {
+///
+/// Advertises the static `entityType:*` sets plus a dynamic `project:{shortcode}`
+/// set per known project and a `cluster:{id}` set per cluster.
+pub fn handle_list_sets(params: &OaiParams, repo: &dyn ProjectRepository, clusters: &[ClusterRaw]) -> String {
     // ListSets accepts only resumptionToken
     if params.identifier.is_some()
         || params.metadata_prefix.is_some()
@@ -23,15 +28,27 @@ pub fn handle_list_sets(params: &OaiParams) -> String {
         return build_error_response(OaiError::BadResumptionToken, Some("ListSets"));
     }
 
+    // Dynamic project sets: (setSpec, setName) = (project:{shortcode}, project name).
+    let project_sets: Vec<(String, String)> = repo
+        .get_all()
+        .iter()
+        .map(|p| (format!("project:{}", p.shortcode), p.name.clone()))
+        .collect();
+
+    // Dynamic cluster sets: (setSpec, setName) = (cluster:{id}, cluster name).
+    let cluster_sets: Vec<(String, String)> =
+        clusters.iter().map(|c| (format!("cluster:{}", c.id), c.name.clone())).collect();
+
     let mut builder = OaiXmlBuilder::new();
     builder.write_request("ListSets", &[]);
-    builder.write_list_sets();
+    builder.write_list_sets(&project_sets, &cluster_sets);
 
     builder.finish()
 }
 
 #[cfg(test)]
 mod tests {
+    use super::super::test_utils::{cluster_fixture, golden, incunabula_project, normalize, InMemoryProjectRepository};
     use super::*;
 
     fn make_params() -> OaiParams {
@@ -46,7 +63,13 @@ mod tests {
         }
     }
 
-    use super::super::test_utils::{golden, normalize};
+    fn repo() -> InMemoryProjectRepository {
+        InMemoryProjectRepository::new(vec![incunabula_project()])
+    }
+
+    fn clusters() -> Vec<ClusterRaw> {
+        vec![cluster_fixture("cluster-001", "EKWS", &["0803"])]
+    }
 
     // ---- error cases ----
 
@@ -54,7 +77,7 @@ mod tests {
     fn unexpected_argument_returns_bad_argument() {
         let mut params = make_params();
         params.from = Some("2020-01-01".to_string());
-        let xml = handle_list_sets(&params);
+        let xml = handle_list_sets(&params, &repo(), &clusters());
         assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
         assert!(xml.contains("Unexpected argument for ListSets"), "got: {}", xml);
     }
@@ -63,8 +86,39 @@ mod tests {
     fn resumption_token_returns_bad_resumption_token() {
         let mut params = make_params();
         params.resumption_token = Some("some-token".to_string());
-        let xml = handle_list_sets(&params);
+        let xml = handle_list_sets(&params, &repo(), &clusters());
         assert!(xml.contains("<error code=\"badResumptionToken\">"), "got: {}", xml);
+    }
+
+    // ---- dynamic set content ----
+
+    #[test]
+    fn advertises_static_project_and_cluster_sets() {
+        let params = make_params();
+        let xml = handle_list_sets(&params, &repo(), &clusters());
+        // static sets remain
+        assert!(xml.contains("entityType:ProjectCluster"), "got: {}", xml);
+        assert!(xml.contains("entityType:ResearchProject"), "got: {}", xml);
+        // dynamic project set with the project name as setName
+        assert!(xml.contains("<setSpec>project:0803</setSpec>"), "got: {}", xml);
+        // dynamic cluster set with the cluster name as setName
+        assert!(xml.contains("<setSpec>cluster:cluster-001</setSpec>"), "got: {}", xml);
+        assert!(
+            xml.contains("<setName>EKWS</setName>"),
+            "cluster setName should be the name, got: {}",
+            xml
+        );
+    }
+
+    #[test]
+    fn is_never_empty_with_no_projects_or_clusters() {
+        let params = make_params();
+        let xml = handle_list_sets(&params, &InMemoryProjectRepository::new(vec![]), &[]);
+        assert!(
+            xml.contains("entityType:ResearchProject"),
+            "static sets always present, got: {}",
+            xml
+        );
     }
 
     // ---- golden tests ----
@@ -72,7 +126,7 @@ mod tests {
     #[test]
     fn golden_list_sets_response() {
         let params = make_params();
-        let xml = handle_list_sets(&params);
+        let xml = handle_list_sets(&params, &repo(), &clusters());
         let expected = golden("list_sets.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -82,7 +136,7 @@ mod tests {
     #[test]
     fn list_sets_response_is_valid_oai_pmh() {
         let params = make_params();
-        let xml = handle_list_sets(&params);
+        let xml = handle_list_sets(&params, &repo(), &clusters());
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 }

--- a/modules/dpe/api-oai/src/handlers/mod.rs
+++ b/modules/dpe/api-oai/src/handlers/mod.rs
@@ -18,7 +18,9 @@ mod list_sets;
 use axum::extract::Query;
 use axum::http::{header, StatusCode};
 use axum::response::IntoResponse;
-use dpe_core::{FsProjectRepository, FsRecordRepository, ProjectRepository, RecordRepository};
+use dpe_core::{
+    cluster_cache, ClusterRaw, FsProjectRepository, FsRecordRepository, ProjectRepository, RecordRepository,
+};
 use get_record::handle_get_record;
 use identify::handle_identify;
 use list_identifiers::handle_list_identifiers;
@@ -54,14 +56,15 @@ pub const SUPPORTED_PREFIXES: [&str; 2] = ["oai_dc", "oai_datacite"];
 pub async fn oai_handler(Query(params): Query<OaiParams>) -> impl IntoResponse {
     let repo = FsProjectRepository::new();
     let record_repo = FsRecordRepository::new();
+    let clusters = cluster_cache::all_clusters();
 
     let xml = match params.verb.as_deref() {
         Some("Identify") => handle_identify(&params, &repo),
         Some("ListMetadataFormats") => handle_list_metadata_formats(&params, &repo),
-        Some("ListSets") => handle_list_sets(&params),
-        Some("ListIdentifiers") => handle_list_identifiers(&params, &repo, &record_repo),
-        Some("ListRecords") => handle_list_records(&params, &repo, &record_repo),
-        Some("GetRecord") => handle_get_record(&params, &repo, &record_repo),
+        Some("ListSets") => handle_list_sets(&params, &repo, clusters),
+        Some("ListIdentifiers") => handle_list_identifiers(&params, &repo, &record_repo, clusters),
+        Some("ListRecords") => handle_list_records(&params, &repo, &record_repo, clusters),
+        Some("GetRecord") => handle_get_record(&params, &repo, &record_repo, clusters),
         Some(_) => build_error_response(OaiError::BadVerb, None),
         None => build_error_response(OaiError::BadVerb, None),
     };
@@ -81,14 +84,50 @@ pub fn build_error_response(error: OaiError, verb: Option<&str>) -> String {
     builder.finish()
 }
 
-/// Parses the set filter and returns (include_clusters, include_projects, include_records).
-pub fn parse_set_filter(set: Option<&str>) -> (bool, bool, bool) {
+/// The syntactic meaning of a `set` argument, resolved purely from the string —
+/// no repository or cluster-cache access. Existence of a named project/cluster is
+/// validated later, in `validate_list_params`.
+#[derive(Debug, PartialEq)]
+pub enum SetSyntax {
+    /// No `set` argument — include everything.
+    All,
+    /// An `entityType:*` set, expanded to which entity kinds it selects.
+    EntityType { clusters: bool, projects: bool, records: bool },
+    /// `project:{shortcode}` — the records of one research project.
+    Project(String),
+    /// `cluster:{id}` — the project entries of a cluster plus all their records.
+    Cluster(String),
+}
+
+/// Parses the syntactic meaning of a `set` argument.
+///
+/// Returns `Err(OaiError::BadArgument)` for an unrecognised prefix or an empty
+/// `project:`/`cluster:` value. Whether a named project/cluster actually exists
+/// is checked separately (repository/cache access required).
+pub fn parse_set_syntax(set: Option<&str>) -> Result<SetSyntax, OaiError> {
+    let Some(set) = set else {
+        return Ok(SetSyntax::All);
+    };
+
     match set {
-        Some("entityType:ProjectCluster") => (true, false, false),
-        Some("entityType:ResearchProject") => (false, true, false),
-        Some("entityType:Record") => (false, false, true),
-        None => (true, true, true),
-        Some(_) => (false, false, false), // Unknown set
+        "entityType:ProjectCluster" => Ok(SetSyntax::EntityType { clusters: true, projects: false, records: false }),
+        "entityType:ResearchProject" => Ok(SetSyntax::EntityType { clusters: false, projects: true, records: false }),
+        "entityType:Record" => Ok(SetSyntax::EntityType { clusters: false, projects: false, records: true }),
+        _ => {
+            if let Some(shortcode) = set.strip_prefix("project:") {
+                if shortcode.is_empty() {
+                    return Err(OaiError::BadArgument("set argument has an empty project shortcode".to_string()));
+                }
+                Ok(SetSyntax::Project(shortcode.to_string()))
+            } else if let Some(id) = set.strip_prefix("cluster:") {
+                if id.is_empty() {
+                    return Err(OaiError::BadArgument("set argument has an empty cluster id".to_string()));
+                }
+                Ok(SetSyntax::Cluster(id.to_string()))
+            } else {
+                Err(OaiError::BadArgument(format!("unsupported set: {set}")))
+            }
+        }
     }
 }
 
@@ -100,8 +139,10 @@ pub fn validate_list_params<'a>(
     params: &'a OaiParams,
     repo: &dyn ProjectRepository,
     record_repo: &dyn RecordRepository,
+    clusters: &[ClusterRaw],
 ) -> Result<(&'a str, Vec<OaiRecord>), OaiError> {
-    // metadataPrefix is required
+    // metadataPrefix is required. Validated BEFORE the set, so a request that is
+    // missing/invalid in both reports the prefix error (precedence preserved).
     let prefix = params
         .metadata_prefix
         .as_deref()
@@ -122,42 +163,151 @@ pub fn validate_list_params<'a>(
         return Err(OaiError::BadResumptionToken);
     }
 
-    // Parse set filter
-    let (include_clusters, include_projects, include_records) = parse_set_filter(params.set.as_deref());
-    if !include_clusters && !include_projects && !include_records {
-        return Err(OaiError::NoRecordsMatch);
-    }
+    // Syntactic parse — an unsupported set or empty value is a badArgument.
+    let syntax = parse_set_syntax(params.set.as_deref())?;
 
     let from = params.from.as_deref();
     let until = params.until.as_deref();
 
-    // Collect project OAI records (clusters not yet implemented)
-    let mut oai_records: Vec<OaiRecord> = if include_projects {
-        repo.get_all()
-            .iter()
-            .filter(|p| matches_date_filter(p, from, until))
-            .map(|p| to_oai_record(p, prefix))
-            .collect()
-    } else {
-        Vec::new()
+    let oai_records = match syntax {
+        SetSyntax::All => collect_entities(repo, record_repo, prefix, clusters, from, until, true, true),
+        SetSyntax::EntityType {
+            projects: include_projects,
+            records: include_records,
+            // `entityType:ProjectCluster` selects nothing today (clusters are not
+            // emitted as first-class OAI items), so its records list is empty.
+            clusters: _,
+        } => collect_entities(
+            repo,
+            record_repo,
+            prefix,
+            clusters,
+            from,
+            until,
+            include_projects,
+            include_records,
+        ),
+        SetSyntax::Project(shortcode) => {
+            // Existence check: an unknown project shortcode is a badArgument.
+            if repo.get_by_shortcode(&shortcode).is_none() {
+                return Err(OaiError::BadArgument(format!("unknown project set: project:{shortcode}")));
+            }
+            // Records of this project only — no project entry (REQ-1.3).
+            record_repo
+                .get_all()
+                .iter()
+                .filter(|r| r.pid.shortcode.eq_ignore_ascii_case(&shortcode))
+                .filter(|r| matches_date_filter_record(r, from, until))
+                .map(|r| to_oai_record_from_record(r, prefix, clusters))
+                .collect()
+        }
+        SetSyntax::Cluster(id) => {
+            // Existence check: an unknown cluster id is a badArgument.
+            let Some(member_shortcodes) = cluster_cache::projects_for_cluster_in(clusters, &id) else {
+                return Err(OaiError::BadArgument(format!("unknown cluster set: cluster:{id}")));
+            };
+            collect_cluster(repo, record_repo, prefix, clusters, from, until, member_shortcodes)
+        }
     };
-
-    // Collect record OAI records
-    if include_records {
-        let mut record_oai: Vec<OaiRecord> = record_repo
-            .get_all()
-            .iter()
-            .filter(|r| matches_date_filter_record(r, from, until))
-            .map(|r| to_oai_record_from_record(r, prefix))
-            .collect();
-        oai_records.append(&mut record_oai);
-    }
 
     if oai_records.is_empty() {
         return Err(OaiError::NoRecordsMatch);
     }
 
     Ok((prefix, oai_records))
+}
+
+/// Collects project and/or record OAI items for the entity-type and `All` cases.
+#[allow(clippy::too_many_arguments)]
+fn collect_entities(
+    repo: &dyn ProjectRepository,
+    record_repo: &dyn RecordRepository,
+    prefix: &str,
+    clusters: &[ClusterRaw],
+    from: Option<&str>,
+    until: Option<&str>,
+    include_projects: bool,
+    include_records: bool,
+) -> Vec<OaiRecord> {
+    let mut oai_records: Vec<OaiRecord> = if include_projects {
+        repo.get_all()
+            .iter()
+            .filter(|p| matches_date_filter(p, from, until))
+            .map(|p| to_oai_record(p, prefix, clusters))
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    if include_records {
+        let mut record_oai: Vec<OaiRecord> = record_repo
+            .get_all()
+            .iter()
+            .filter(|r| matches_date_filter_record(r, from, until))
+            .map(|r| to_oai_record_from_record(r, prefix, clusters))
+            .collect();
+        oai_records.append(&mut record_oai);
+    }
+
+    oai_records
+}
+
+/// Collects all entities under a cluster: the project entries whose shortcode is a
+/// cluster member (and which exist in the repository) plus all their records.
+/// Project entries are deduplicated by shortcode and records by ARK suffix, so a
+/// shortcode listed more than once does not produce duplicate items (REQ-2.5).
+fn collect_cluster(
+    repo: &dyn ProjectRepository,
+    record_repo: &dyn RecordRepository,
+    prefix: &str,
+    clusters: &[ClusterRaw],
+    from: Option<&str>,
+    until: Option<&str>,
+    member_shortcodes: &[String],
+) -> Vec<OaiRecord> {
+    let is_member = |shortcode: &str| member_shortcodes.iter().any(|m| m.eq_ignore_ascii_case(shortcode));
+
+    // Project entries: members that actually exist in the repository, deduplicated
+    // by shortcode (case-insensitive).
+    let mut seen_projects: Vec<String> = Vec::new();
+    let mut oai_records: Vec<OaiRecord> = repo
+        .get_all()
+        .iter()
+        .filter(|p| is_member(&p.shortcode))
+        .filter(|p| matches_date_filter(p, from, until))
+        .filter(|p| {
+            let key = p.shortcode.to_ascii_lowercase();
+            if seen_projects.contains(&key) {
+                false
+            } else {
+                seen_projects.push(key);
+                true
+            }
+        })
+        .map(|p| to_oai_record(p, prefix, clusters))
+        .collect();
+
+    // Records of member projects, deduplicated by ARK suffix.
+    let mut seen_records: Vec<String> = Vec::new();
+    let mut record_oai: Vec<OaiRecord> = record_repo
+        .get_all()
+        .iter()
+        .filter(|r| is_member(&r.pid.shortcode))
+        .filter(|r| matches_date_filter_record(r, from, until))
+        .filter(|r| {
+            let key = r.pid.ark_suffix();
+            if seen_records.contains(&key) {
+                false
+            } else {
+                seen_records.push(key);
+                true
+            }
+        })
+        .map(|r| to_oai_record_from_record(r, prefix, clusters))
+        .collect();
+    oai_records.append(&mut record_oai);
+
+    oai_records
 }
 
 /// Builds the request parameter list shared by list verb XML responses.
@@ -180,16 +330,47 @@ pub mod test_utils;
 
 #[cfg(test)]
 mod tests {
-    use super::{build_error_response, parse_set_filter};
+    use super::{build_error_response, parse_set_syntax, SetSyntax};
     use crate::error::OaiError;
 
     #[test]
-    fn test_parse_set_filter() {
-        assert_eq!(parse_set_filter(None), (true, true, true));
-        assert_eq!(parse_set_filter(Some("entityType:ProjectCluster")), (true, false, false));
-        assert_eq!(parse_set_filter(Some("entityType:ResearchProject")), (false, true, false));
-        assert_eq!(parse_set_filter(Some("entityType:Record")), (false, false, true));
-        assert_eq!(parse_set_filter(Some("unknown")), (false, false, false));
+    fn parse_set_syntax_entity_types_and_all() {
+        assert_eq!(parse_set_syntax(None).unwrap(), SetSyntax::All);
+        assert_eq!(
+            parse_set_syntax(Some("entityType:ProjectCluster")).unwrap(),
+            SetSyntax::EntityType { clusters: true, projects: false, records: false }
+        );
+        assert_eq!(
+            parse_set_syntax(Some("entityType:ResearchProject")).unwrap(),
+            SetSyntax::EntityType { clusters: false, projects: true, records: false }
+        );
+        assert_eq!(
+            parse_set_syntax(Some("entityType:Record")).unwrap(),
+            SetSyntax::EntityType { clusters: false, projects: false, records: true }
+        );
+    }
+
+    #[test]
+    fn parse_set_syntax_project_and_cluster() {
+        assert_eq!(
+            parse_set_syntax(Some("project:0803")).unwrap(),
+            SetSyntax::Project("0803".to_string())
+        );
+        assert_eq!(
+            parse_set_syntax(Some("cluster:cluster-001")).unwrap(),
+            SetSyntax::Cluster("cluster-001".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_set_syntax_unknown_or_empty_is_bad_argument() {
+        assert!(matches!(parse_set_syntax(Some("garbage")), Err(OaiError::BadArgument(_))));
+        assert!(matches!(
+            parse_set_syntax(Some("entityType:Unknown")),
+            Err(OaiError::BadArgument(_))
+        ));
+        assert!(matches!(parse_set_syntax(Some("project:")), Err(OaiError::BadArgument(_))));
+        assert!(matches!(parse_set_syntax(Some("cluster:")), Err(OaiError::BadArgument(_))));
     }
 
     #[test]

--- a/modules/dpe/api-oai/src/handlers/test_utils.rs
+++ b/modules/dpe/api-oai/src/handlers/test_utils.rs
@@ -5,7 +5,7 @@ use dpe_core::project::{
     AccessRights, AccessRightsType, Attribution, Discipline, Funding, Grant, LegalInfo, License, Project,
     ProjectStatus, TemporalCoverage,
 };
-use dpe_core::{ProjectRepository, Record, RecordRepository};
+use dpe_core::{ClusterRaw, ProjectRepository, Record, RecordRepository};
 
 /// In-memory repository for testing.
 pub struct InMemoryProjectRepository {
@@ -121,6 +121,21 @@ pub fn incunabula_project() -> Project {
         documentation_material: None,
         provenance: None,
         additional_material: None,
+    }
+}
+
+/// Builds a cluster fixture (`cluster-001`, "EKWS") containing the given member
+/// project shortcodes. Use for cluster-set tests so they don't depend on the
+/// process-global cluster cache.
+pub fn cluster_fixture(id: &str, name: &str, projects: &[&str]) -> ClusterRaw {
+    let mut description = std::collections::HashMap::new();
+    description.insert("en".to_string(), format!("{name} description"));
+    ClusterRaw {
+        id: id.to_string(),
+        name: name.to_string(),
+        description,
+        pid: None,
+        projects: projects.iter().map(|p| p.to_string()).collect(),
     }
 }
 

--- a/modules/dpe/api-oai/src/metadata/mod.rs
+++ b/modules/dpe/api-oai/src/metadata/mod.rs
@@ -12,7 +12,8 @@ mod record_dublin_core;
 mod types;
 
 use datacite::project_to_datacite;
-use dpe_core::{record_datestamp, Project, Record, ARK_PATH_PREFIX};
+use dpe_core::cluster_cache::clusters_for_shortcode_in;
+use dpe_core::{record_datestamp, ClusterRaw, Project, Record, ARK_PATH_PREFIX};
 use dublin_core::project_to_dublin_core;
 use record_datacite::record_to_datacite;
 use record_dublin_core::record_to_dublin_core;
@@ -43,8 +44,19 @@ pub fn parse_oai_identifier(identifier: &str) -> Option<String> {
     ark_part.strip_prefix(ARK_PATH_PREFIX).map(|s| s.to_string())
 }
 
+/// Builds the set specs for a project shortcode: its `project:{shortcode}` set and
+/// one `cluster:{id}` set per cluster the project belongs to (resolved from the
+/// given cluster slice). The caller prepends the entity-type set spec.
+fn membership_set_specs(entity_type: &str, shortcode: &str, clusters: &[ClusterRaw]) -> Vec<String> {
+    let mut specs = vec![entity_type.to_string(), format!("project:{shortcode}")];
+    for cluster in clusters_for_shortcode_in(clusters, shortcode) {
+        specs.push(format!("cluster:{}", cluster.id));
+    }
+    specs
+}
+
 /// Creates an OAI record from a project for the given metadata prefix.
-pub fn to_oai_record(project: &Project, metadata_prefix: &str) -> OaiRecord {
+pub fn to_oai_record(project: &Project, metadata_prefix: &str, clusters: &[ClusterRaw]) -> OaiRecord {
     let identifier = if !dpe_core::is_placeholder(&project.pid) && !project.pid.is_empty() {
         make_oai_identifier_from_pid(&project.pid).unwrap_or_else(|| make_oai_identifier(&project.shortcode))
     } else {
@@ -57,7 +69,7 @@ pub fn to_oai_record(project: &Project, metadata_prefix: &str) -> OaiRecord {
         } else {
             "2015-01-01".to_string()
         },
-        set_specs: vec!["entityType:ResearchProject".to_string()],
+        set_specs: membership_set_specs("entityType:ResearchProject", &project.shortcode, clusters),
     };
 
     let dublin_core = if metadata_prefix == "oai_dc" {
@@ -76,13 +88,13 @@ pub fn to_oai_record(project: &Project, metadata_prefix: &str) -> OaiRecord {
 }
 
 /// Creates an OAI record from a Record for the given metadata prefix.
-pub fn to_oai_record_from_record(record: &Record, metadata_prefix: &str) -> OaiRecord {
+pub fn to_oai_record_from_record(record: &Record, metadata_prefix: &str, clusters: &[ClusterRaw]) -> OaiRecord {
     let suffix_owned = record.pid.ark_suffix();
     let suffix = &suffix_owned;
     let header = OaiRecordHeader {
         identifier: make_oai_identifier(suffix),
         datestamp: record_datestamp(record),
-        set_specs: vec!["entityType:Record".to_string()],
+        set_specs: membership_set_specs("entityType:Record", &record.pid.shortcode, clusters),
     };
 
     let dublin_core = if metadata_prefix == "oai_dc" {

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_oai_datacite.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_oai_datacite.xml
@@ -7,6 +7,7 @@
         <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>
         <datestamp>2008-06-01</datestamp>
         <setSpec>entityType:ResearchProject</setSpec>
+        <setSpec>project:0803</setSpec>
       </header>
       <metadata>
         <oai_datacite xmlns="http://schema.datacite.org/oai/oai-1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schema.datacite.org/oai/oai-1.1/ http://schema.datacite.org/oai/oai-1.1/oai.xsd">

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_oai_dc.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_oai_dc.xml
@@ -7,6 +7,7 @@
         <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>
         <datestamp>2008-06-01</datestamp>
         <setSpec>entityType:ResearchProject</setSpec>
+        <setSpec>project:0803</setSpec>
       </header>
       <metadata>
         <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_record_oai_datacite.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_record_oai_datacite.xml
@@ -7,6 +7,7 @@
         <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh</identifier>
         <datestamp>2012-06-19T14:33:33Z</datestamp>
         <setSpec>entityType:Record</setSpec>
+        <setSpec>project:0803</setSpec>
       </header>
       <metadata>
         <oai_datacite xmlns="http://schema.datacite.org/oai/oai-1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schema.datacite.org/oai/oai-1.1/ http://schema.datacite.org/oai/oai-1.1/oai.xsd">

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_record_oai_dc.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_record_oai_dc.xml
@@ -7,6 +7,7 @@
         <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh</identifier>
         <datestamp>2012-06-19T14:33:33Z</datestamp>
         <setSpec>entityType:Record</setSpec>
+        <setSpec>project:0803</setSpec>
       </header>
       <metadata>
         <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_identifiers_mixed_oai_dc.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_identifiers_mixed_oai_dc.xml
@@ -6,11 +6,13 @@
       <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>
       <datestamp>2008-06-01</datestamp>
       <setSpec>entityType:ResearchProject</setSpec>
+      <setSpec>project:0803</setSpec>
     </header>
     <header>
       <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh</identifier>
       <datestamp>2012-06-19T14:33:33Z</datestamp>
       <setSpec>entityType:Record</setSpec>
+      <setSpec>project:0803</setSpec>
     </header>
   </ListIdentifiers>
 </OAI-PMH>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_identifiers_oai_datacite.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_identifiers_oai_datacite.xml
@@ -6,6 +6,7 @@
       <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>
       <datestamp>2008-06-01</datestamp>
       <setSpec>entityType:ResearchProject</setSpec>
+      <setSpec>project:0803</setSpec>
     </header>
   </ListIdentifiers>
 </OAI-PMH>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_identifiers_oai_dc.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_identifiers_oai_dc.xml
@@ -6,6 +6,7 @@
       <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>
       <datestamp>2008-06-01</datestamp>
       <setSpec>entityType:ResearchProject</setSpec>
+      <setSpec>project:0803</setSpec>
     </header>
   </ListIdentifiers>
 </OAI-PMH>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_identifiers_record_only_oai_dc.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_identifiers_record_only_oai_dc.xml
@@ -6,6 +6,7 @@
       <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh</identifier>
       <datestamp>2012-06-19T14:33:33Z</datestamp>
       <setSpec>entityType:Record</setSpec>
+      <setSpec>project:0803</setSpec>
     </header>
   </ListIdentifiers>
 </OAI-PMH>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_mixed_oai_dc.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_mixed_oai_dc.xml
@@ -7,6 +7,7 @@
         <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>
         <datestamp>2008-06-01</datestamp>
         <setSpec>entityType:ResearchProject</setSpec>
+        <setSpec>project:0803</setSpec>
       </header>
       <metadata>
         <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
@@ -34,6 +35,7 @@
         <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh</identifier>
         <datestamp>2012-06-19T14:33:33Z</datestamp>
         <setSpec>entityType:Record</setSpec>
+        <setSpec>project:0803</setSpec>
       </header>
       <metadata>
         <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_oai_datacite.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_oai_datacite.xml
@@ -7,6 +7,7 @@
         <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>
         <datestamp>2008-06-01</datestamp>
         <setSpec>entityType:ResearchProject</setSpec>
+        <setSpec>project:0803</setSpec>
       </header>
       <metadata>
         <oai_datacite xmlns="http://schema.datacite.org/oai/oai-1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schema.datacite.org/oai/oai-1.1/ http://schema.datacite.org/oai/oai-1.1/oai.xsd">

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_oai_dc.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_oai_dc.xml
@@ -7,6 +7,7 @@
         <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>
         <datestamp>2008-06-01</datestamp>
         <setSpec>entityType:ResearchProject</setSpec>
+        <setSpec>project:0803</setSpec>
       </header>
       <metadata>
         <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_record_only_oai_dc.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_record_only_oai_dc.xml
@@ -7,6 +7,7 @@
         <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh</identifier>
         <datestamp>2012-06-19T14:33:33Z</datestamp>
         <setSpec>entityType:Record</setSpec>
+        <setSpec>project:0803</setSpec>
       </header>
       <metadata>
         <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_sets.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_sets.xml
@@ -10,5 +10,13 @@
       <setSpec>entityType:ResearchProject</setSpec>
       <setName>Research Projects</setName>
     </set>
+    <set>
+      <setSpec>project:0803</setSpec>
+      <setName>Die Bilderfolgen der Basler Frühdrucke: Spätmittelalterliche Didaxe als Bild-Text-Lektüre</setName>
+    </set>
+    <set>
+      <setSpec>cluster:cluster-001</setSpec>
+      <setName>EKWS</setName>
+    </set>
   </ListSets>
 </OAI-PMH>

--- a/modules/dpe/api-oai/src/xml.rs
+++ b/modules/dpe/api-oai/src/xml.rs
@@ -158,7 +158,10 @@ impl OaiXmlBuilder {
     }
 
     /// Writes the ListSets response content.
-    pub fn write_list_sets(&mut self) {
+    ///
+    /// Emits the static `entityType:*` sets followed by the dynamic project and
+    /// cluster sets passed as `(setSpec, setName)` pairs.
+    pub fn write_list_sets(&mut self, project_sets: &[(String, String)], cluster_sets: &[(String, String)]) {
         self.start_element("ListSets");
 
         self.start_element("set");
@@ -170,6 +173,20 @@ impl OaiXmlBuilder {
         self.write_element("setSpec", "entityType:ResearchProject");
         self.write_element("setName", "Research Projects");
         self.end_element("set");
+
+        for (set_spec, set_name) in project_sets {
+            self.start_element("set");
+            self.write_element("setSpec", set_spec);
+            self.write_element("setName", set_name);
+            self.end_element("set");
+        }
+
+        for (set_spec, set_name) in cluster_sets {
+            self.start_element("set");
+            self.write_element("setSpec", set_spec);
+            self.write_element("setName", set_name);
+            self.end_element("set");
+        }
 
         self.end_element("ListSets");
     }

--- a/modules/dpe/core/src/cluster_cache.rs
+++ b/modules/dpe/core/src/cluster_cache.rs
@@ -7,7 +7,7 @@
 /// Note: This module is gated with `#[cfg(not(target_arch = "wasm32"))]` in lib.rs.
 use std::sync::OnceLock;
 
-use super::cluster::ClusterRaw;
+use super::cluster::{ClusterRaw, ClusterRef};
 use super::utils::get_data_dir;
 
 static CLUSTERS: OnceLock<Vec<ClusterRaw>> = OnceLock::new();
@@ -15,6 +15,34 @@ static CLUSTERS: OnceLock<Vec<ClusterRaw>> = OnceLock::new();
 /// Return a reference to the cached cluster list, loading it on first call.
 pub fn all_clusters() -> &'static [ClusterRaw] {
     CLUSTERS.get_or_init(load_all_clusters)
+}
+
+/// Returns the clusters in `clusters` whose `projects` list contains `shortcode`
+/// (compared case-insensitively). Pure over the given slice so it can be unit-tested
+/// without touching the process-global cache.
+pub fn clusters_for_shortcode_in(clusters: &[ClusterRaw], shortcode: &str) -> Vec<ClusterRef> {
+    clusters
+        .iter()
+        .filter(|raw| raw.projects.iter().any(|p| p.eq_ignore_ascii_case(shortcode)))
+        .map(|raw| raw.clone().into_ref())
+        .collect()
+}
+
+/// Returns the clusters (from the cache) a project shortcode belongs to.
+pub fn clusters_for_shortcode(shortcode: &str) -> Vec<ClusterRef> {
+    clusters_for_shortcode_in(all_clusters(), shortcode)
+}
+
+/// Returns the project shortcodes belonging to the cluster with the given `id`
+/// (exact match), or `None` if no such cluster exists in `clusters`.
+pub fn projects_for_cluster_in<'a>(clusters: &'a [ClusterRaw], id: &str) -> Option<&'a [String]> {
+    clusters.iter().find(|raw| raw.id == id).map(|raw| raw.projects.as_slice())
+}
+
+/// Returns the project shortcodes belonging to the cluster `id` (from the cache),
+/// or `None` if no such cluster exists.
+pub fn projects_for_cluster(id: &str) -> Option<&'static [String]> {
+    projects_for_cluster_in(all_clusters(), id)
 }
 
 fn load_all_clusters() -> Vec<ClusterRaw> {
@@ -44,4 +72,76 @@ fn load_all_clusters() -> Vec<ClusterRaw> {
         }
     }
     clusters
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    fn cluster(id: &str, name: &str, projects: &[&str]) -> ClusterRaw {
+        let mut description = HashMap::new();
+        description.insert("en".to_string(), format!("{name} description"));
+        ClusterRaw {
+            id: id.to_string(),
+            name: name.to_string(),
+            description,
+            pid: None,
+            projects: projects.iter().map(|p| p.to_string()).collect(),
+        }
+    }
+
+    fn fixtures() -> Vec<ClusterRaw> {
+        vec![
+            cluster("cluster-001", "EKWS", &["0812", "082A"]),
+            cluster("cluster-005", "DaSCH", &["0803"]),
+        ]
+    }
+
+    #[test]
+    fn clusters_for_shortcode_in_matches_membership() {
+        let clusters = fixtures();
+        let found = clusters_for_shortcode_in(&clusters, "0812");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].id, "cluster-001");
+        assert_eq!(found[0].name, "EKWS");
+    }
+
+    #[test]
+    fn clusters_for_shortcode_in_is_case_insensitive() {
+        let clusters = fixtures();
+        // membership list has "082A"; query with lowercase still matches.
+        let found = clusters_for_shortcode_in(&clusters, "082a");
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].id, "cluster-001");
+    }
+
+    #[test]
+    fn clusters_for_shortcode_in_returns_empty_for_unknown() {
+        let clusters = fixtures();
+        assert!(clusters_for_shortcode_in(&clusters, "9999").is_empty());
+    }
+
+    #[test]
+    fn projects_for_cluster_in_returns_members() {
+        let clusters = fixtures();
+        assert_eq!(
+            projects_for_cluster_in(&clusters, "cluster-001"),
+            Some(["0812".to_string(), "082A".to_string()].as_slice())
+        );
+    }
+
+    #[test]
+    fn projects_for_cluster_in_unknown_id_is_none() {
+        let clusters = fixtures();
+        assert_eq!(projects_for_cluster_in(&clusters, "cluster-999"), None);
+    }
+
+    #[test]
+    fn cluster_id_match_is_exact_case_sensitive() {
+        let clusters = fixtures();
+        // cluster ids are exact-match (case-sensitive), unlike project shortcodes.
+        assert_eq!(projects_for_cluster_in(&clusters, "CLUSTER-001"), None);
+    }
 }

--- a/modules/dpe/core/src/lib.rs
+++ b/modules/dpe/core/src/lib.rs
@@ -21,6 +21,8 @@ pub mod record_repository;
 pub mod utils;
 
 // Re-exports for convenience
+#[cfg(not(target_arch = "wasm32"))]
+pub use cluster::ClusterRaw;
 pub use cluster::ClusterRef;
 pub use collection::CollectionRef;
 pub use contributors::ResolvedContributor;

--- a/modules/dpe/web/src/domain/projects.rs
+++ b/modules/dpe/web/src/domain/projects.rs
@@ -615,11 +615,7 @@ pub fn get_project(shortcode: &str) -> Option<Project> {
     // Resolve clusters from the in-memory cache (reverse lookup). Compare
     // case-insensitively so cluster files referencing a different case still
     // resolve to the same project.
-    project.clusters = dpe_core::cluster_cache::all_clusters()
-        .iter()
-        .filter(|raw| raw.projects.iter().any(|p| p.eq_ignore_ascii_case(&canonical_shortcode)))
-        .map(|raw| raw.clone().into_ref())
-        .collect();
+    project.clusters = dpe_core::cluster_cache::clusters_for_shortcode(&canonical_shortcode);
 
     // Resolve collection IDs stored on the cached project.
     let data_path = PathBuf::from(get_data_dir());


### PR DESCRIPTION
[DEV-6526](https://linear.app/dasch/issue/DEV-6526)

## Summary
- Adds two hierarchical OAI-PMH set filters to the DPE `/oai` endpoint: `project:{shortcode}` (a project's records) and `cluster:{id}` (a cluster's project entries plus all their records).
- `ListSets` now advertises a `project:{shortcode}` set per project and a `cluster:{id}` set per cluster, alongside the existing static `entityType:*` sets.
- Every item header carries its full set membership (`entityType:*`, `project:{shortcode}`, applicable `cluster:{id}`).

## Changes
**`dpe-core`**
- Extract the cluster reverse-lookup (previously inline in the web `get_project` path) into reusable `cluster_cache` helpers: `clusters_for_shortcode[_in]` and `projects_for_cluster[_in]`. The `*_in` variants take an injectable `&[ClusterRaw]` slice so they're unit-testable without the process-global `OnceLock`. Re-export `ClusterRaw` (native-only).
- `web get_project` refactored to call the new helper (behaviour-preserving).

**`api-oai`**
- Replace the boolean `parse_set_filter` tuple with a two-step parse: a pure `parse_set_syntax` (syntactic; unknown prefix / empty value → `badArgument`) plus a repo/cache-backed existence check in `validate_list_params` (unknown project/cluster → `badArgument`; known-but-empty → `noRecordsMatch`).
- `project:{shortcode}` returns that project's records only (no project entry). `cluster:{id}` returns the cluster's project entries + their records, deduplicated; a real-but-recordless cluster still returns the project entries (deliberate asymmetry with `project:`).
- Set filtering composes with the existing `from`/`until` date filtering (intersection); `metadataPrefix` is still validated before `set` (error precedence preserved).
- `handle_list_sets` takes a `ProjectRepository` and the cluster slice; `write_list_sets` emits the dynamic sets.
- `to_oai_record` / `to_oai_record_from_record` stamp `project:` + `cluster:` setSpecs.

## Test Plan
- `cargo test --tests` — full workspace green (108 api-oai tests incl. new project/cluster filtering, `badArgument` vs `noRecordsMatch`, cluster emptiness asymmetry, `ListIdentifiers` parity, dynamic `ListSets`, schema-validation, and regenerated golden files).
- `cargo clippy -- -D warnings` — clean.
- `cargo +nightly fmt --check --all` — clean.
- `cargo check --target wasm32-unknown-unknown -p dpe-web --no-default-features` — clean.

Specs (PRD + implementation plan): dasch-swiss/dasch-specs `specs/2026-06-10-oai-pmh-set-filters/`.