### PR TITLE
docs: add OAI-PMH endpoint usage page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ All authoritative documentation lives in `docs/src/`. Key pages:
 | Testing Strategy | `docs/src/dpe/testing-strategy.md` |
 | Observability | `docs/src/dpe/observability.md` |
 | Operations (Docker, env vars) | `docs/src/dpe/operations.md` |
+| OAI-PMH Endpoint Usage | `docs/src/dpe/oai-pmh.md` |
 | Workflows & Commits | `docs/src/workflows.md` |
 | Tech Stack | `docs/src/fundamentals/tech_stack.md` |
 | Review Guidelines | `docs/src/fundamentals/review-guidelines.md` |

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -22,6 +22,7 @@
 - [Testing Strategy](./dpe/testing-strategy.md)
 - [Observability](./dpe/observability.md)
 - [Operations](./dpe/operations.md)
+- [OAI-PMH Endpoint](./dpe/oai-pmh.md)
 
 ---
 

--- a/docs/src/dpe/architecture.md
+++ b/docs/src/dpe/architecture.md
@@ -22,7 +22,7 @@ dpe-core          Pure domain types, repositories, data loading
 ```
 
 - **dpe-core**: Framework-free domain layer. All types, repository traits, Fs implementations, and data loading.
-- **dpe-api-oai**: OAI-PMH 2.0 endpoint. Depends only on dpe-core — no Leptos.
+- **dpe-api-oai**: OAI-PMH 2.0 endpoint (see [OAI-PMH Endpoint](./oai-pmh.md)). Depends only on dpe-core — no Leptos.
 - **dpe-web**: Leptos SSR components, pages, and `#[server]` wrappers. Re-exports dpe-core types for backward compatibility.
 - **dpe-server**: Thin composition root. Wires Leptos routes (dpe-web) and API handlers (dpe-api-oai) into a single Axum server.
 

--- a/docs/src/dpe/oai-pmh.md
+++ b/docs/src/dpe/oai-pmh.md
@@ -66,6 +66,8 @@ With an `identifier` argument, the supported formats for that item are returned.
 curl "https://api.dev.dasch.swiss/dpe/oai?verb=ListSets"
 ```
 
+Abbreviated example response — the full response also contains one `project:{shortcode}` set per project and one `cluster:{id}` set per cluster:
+
 ```xml
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" ...>
   <request verb="ListSets">https://meta.dasch.swiss/oai</request>
@@ -78,9 +80,20 @@ curl "https://api.dev.dasch.swiss/dpe/oai?verb=ListSets"
       <setSpec>entityType:ResearchProject</setSpec>
       <setName>Research Projects</setName>
     </set>
+    <set>
+      <setSpec>project:0803</setSpec>
+      <setName>Die Bilderfolgen der Basler Frühdrucke</setName>
+    </set>
+    <set>
+      <setSpec>cluster:cluster-003</setSpec>
+      <setName>Bernoulli-Euler Online (BEOL)</setName>
+    </set>
+    <!-- further project: and cluster: sets omitted -->
   </ListSets>
 </OAI-PMH>
 ```
+
+The response is a single un-paginated list and always includes the static `entityType:*` sets, so it is never empty.
 
 ## Metadata Formats
 
@@ -104,15 +117,23 @@ These differ from the resolvable ARK URLs (`https://ark.dasch.swiss/ark:/72163/1
 
 ## Sets
 
-Sets group items by entity type. Selective harvesting uses the `set` argument on `ListIdentifiers` and `ListRecords`.
+Selective harvesting uses the `set` argument on `ListIdentifiers` and `ListRecords`. Two kinds of sets exist: static **entity-type** sets and dynamic **project**/**cluster** sets.
 
-| `setSpec` | Contents | Status |
-|-----------|----------|--------|
-| `entityType:ResearchProject` | Research project metadata entries | Harvestable |
+| `setSpec` | Contents | Notes |
+|-----------|----------|-------|
+| `entityType:ResearchProject` | All research project metadata entries | Advertised by `ListSets` |
 | `entityType:ProjectCluster` | Project clusters | Advertised but currently empty — always returns `noRecordsMatch` |
-| `entityType:Record` | Record-level metadata entries | Accepted as a filter and stamped on record headers, but not advertised by `ListSets`; subject to change |
+| `entityType:Record` | All record-level metadata entries | Accepted as a filter and stamped on record headers, but not advertised by `ListSets`; subject to change |
+| `project:{shortcode}` | The Records belonging to one research project | One set per project, `setName` = project name. Shortcode matching is case-insensitive. |
+| `cluster:{id}` | All entities under one project cluster: the cluster's research project metadata entries **plus** all of those projects' Records | One set per cluster, `setName` = cluster name. The `{id}` is the stable cluster id (e.g. `cluster-003`). |
 
-An unknown `set` value is not rejected — it matches nothing and returns `noRecordsMatch`, the same response as an empty repository.
+The hierarchy is **Cluster → Projects → Records**, and the two dynamic set kinds deliberately differ in breadth: `project:{shortcode}` is a record-harvesting scope (it does *not* include the project's own metadata entry), while `cluster:{id}` is the discovery container for a whole cluster and therefore also surfaces the project metadata entries a harvester needs to navigate. To fetch a single project's *metadata entry*, use `entityType:ResearchProject` or the project's `cluster:{id}` set.
+
+A project belongs to a cluster if the cluster's member list contains the project's shortcode (case-insensitive); records inherit their parent project's cluster membership.
+
+**Set membership on headers.** Every item header lists its full set membership, so membership can be determined from an item alone: record headers carry `entityType:Record`, their `project:{shortcode}`, and a `cluster:{id}` for each cluster of the parent project; project headers carry `entityType:ResearchProject`, their own `project:{shortcode}`, and their `cluster:{id}` sets.
+
+**Set validation.** An unrecognised `set` value — bad prefix, empty value, or a `project:`/`cluster:` value matching no known project or cluster — is rejected with `badArgument`. A recognised set that matches zero items (e.g. a known project with no records yet, possibly after date filtering) returns `noRecordsMatch`.
 
 ## Harvesting
 
@@ -126,6 +147,16 @@ Selective harvest of research projects only:
 
 ```bash
 curl "https://api.dev.dasch.swiss/dpe/oai?verb=ListRecords&metadataPrefix=oai_datacite&set=entityType:ResearchProject"
+```
+
+Selective harvest of one project's records, or of everything under one cluster:
+
+```bash
+# All records of project 0803
+curl "https://api.dev.dasch.swiss/dpe/oai?verb=ListRecords&metadataPrefix=oai_dc&set=project:0803"
+
+# All project entries and records under cluster cluster-003
+curl "https://api.dev.dasch.swiss/dpe/oai?verb=ListRecords&metadataPrefix=oai_dc&set=cluster:cluster-003"
 ```
 
 Headers only (no metadata payloads):
@@ -157,6 +188,8 @@ Abbreviated example response:
         <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>
         <datestamp>2008-06-01</datestamp>
         <setSpec>entityType:ResearchProject</setSpec>
+        <setSpec>project:0803</setSpec>
+        <!-- plus a cluster:{id} setSpec for each cluster the project belongs to -->
       </header>
       <metadata>
         <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" ...>
@@ -198,11 +231,11 @@ Errors are returned as OAI `<error>` elements with HTTP status `200`:
 | Code | Returned when |
 |------|---------------|
 | `badVerb` | The `verb` argument is missing or not one of the six verbs. The `<request>` element omits the verb attribute in this case. |
-| `badArgument` | An argument is missing, repeated, or not allowed for the verb (e.g. `set` on `GetRecord`). |
+| `badArgument` | An argument is missing, repeated, or not allowed for the verb (e.g. `set` on `GetRecord`); also returned for an unrecognised `set` value (bad prefix, empty value, or unknown project/cluster). |
 | `badResumptionToken` | A `resumptionToken` argument is supplied (resumption tokens are not supported). |
 | `cannotDisseminateFormat` | `metadataPrefix` is not `oai_dc` or `oai_datacite`. |
 | `idDoesNotExist` | The `identifier` does not resolve — including malformed identifiers (wrong prefix, bare shortcode), which are not reported as `badArgument`. |
-| `noRecordsMatch` | A list request matches nothing: empty result, unknown `set` value, or a `from`/`until` window with no matches. An empty list is never returned. |
+| `noRecordsMatch` | A list request matches nothing: empty result, a recognised `set` with no items, or a `from`/`until` window with no matches. An empty list is never returned. |
 
 ## Known Limitations
 

--- a/docs/src/dpe/oai-pmh.md
+++ b/docs/src/dpe/oai-pmh.md
@@ -1,0 +1,214 @@
+# OAI-PMH Endpoint
+
+Usage guide for the DPE [OAI-PMH 2.0](https://www.openarchives.org/OAI/openarchivesprotocol.html) data provider, which exposes DaSCH research project and record metadata for harvesting. The implementation lives in the `dpe-api-oai` crate (see [Project Structure](./project_structure.md)).
+
+## Endpoint
+
+- **Path**: `GET /dpe/oai` — GET only; POST requests are not supported
+- **Response**: always `200 OK` with `Content-Type: text/xml; charset=utf-8`. Protocol errors are reported as OAI `<error>` elements inside the XML body, not as HTTP error codes.
+- **Protocol version**: 2.0
+
+| Environment | Base URL |
+|-------------|----------|
+| Local development (`just watch-dpe`) | `http://localhost:4000/dpe/oai` |
+| DEV | `https://api.dev.dasch.swiss/dpe/oai` |
+| Production | Not yet deployed; see [Known Limitations](#known-limitations) regarding the advertised `baseURL` |
+
+## Verbs
+
+All six OAI-PMH 2.0 verbs are implemented:
+
+| Verb | Required arguments | Optional arguments |
+|------|--------------------|--------------------|
+| `Identify` | — | — |
+| `ListMetadataFormats` | — | `identifier` |
+| `ListSets` | — | — |
+| `ListIdentifiers` | `metadataPrefix` | `from`, `until`, `set` |
+| `ListRecords` | `metadataPrefix` | `from`, `until`, `set` |
+| `GetRecord` | `identifier`, `metadataPrefix` | — |
+
+Arguments outside these lists are rejected with `badArgument`, with two exceptions that are silently ignored: `set` on `ListSets` and `metadataPrefix` on `ListMetadataFormats`. A `resumptionToken` is rejected with `badResumptionToken` on every verb — see [Known Limitations](#known-limitations).
+
+### Identify
+
+```bash
+curl "https://api.dev.dasch.swiss/dpe/oai?verb=Identify"
+```
+
+Abbreviated example response (values vary by environment):
+
+```xml
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" ...>
+  <request verb="Identify">https://meta.dasch.swiss/oai</request>
+  <Identify>
+    <repositoryName>DaSCH Service Platform Repository</repositoryName>
+    <baseURL>https://meta.dasch.swiss/oai</baseURL>
+    <protocolVersion>2.0</protocolVersion>
+    <adminEmail>info@dasch.swiss</adminEmail>
+    <earliestDatestamp>2008-06-01</earliestDatestamp>
+    <deletedRecord>no</deletedRecord>
+    <granularity>YYYY-MM-DD</granularity>
+  </Identify>
+</OAI-PMH>
+```
+
+### ListMetadataFormats
+
+```bash
+curl "https://api.dev.dasch.swiss/dpe/oai?verb=ListMetadataFormats"
+```
+
+With an `identifier` argument, the supported formats for that item are returned. Note: identifiers are currently validated against projects only — a record identifier that works with `GetRecord` returns `idDoesNotExist` here.
+
+### ListSets
+
+```bash
+curl "https://api.dev.dasch.swiss/dpe/oai?verb=ListSets"
+```
+
+```xml
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" ...>
+  <request verb="ListSets">https://meta.dasch.swiss/oai</request>
+  <ListSets>
+    <set>
+      <setSpec>entityType:ProjectCluster</setSpec>
+      <setName>Project Clusters</setName>
+    </set>
+    <set>
+      <setSpec>entityType:ResearchProject</setSpec>
+      <setName>Research Projects</setName>
+    </set>
+  </ListSets>
+</OAI-PMH>
+```
+
+## Metadata Formats
+
+| `metadataPrefix` | Schema | Namespace |
+|------------------|--------|-----------|
+| `oai_dc` | `http://www.openarchives.org/OAI/2.0/oai_dc.xsd` | `http://www.openarchives.org/OAI/2.0/oai_dc/` |
+| `oai_datacite` | `http://schema.datacite.org/oai/oai-1.1/oai.xsd` | `http://schema.datacite.org/oai/oai-1.1/` |
+
+The `oai_datacite` payload contains DataCite kernel 4 metadata (`schemaVersion` 4.6, `datacentreSymbol` `DASCH.DSP`), following the DaSCH Metadata to DataCite mapping specification. `oai_dc` is the simpler Dublin Core representation; `oai_datacite` carries richer structured metadata (contributors, related identifiers, rights, geolocations, funding references).
+
+## Identifiers
+
+OAI identifiers are derived from DaSCH [ARK](https://arks.org/) identifiers:
+
+| Item type | Pattern | Example |
+|-----------|---------|---------|
+| Research project | `oai:meta.dasch.swiss:ark:/72163/1/{shortcode}` | `oai:meta.dasch.swiss:ark:/72163/1/0803` |
+| Record | `oai:meta.dasch.swiss:ark:/72163/1/{shortcode}/{record_id}` | `oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh` |
+
+These differ from the resolvable ARK URLs (`https://ark.dasch.swiss/ark:/72163/1/...`), which appear in the metadata payloads as `dc:identifier` / DataCite `identifier`.
+
+## Sets
+
+Sets group items by entity type. Selective harvesting uses the `set` argument on `ListIdentifiers` and `ListRecords`.
+
+| `setSpec` | Contents | Status |
+|-----------|----------|--------|
+| `entityType:ResearchProject` | Research project metadata entries | Harvestable |
+| `entityType:ProjectCluster` | Project clusters | Advertised but currently empty — always returns `noRecordsMatch` |
+| `entityType:Record` | Record-level metadata entries | Accepted as a filter and stamped on record headers, but not advertised by `ListSets`; subject to change |
+
+An unknown `set` value is not rejected — it matches nothing and returns `noRecordsMatch`, the same response as an empty repository.
+
+## Harvesting
+
+Full harvest of all items:
+
+```bash
+curl "https://api.dev.dasch.swiss/dpe/oai?verb=ListRecords&metadataPrefix=oai_dc"
+```
+
+Selective harvest of research projects only:
+
+```bash
+curl "https://api.dev.dasch.swiss/dpe/oai?verb=ListRecords&metadataPrefix=oai_datacite&set=entityType:ResearchProject"
+```
+
+Headers only (no metadata payloads):
+
+```bash
+curl "https://api.dev.dasch.swiss/dpe/oai?verb=ListIdentifiers&metadataPrefix=oai_dc"
+```
+
+List responses are returned complete and unpaged — there is no `resumptionToken` element, and its absence means the response is complete, not truncated.
+
+### Fetching a single item
+
+```bash
+# A research project
+curl "https://api.dev.dasch.swiss/dpe/oai?verb=GetRecord&metadataPrefix=oai_dc&identifier=oai:meta.dasch.swiss:ark:/72163/1/0803"
+
+# A record within a project
+curl "https://api.dev.dasch.swiss/dpe/oai?verb=GetRecord&metadataPrefix=oai_dc&identifier=oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"
+```
+
+Abbreviated example response:
+
+```xml
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" ...>
+  <request verb="GetRecord" identifier="oai:meta.dasch.swiss:ark:/72163/1/0803" metadataPrefix="oai_dc">https://meta.dasch.swiss/oai</request>
+  <GetRecord>
+    <record>
+      <header>
+        <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>
+        <datestamp>2008-06-01</datestamp>
+        <setSpec>entityType:ResearchProject</setSpec>
+      </header>
+      <metadata>
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" ...>
+          <dc:title>Die Bilderfolgen der Basler Frühdrucke</dc:title>
+          <dc:publisher>DaSCH</dc:publisher>
+          <dc:date>2008-06-01</dc:date>
+          <dc:type>Project</dc:type>
+          <dc:identifier>https://ark.dasch.swiss/ark:/72163/1/0803</dc:identifier>
+          <!-- further Dublin Core elements omitted -->
+        </oai_dc:dc>
+      </metadata>
+    </record>
+  </GetRecord>
+</OAI-PMH>
+```
+
+## Datestamps and Date Filtering
+
+`ListIdentifiers` and `ListRecords` accept `from` and `until` arguments. Both bounds are inclusive. Before relying on them, understand what the datestamps mean:
+
+- **Project datestamp**: the project's research *start date* (fallback `2015-01-01`) — not the date the metadata was created or last modified.
+- **Record datestamp**: the record's `dateModified`, falling back to `datePublished`, then `dateCreated`, then `2015-01-01`. Record datestamps may carry a full timestamp (e.g. `2012-06-19T14:33:33Z`) even though `Identify` advertises `YYYY-MM-DD` granularity.
+
+Filtering compares `from`/`until` against datestamps as plain strings (lexicographic comparison):
+
+- Use `YYYY-MM-DD` values. Other formats are not rejected with an error but compare incorrectly.
+- Because record datestamps may include a time component, `until=2012-06-19` excludes a record stamped `2012-06-19T14:33:33Z`. To include a full day, filter with `until` set to the following day.
+
+```bash
+curl "https://api.dev.dasch.swiss/dpe/oai?verb=ListIdentifiers&metadataPrefix=oai_dc&from=2010-01-01&until=2020-12-31"
+```
+
+**Incremental harvesting is not reliable with these semantics.** Project datestamps reflect research start dates, so new or updated project metadata does not surface through `from`-based incremental harvests, and deletions are not tracked (`deletedRecord: no`). Harvesters should periodically re-harvest the full repository instead of relying on date-based increments.
+
+## Errors
+
+Errors are returned as OAI `<error>` elements with HTTP status `200`:
+
+| Code | Returned when |
+|------|---------------|
+| `badVerb` | The `verb` argument is missing or not one of the six verbs. The `<request>` element omits the verb attribute in this case. |
+| `badArgument` | An argument is missing, repeated, or not allowed for the verb (e.g. `set` on `GetRecord`). |
+| `badResumptionToken` | A `resumptionToken` argument is supplied (resumption tokens are not supported). |
+| `cannotDisseminateFormat` | `metadataPrefix` is not `oai_dc` or `oai_datacite`. |
+| `idDoesNotExist` | The `identifier` does not resolve — including malformed identifiers (wrong prefix, bare shortcode), which are not reported as `badArgument`. |
+| `noRecordsMatch` | A list request matches nothing: empty result, unknown `set` value, or a `from`/`until` window with no matches. An empty list is never returned. |
+
+## Known Limitations
+
+- **No resumption tokens.** List responses are complete and unpaged; any `resumptionToken` argument yields `badResumptionToken`.
+- **Advertised `baseURL` differs from the actual endpoint.** `Identify` reports `https://meta.dasch.swiss/oai`, while the endpoint is mounted at `/dpe/oai`. Automated OAI validators and harvest managers that compare the `baseURL` against the request URL will flag this.
+- **No deleted-record tracking** (`deletedRecord: no`). Items that disappear are not announced; see the re-harvesting recommendation above.
+- **GET only.** OAI-PMH 2.0 also requires POST; harvesters that default to POST will not get an OAI response.
+- **`ListMetadataFormats` with a record identifier** returns `idDoesNotExist`, even for records that `GetRecord` resolves.
+- **`entityType:ProjectCluster`** is advertised by `ListSets` but contains no items yet.

--- a/docs/src/dpe/observability.md
+++ b/docs/src/dpe/observability.md
@@ -24,7 +24,7 @@ just watch-dpe-otel
 
 # Terminal 3: Generate traffic
 curl http://localhost:4000/projects
-curl http://localhost:4000/oai?verb=Identify
+curl http://localhost:4000/dpe/oai?verb=Identify
 curl http://localhost:4000/healthz
 ```
 
@@ -34,7 +34,7 @@ curl http://localhost:4000/healthz
 
 Open <http://localhost:3000> (no login required):
 
-- **Tempo** (Explore → Tempo): traces for `/projects` and `/oai`, none for `/healthz`
+- **Tempo** (Explore → Tempo): traces for `/projects` and `/dpe/oai`, none for `/healthz`
 - **Service map**: "dpe" service with Rust tech icon
 - **Loki** (Explore → Loki): OTel log records bridged from the `tracing` subscriber (severity, span context, structured fields)
 - **Mimir** (Explore → Mimir): browser telemetry metrics (`browser.web_vital`, `browser.error`, etc.)

--- a/docs/src/dpe/project_structure.md
+++ b/docs/src/dpe/project_structure.md
@@ -42,7 +42,7 @@ Dependencies: `serde`, `serde_json` only.
 
 ### `dpe-api-oai` (api-oai/)
 
-OAI-PMH 2.0 Data Provider. Implements the six required verbs (Identify, ListMetadataFormats, ListSets, ListIdentifiers, ListRecords, GetRecord).
+OAI-PMH 2.0 Data Provider. Implements the six required verbs (Identify, ListMetadataFormats, ListSets, ListIdentifiers, ListRecords, GetRecord). Usage is documented in [OAI-PMH Endpoint](./oai-pmh.md).
 
 Depends on `dpe-core` for domain types — no Leptos or web framework dependency.
 


### PR DESCRIPTION
[DEV-6526](https://linear.app/dasch/issue/DEV-6526)

## Summary
- Adds a usage guide for the OAI-PMH endpoint (`docs/src/dpe/oai-pmh.md`): base URLs per environment, all six verbs with curl examples and trimmed responses, metadata formats, identifier scheme, sets, datestamp/date-filtering semantics, error reference, and known limitations.
- Documents the `project:{shortcode}` / `cluster:{id}` set filters per the DEV-6526 PRD semantics — **this PR should merge after (or together with) the set-filters implementation.**
- Fixes stale `/oai` paths in the observability guide (route is `/dpe/oai`).

## Changes
- **New page**: `docs/src/dpe/oai-pmh.md`, registered in `SUMMARY.md`, cross-linked from `architecture.md`, `project_structure.md`, and the root `CLAUDE.md` docs table.
- **Fixes**: `observability.md` curl example and Tempo prose now use `/dpe/oai`.

## Test Plan
- `just docs-build` (`mdbook build docs`, same as CI) passes; new page renders and all cross-links resolve in the built book.
- Content fact-checked against `modules/dpe/api-oai` (verbs, prefixes, sets, error codes, identifier formats, datestamp logic) and reviewed by a consistency pass.

## Notes
- Known limitations section documents the hardcoded `Identify` baseURL (`https://meta.dasch.swiss/oai`) vs. the actual mount — open question whether that is the intended canonical URL.
- Plan: `dasch-specs/specs/2026-06-11-oai-pmh-usage-docs/01-docs-oai-pmh-usage-plan.md`