### PR TITLE
feat(dpe-api-oai): Resolve contributor information in OAI-PMH output (DEV-6575)

### DIFF
--- a/modules/dpe/api-oai/src/handlers/get_record.rs
+++ b/modules/dpe/api-oai/src/handlers/get_record.rs
@@ -1,6 +1,6 @@
 //! Handler for the OAI-PMH GetRecord verb.
 
-use dpe_core::{ClusterRaw, Project, ProjectRepository, Record, RecordRepository};
+use dpe_core::{ClusterRaw, ContributorLookup, Project, ProjectRepository, Record, RecordRepository};
 
 use super::{build_error_response, OaiParams, SUPPORTED_PREFIXES};
 use crate::error::OaiError;
@@ -13,12 +13,13 @@ pub fn handle_get_record(
     repo: &dyn ProjectRepository,
     record_repo: &dyn RecordRepository,
     clusters: &[ClusterRaw],
+    lookup: &dyn ContributorLookup,
 ) -> String {
     let result = require_identifier(params)
         .and_then(|id| require_metadata_prefix(params).map(|prefix| (id, prefix)))
         .and_then(|(id, prefix)| reject_unexpected_args(params).map(|_| (id, prefix)))
         .and_then(|(id, prefix)| resolve_entity(id, repo, record_repo).map(|oai| (id, prefix, oai)))
-        .map(|(id, prefix, oai)| build_response(id, prefix, oai, clusters));
+        .map(|(id, prefix, oai)| build_response(id, prefix, oai, clusters, lookup));
 
     result.unwrap_or_else(|err| build_error_response(err, Some("GetRecord")))
 }
@@ -75,9 +76,15 @@ fn resolve_entity(
     Err(OaiError::IdDoesNotExist)
 }
 
-fn build_response(identifier: &str, prefix: &str, entity: OaiEntity, clusters: &[ClusterRaw]) -> String {
+fn build_response(
+    identifier: &str,
+    prefix: &str,
+    entity: OaiEntity,
+    clusters: &[ClusterRaw],
+    lookup: &dyn ContributorLookup,
+) -> String {
     let oai_record: OaiRecord = match entity {
-        OaiEntity::Project(ref project) => to_oai_record(project, prefix, clusters),
+        OaiEntity::Project(ref project) => to_oai_record(project, prefix, clusters, lookup),
         OaiEntity::Record(ref record) => to_oai_record_from_record(record, prefix, clusters),
     };
 
@@ -94,7 +101,7 @@ mod tests {
     use dpe_core::Record;
 
     use super::super::test_utils::{
-        golden, incunabula_project, normalize, InMemoryProjectRepository, InMemoryRecordRepository,
+        golden, incunabula_lookup, incunabula_project, normalize, InMemoryProjectRepository, InMemoryRecordRepository,
     };
     use super::*;
 
@@ -129,7 +136,13 @@ mod tests {
     #[test]
     fn missing_identifier_returns_bad_argument() {
         let params = make_params(None, Some("oai_dc"));
-        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_get_record(
+            &params,
+            &repo_with_incunabula(),
+            &InMemoryRecordRepository::empty(),
+            &[],
+            &incunabula_lookup(),
+        );
         assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
         assert!(xml.contains("identifier argument is required"), "got: {}", xml);
         assert!(
@@ -142,7 +155,13 @@ mod tests {
     #[test]
     fn missing_metadata_prefix_returns_bad_argument() {
         let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), None);
-        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_get_record(
+            &params,
+            &repo_with_incunabula(),
+            &InMemoryRecordRepository::empty(),
+            &[],
+            &incunabula_lookup(),
+        );
         assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
         assert!(xml.contains("metadataPrefix argument is required"), "got: {}", xml);
     }
@@ -150,14 +169,26 @@ mod tests {
     #[test]
     fn unsupported_metadata_prefix_returns_cannot_disseminate() {
         let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), Some("marc21"));
-        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_get_record(
+            &params,
+            &repo_with_incunabula(),
+            &InMemoryRecordRepository::empty(),
+            &[],
+            &incunabula_lookup(),
+        );
         assert!(xml.contains("<error code=\"cannotDisseminateFormat\">"), "got: {}", xml);
     }
 
     #[test]
     fn unknown_id_not_in_either_repo_returns_id_does_not_exist() {
         let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/9999"), Some("oai_dc"));
-        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_get_record(
+            &params,
+            &repo_with_incunabula(),
+            &InMemoryRecordRepository::empty(),
+            &[],
+            &incunabula_lookup(),
+        );
         assert!(xml.contains("<error code=\"idDoesNotExist\">"), "got: {}", xml);
     }
 
@@ -165,7 +196,13 @@ mod tests {
     fn unexpected_argument_returns_bad_argument() {
         let mut params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), Some("oai_dc"));
         params.set = Some("entityType:ResearchProject".to_string());
-        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_get_record(
+            &params,
+            &repo_with_incunabula(),
+            &InMemoryRecordRepository::empty(),
+            &[],
+            &incunabula_lookup(),
+        );
         assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
     }
 
@@ -174,7 +211,13 @@ mod tests {
     #[test]
     fn golden_oai_dc_response() {
         let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), Some("oai_dc"));
-        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_get_record(
+            &params,
+            &repo_with_incunabula(),
+            &InMemoryRecordRepository::empty(),
+            &[],
+            &incunabula_lookup(),
+        );
         let expected = golden("get_record_oai_dc.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -182,7 +225,13 @@ mod tests {
     #[test]
     fn golden_oai_datacite_response() {
         let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), Some("oai_datacite"));
-        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_get_record(
+            &params,
+            &repo_with_incunabula(),
+            &InMemoryRecordRepository::empty(),
+            &[],
+            &incunabula_lookup(),
+        );
         let expected = golden("get_record_oai_datacite.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -195,7 +244,13 @@ mod tests {
             Some("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             Some("oai_dc"),
         );
-        let xml = handle_get_record(&params, &InMemoryProjectRepository::new(vec![]), &repo_with_record(), &[]);
+        let xml = handle_get_record(
+            &params,
+            &InMemoryProjectRepository::new(vec![]),
+            &repo_with_record(),
+            &[],
+            &incunabula_lookup(),
+        );
         let expected = golden("get_record_record_oai_dc.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -206,7 +261,13 @@ mod tests {
             Some("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             Some("oai_datacite"),
         );
-        let xml = handle_get_record(&params, &InMemoryProjectRepository::new(vec![]), &repo_with_record(), &[]);
+        let xml = handle_get_record(
+            &params,
+            &InMemoryProjectRepository::new(vec![]),
+            &repo_with_record(),
+            &[],
+            &incunabula_lookup(),
+        );
         let expected = golden("get_record_record_oai_datacite.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -216,14 +277,26 @@ mod tests {
     #[test]
     fn get_record_oai_dc_response_is_valid_oai_pmh() {
         let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), Some("oai_dc"));
-        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_get_record(
+            &params,
+            &repo_with_incunabula(),
+            &InMemoryRecordRepository::empty(),
+            &[],
+            &incunabula_lookup(),
+        );
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 
     #[test]
     fn get_record_oai_datacite_response_is_valid_oai_pmh() {
         let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), Some("oai_datacite"));
-        let xml = handle_get_record(&params, &repo_with_incunabula(), &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_get_record(
+            &params,
+            &repo_with_incunabula(),
+            &InMemoryRecordRepository::empty(),
+            &[],
+            &incunabula_lookup(),
+        );
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 
@@ -233,7 +306,13 @@ mod tests {
             Some("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             Some("oai_dc"),
         );
-        let xml = handle_get_record(&params, &InMemoryProjectRepository::new(vec![]), &repo_with_record(), &[]);
+        let xml = handle_get_record(
+            &params,
+            &InMemoryProjectRepository::new(vec![]),
+            &repo_with_record(),
+            &[],
+            &incunabula_lookup(),
+        );
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 
@@ -243,7 +322,13 @@ mod tests {
             Some("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             Some("oai_datacite"),
         );
-        let xml = handle_get_record(&params, &InMemoryProjectRepository::new(vec![]), &repo_with_record(), &[]);
+        let xml = handle_get_record(
+            &params,
+            &InMemoryProjectRepository::new(vec![]),
+            &repo_with_record(),
+            &[],
+            &incunabula_lookup(),
+        );
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 }

--- a/modules/dpe/api-oai/src/handlers/list_identifiers.rs
+++ b/modules/dpe/api-oai/src/handlers/list_identifiers.rs
@@ -1,6 +1,6 @@
 //! Handler for the OAI-PMH ListIdentifiers verb.
 
-use dpe_core::{ClusterRaw, ProjectRepository, RecordRepository};
+use dpe_core::{ClusterRaw, ContributorLookup, ProjectRepository, RecordRepository};
 
 use super::{build_error_response, build_list_request_params, validate_list_params, OaiParams};
 use crate::xml::OaiXmlBuilder;
@@ -11,8 +11,9 @@ pub fn handle_list_identifiers(
     repo: &dyn ProjectRepository,
     record_repo: &dyn RecordRepository,
     clusters: &[ClusterRaw],
+    lookup: &dyn ContributorLookup,
 ) -> String {
-    let (prefix, records) = match validate_list_params(params, repo, record_repo, clusters) {
+    let (prefix, records) = match validate_list_params(params, repo, record_repo, clusters, lookup) {
         Ok(result) => result,
         Err(err) => return build_error_response(err, Some("ListIdentifiers")),
     };
@@ -34,8 +35,8 @@ pub fn handle_list_identifiers(
 #[cfg(test)]
 mod tests {
     use super::super::test_utils::{
-        cluster_fixture, first_0803_record, golden, incunabula_project, normalize, InMemoryProjectRepository,
-        InMemoryRecordRepository,
+        cluster_fixture, first_0803_record, golden, incunabula_lookup, incunabula_project, normalize,
+        InMemoryProjectRepository, InMemoryRecordRepository,
     };
     use super::*;
 
@@ -57,7 +58,8 @@ mod tests {
     fn missing_metadata_prefix_returns_bad_argument() {
         let params = make_params(None);
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml =
+            handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
         assert!(xml.contains("metadataPrefix argument is required"), "got: {}", xml);
     }
@@ -66,7 +68,8 @@ mod tests {
     fn unsupported_metadata_prefix_returns_cannot_disseminate() {
         let params = make_params(Some("marc21"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml =
+            handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         assert!(xml.contains("<error code=\"cannotDisseminateFormat\">"), "got: {}", xml);
     }
 
@@ -75,7 +78,8 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.resumption_token = Some("some-token".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml =
+            handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         assert!(xml.contains("<error code=\"badResumptionToken\">"), "got: {}", xml);
     }
 
@@ -84,7 +88,8 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("entityType:Unknown".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml =
+            handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
     }
 
@@ -93,7 +98,8 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("entityType:ProjectCluster".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml =
+            handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         assert!(xml.contains("<error code=\"noRecordsMatch\">"), "got: {}", xml);
     }
 
@@ -104,7 +110,7 @@ mod tests {
         params.set = Some("project:0803".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_identifiers(&params, &repo, &record_repo, &[]);
+        let xml = handle_list_identifiers(&params, &repo, &record_repo, &[], &incunabula_lookup());
         assert!(
             xml.contains("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             "record identifier should be present, got: {}",
@@ -125,7 +131,7 @@ mod tests {
         let clusters = vec![cluster_fixture("cluster-001", "EKWS", &["0803"])];
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_identifiers(&params, &repo, &record_repo, &clusters);
+        let xml = handle_list_identifiers(&params, &repo, &record_repo, &clusters, &incunabula_lookup());
         assert!(
             xml.contains("<identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>"),
             "project entry should be present, got: {}",
@@ -143,7 +149,8 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("entityType:Record".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml =
+            handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         assert!(xml.contains("<error code=\"noRecordsMatch\">"), "got: {}", xml);
     }
 
@@ -153,7 +160,7 @@ mod tests {
         params.set = Some("entityType:Record".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_identifiers(&params, &repo, &record_repo, &[]);
+        let xml = handle_list_identifiers(&params, &repo, &record_repo, &[], &incunabula_lookup());
         assert!(
             xml.contains("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             "record identifier should be present, got: {}",
@@ -173,7 +180,8 @@ mod tests {
     fn golden_oai_dc_response() {
         let params = make_params(Some("oai_dc"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml =
+            handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         let expected = golden("list_identifiers_oai_dc.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -182,7 +190,8 @@ mod tests {
     fn golden_oai_datacite_response() {
         let params = make_params(Some("oai_datacite"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml =
+            handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         let expected = golden("list_identifiers_oai_datacite.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -192,7 +201,7 @@ mod tests {
         let params = make_params(Some("oai_dc"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_identifiers(&params, &repo, &record_repo, &[]);
+        let xml = handle_list_identifiers(&params, &repo, &record_repo, &[], &incunabula_lookup());
         let expected = golden("list_identifiers_mixed_oai_dc.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -202,7 +211,13 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("entityType:Record".to_string());
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_identifiers(&params, &InMemoryProjectRepository::new(vec![]), &record_repo, &[]);
+        let xml = handle_list_identifiers(
+            &params,
+            &InMemoryProjectRepository::new(vec![]),
+            &record_repo,
+            &[],
+            &incunabula_lookup(),
+        );
         let expected = golden("list_identifiers_record_only_oai_dc.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -213,7 +228,8 @@ mod tests {
     fn list_identifiers_oai_dc_response_is_valid_oai_pmh() {
         let params = make_params(Some("oai_dc"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml =
+            handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 
@@ -221,7 +237,8 @@ mod tests {
     fn list_identifiers_oai_datacite_response_is_valid_oai_pmh() {
         let params = make_params(Some("oai_datacite"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml =
+            handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 
@@ -230,7 +247,7 @@ mod tests {
         let params = make_params(Some("oai_dc"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_identifiers(&params, &repo, &record_repo, &[]);
+        let xml = handle_list_identifiers(&params, &repo, &record_repo, &[], &incunabula_lookup());
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 
@@ -239,7 +256,13 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("entityType:Record".to_string());
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_identifiers(&params, &InMemoryProjectRepository::new(vec![]), &record_repo, &[]);
+        let xml = handle_list_identifiers(
+            &params,
+            &InMemoryProjectRepository::new(vec![]),
+            &record_repo,
+            &[],
+            &incunabula_lookup(),
+        );
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 }

--- a/modules/dpe/api-oai/src/handlers/list_records.rs
+++ b/modules/dpe/api-oai/src/handlers/list_records.rs
@@ -216,7 +216,13 @@ mod tests {
         params.set = Some("cluster:cluster-001".to_string());
         let clusters = vec![cluster_fixture("cluster-001", "EKWS", &["0803"])];
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &clusters, &incunabula_lookup());
+        let xml = handle_list_records(
+            &params,
+            &repo,
+            &InMemoryRecordRepository::empty(),
+            &clusters,
+            &incunabula_lookup(),
+        );
         assert!(
             xml.contains("<identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>"),
             "project entry should be present even with no records, got: {}",
@@ -232,7 +238,13 @@ mod tests {
         params.set = Some("cluster:cluster-001".to_string());
         let clusters = vec![cluster_fixture("cluster-001", "EKWS", &["9999"])];
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &clusters, &incunabula_lookup());
+        let xml = handle_list_records(
+            &params,
+            &repo,
+            &InMemoryRecordRepository::empty(),
+            &clusters,
+            &incunabula_lookup(),
+        );
         assert!(xml.contains("<error code=\"noRecordsMatch\">"), "got: {}", xml);
     }
 

--- a/modules/dpe/api-oai/src/handlers/list_records.rs
+++ b/modules/dpe/api-oai/src/handlers/list_records.rs
@@ -1,6 +1,6 @@
 //! Handler for the OAI-PMH ListRecords verb.
 
-use dpe_core::{ClusterRaw, ProjectRepository, RecordRepository};
+use dpe_core::{ClusterRaw, ContributorLookup, ProjectRepository, RecordRepository};
 
 use super::{build_error_response, build_list_request_params, validate_list_params, OaiParams};
 use crate::xml::OaiXmlBuilder;
@@ -11,8 +11,9 @@ pub fn handle_list_records(
     repo: &dyn ProjectRepository,
     record_repo: &dyn RecordRepository,
     clusters: &[ClusterRaw],
+    lookup: &dyn ContributorLookup,
 ) -> String {
-    let (prefix, records) = match validate_list_params(params, repo, record_repo, clusters) {
+    let (prefix, records) = match validate_list_params(params, repo, record_repo, clusters, lookup) {
         Ok(result) => result,
         Err(err) => return build_error_response(err, Some("ListRecords")),
     };
@@ -34,8 +35,8 @@ pub fn handle_list_records(
 #[cfg(test)]
 mod tests {
     use super::super::test_utils::{
-        cluster_fixture, first_0803_record, golden, incunabula_project, normalize, InMemoryProjectRepository,
-        InMemoryRecordRepository,
+        cluster_fixture, first_0803_record, golden, incunabula_lookup, incunabula_project, normalize,
+        InMemoryProjectRepository, InMemoryRecordRepository,
     };
     use super::*;
 
@@ -57,7 +58,7 @@ mod tests {
     fn missing_metadata_prefix_returns_bad_argument() {
         let params = make_params(None);
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
         assert!(xml.contains("metadataPrefix argument is required"), "got: {}", xml);
     }
@@ -66,7 +67,7 @@ mod tests {
     fn unsupported_metadata_prefix_returns_cannot_disseminate() {
         let params = make_params(Some("marc21"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         assert!(xml.contains("<error code=\"cannotDisseminateFormat\">"), "got: {}", xml);
     }
 
@@ -75,7 +76,7 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.resumption_token = Some("some-token".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         assert!(xml.contains("<error code=\"badResumptionToken\">"), "got: {}", xml);
     }
 
@@ -84,7 +85,7 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("entityType:Unknown".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
     }
 
@@ -94,7 +95,7 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("entityType:ProjectCluster".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         assert!(xml.contains("<error code=\"noRecordsMatch\">"), "got: {}", xml);
     }
 
@@ -103,7 +104,7 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("project:9999".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
     }
 
@@ -112,7 +113,7 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("cluster:cluster-999".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
     }
 
@@ -122,7 +123,7 @@ mod tests {
         params.set = Some("project:0803".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_records(&params, &repo, &record_repo, &[]);
+        let xml = handle_list_records(&params, &repo, &record_repo, &[], &incunabula_lookup());
         assert!(
             xml.contains("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             "record identifier should be present, got: {}",
@@ -145,7 +146,7 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("project:0803".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         assert!(xml.contains("<error code=\"noRecordsMatch\">"), "got: {}", xml);
     }
 
@@ -154,7 +155,7 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("entityType:Record".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         assert!(xml.contains("<error code=\"noRecordsMatch\">"), "got: {}", xml);
     }
 
@@ -164,7 +165,7 @@ mod tests {
         params.set = Some("entityType:Record".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_records(&params, &repo, &record_repo, &[]);
+        let xml = handle_list_records(&params, &repo, &record_repo, &[], &incunabula_lookup());
         assert!(
             xml.contains("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             "record identifier should be present, got: {}",
@@ -187,7 +188,7 @@ mod tests {
         let clusters = vec![cluster_fixture("cluster-001", "EKWS", &["0803"])];
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_records(&params, &repo, &record_repo, &clusters);
+        let xml = handle_list_records(&params, &repo, &record_repo, &clusters, &incunabula_lookup());
         // project entry present (identifier closes with </identifier>)
         assert!(
             xml.contains("<identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>"),
@@ -215,7 +216,7 @@ mod tests {
         params.set = Some("cluster:cluster-001".to_string());
         let clusters = vec![cluster_fixture("cluster-001", "EKWS", &["0803"])];
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &clusters);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &clusters, &incunabula_lookup());
         assert!(
             xml.contains("<identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>"),
             "project entry should be present even with no records, got: {}",
@@ -231,7 +232,7 @@ mod tests {
         params.set = Some("cluster:cluster-001".to_string());
         let clusters = vec![cluster_fixture("cluster-001", "EKWS", &["9999"])];
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &clusters);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &clusters, &incunabula_lookup());
         assert!(xml.contains("<error code=\"noRecordsMatch\">"), "got: {}", xml);
     }
 
@@ -241,7 +242,7 @@ mod tests {
     fn golden_oai_dc_response() {
         let params = make_params(Some("oai_dc"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         let expected = golden("list_records_oai_dc.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -250,7 +251,7 @@ mod tests {
     fn golden_oai_datacite_response() {
         let params = make_params(Some("oai_datacite"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         let expected = golden("list_records_oai_datacite.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -260,7 +261,7 @@ mod tests {
         let params = make_params(Some("oai_dc"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_records(&params, &repo, &record_repo, &[]);
+        let xml = handle_list_records(&params, &repo, &record_repo, &[], &incunabula_lookup());
         let expected = golden("list_records_mixed_oai_dc.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -270,7 +271,13 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("entityType:Record".to_string());
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_records(&params, &InMemoryProjectRepository::new(vec![]), &record_repo, &[]);
+        let xml = handle_list_records(
+            &params,
+            &InMemoryProjectRepository::new(vec![]),
+            &record_repo,
+            &[],
+            &incunabula_lookup(),
+        );
         let expected = golden("list_records_record_only_oai_dc.xml", &xml);
         assert_eq!(normalize(&xml), expected);
     }
@@ -281,7 +288,7 @@ mod tests {
     fn list_records_oai_dc_response_is_valid_oai_pmh() {
         let params = make_params(Some("oai_dc"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 
@@ -289,7 +296,7 @@ mod tests {
     fn list_records_oai_datacite_response_is_valid_oai_pmh() {
         let params = make_params(Some("oai_datacite"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
-        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[]);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 
@@ -298,7 +305,7 @@ mod tests {
         let params = make_params(Some("oai_dc"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_records(&params, &repo, &record_repo, &[]);
+        let xml = handle_list_records(&params, &repo, &record_repo, &[], &incunabula_lookup());
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 
@@ -307,7 +314,13 @@ mod tests {
         let mut params = make_params(Some("oai_dc"));
         params.set = Some("entityType:Record".to_string());
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
-        let xml = handle_list_records(&params, &InMemoryProjectRepository::new(vec![]), &record_repo, &[]);
+        let xml = handle_list_records(
+            &params,
+            &InMemoryProjectRepository::new(vec![]),
+            &record_repo,
+            &[],
+            &incunabula_lookup(),
+        );
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 }

--- a/modules/dpe/api-oai/src/handlers/mod.rs
+++ b/modules/dpe/api-oai/src/handlers/mod.rs
@@ -19,7 +19,8 @@ use axum::extract::Query;
 use axum::http::{header, StatusCode};
 use axum::response::IntoResponse;
 use dpe_core::{
-    cluster_cache, ClusterRaw, FsProjectRepository, FsRecordRepository, ProjectRepository, RecordRepository,
+    cluster_cache, CachedContributorLookup, ClusterRaw, ContributorLookup, FsProjectRepository, FsRecordRepository,
+    ProjectRepository, RecordRepository,
 };
 use get_record::handle_get_record;
 use identify::handle_identify;
@@ -57,14 +58,15 @@ pub async fn oai_handler(Query(params): Query<OaiParams>) -> impl IntoResponse {
     let repo = FsProjectRepository::new();
     let record_repo = FsRecordRepository::new();
     let clusters = cluster_cache::all_clusters();
+    let lookup = CachedContributorLookup;
 
     let xml = match params.verb.as_deref() {
         Some("Identify") => handle_identify(&params, &repo),
         Some("ListMetadataFormats") => handle_list_metadata_formats(&params, &repo),
         Some("ListSets") => handle_list_sets(&params, &repo, clusters),
-        Some("ListIdentifiers") => handle_list_identifiers(&params, &repo, &record_repo, clusters),
-        Some("ListRecords") => handle_list_records(&params, &repo, &record_repo, clusters),
-        Some("GetRecord") => handle_get_record(&params, &repo, &record_repo, clusters),
+        Some("ListIdentifiers") => handle_list_identifiers(&params, &repo, &record_repo, clusters, &lookup),
+        Some("ListRecords") => handle_list_records(&params, &repo, &record_repo, clusters, &lookup),
+        Some("GetRecord") => handle_get_record(&params, &repo, &record_repo, clusters, &lookup),
         Some(_) => build_error_response(OaiError::BadVerb, None),
         None => build_error_response(OaiError::BadVerb, None),
     };
@@ -140,6 +142,7 @@ pub fn validate_list_params<'a>(
     repo: &dyn ProjectRepository,
     record_repo: &dyn RecordRepository,
     clusters: &[ClusterRaw],
+    lookup: &dyn ContributorLookup,
 ) -> Result<(&'a str, Vec<OaiRecord>), OaiError> {
     // metadataPrefix is required. Validated BEFORE the set, so a request that is
     // missing/invalid in both reports the prefix error (precedence preserved).
@@ -170,7 +173,7 @@ pub fn validate_list_params<'a>(
     let until = params.until.as_deref();
 
     let oai_records = match syntax {
-        SetSyntax::All => collect_entities(repo, record_repo, prefix, clusters, from, until, true, true),
+        SetSyntax::All => collect_entities(repo, record_repo, prefix, clusters, lookup, from, until, true, true),
         SetSyntax::EntityType {
             projects: include_projects,
             records: include_records,
@@ -182,6 +185,7 @@ pub fn validate_list_params<'a>(
             record_repo,
             prefix,
             clusters,
+            lookup,
             from,
             until,
             include_projects,
@@ -206,7 +210,7 @@ pub fn validate_list_params<'a>(
             let Some(member_shortcodes) = cluster_cache::projects_for_cluster_in(clusters, &id) else {
                 return Err(OaiError::BadArgument(format!("unknown cluster set: cluster:{id}")));
             };
-            collect_cluster(repo, record_repo, prefix, clusters, from, until, member_shortcodes)
+            collect_cluster(repo, record_repo, prefix, clusters, lookup, from, until, member_shortcodes)
         }
     };
 
@@ -224,6 +228,7 @@ fn collect_entities(
     record_repo: &dyn RecordRepository,
     prefix: &str,
     clusters: &[ClusterRaw],
+    lookup: &dyn ContributorLookup,
     from: Option<&str>,
     until: Option<&str>,
     include_projects: bool,
@@ -233,7 +238,7 @@ fn collect_entities(
         repo.get_all()
             .iter()
             .filter(|p| matches_date_filter(p, from, until))
-            .map(|p| to_oai_record(p, prefix, clusters))
+            .map(|p| to_oai_record(p, prefix, clusters, lookup))
             .collect()
     } else {
         Vec::new()
@@ -256,11 +261,13 @@ fn collect_entities(
 /// cluster member (and which exist in the repository) plus all their records.
 /// Project entries are deduplicated by shortcode and records by ARK suffix, so a
 /// shortcode listed more than once does not produce duplicate items (REQ-2.5).
+#[allow(clippy::too_many_arguments)]
 fn collect_cluster(
     repo: &dyn ProjectRepository,
     record_repo: &dyn RecordRepository,
     prefix: &str,
     clusters: &[ClusterRaw],
+    lookup: &dyn ContributorLookup,
     from: Option<&str>,
     until: Option<&str>,
     member_shortcodes: &[String],
@@ -284,7 +291,7 @@ fn collect_cluster(
                 true
             }
         })
-        .map(|p| to_oai_record(p, prefix, clusters))
+        .map(|p| to_oai_record(p, prefix, clusters, lookup))
         .collect();
 
     // Records of member projects, deduplicated by ARK suffix.

--- a/modules/dpe/api-oai/src/handlers/test_utils.rs
+++ b/modules/dpe/api-oai/src/handlers/test_utils.rs
@@ -49,7 +49,7 @@ pub fn incunabula_person() -> Person {
         given_names: vec!["Heinrich".to_string()],
         family_names: vec!["Holzmann".to_string()],
         job_titles: vec!["Professor".to_string()],
-        affiliations: vec!["0803-organization-000".to_string()],
+        affiliations: vec!["organization-000".to_string()],
         same_as: vec![AuthorityFileReference {
             type_: "ORCID".to_string(),
             url: "https://orcid.org/0000-0002-1825-0097".to_string(),
@@ -74,10 +74,10 @@ pub fn incunabula_project_leader() -> Person {
 }
 
 /// Builds an organization fixture matching the incunabula affiliation and funder
-/// `0803-organization-000`.
+/// `organization-000`.
 pub fn incunabula_organization() -> Organization {
     Organization {
-        id: "0803-organization-000".to_string(),
+        id: "organization-000".to_string(),
         name: "Universität Basel".to_string(),
         same_as: vec![],
         url: "https://www.unibas.ch/".to_string(),
@@ -191,7 +191,7 @@ pub fn incunabula_project() -> Project {
                 contributor_type: vec!["Project Leader".to_string()],
             },
             Attribution {
-                contributor: "0803-organization-000".to_string(),
+                contributor: "organization-000".to_string(),
                 contributor_type: vec!["Hosting Institution".to_string()],
             },
         ],
@@ -206,7 +206,7 @@ pub fn incunabula_project() -> Project {
         contact_point: None,
         publications: None,
         funding: Funding::Grants(vec![Grant {
-            funders: vec!["0803-organization-000".to_string()],
+            funders: vec!["organization-000".to_string()],
             number: Some("120378".to_string()),
             name: Some("Project funding".to_string()),
             url: Some("https://data.snf.ch/grants/grant/120378".to_string()),

--- a/modules/dpe/api-oai/src/handlers/test_utils.rs
+++ b/modules/dpe/api-oai/src/handlers/test_utils.rs
@@ -1,11 +1,99 @@
 #![cfg(test)]
 
+use std::collections::HashMap;
+
 use dpe_core::models::AuthorityFileReference;
 use dpe_core::project::{
     AccessRights, AccessRightsType, Attribution, Discipline, Funding, Grant, LegalInfo, License, Project,
     ProjectStatus, TemporalCoverage,
 };
-use dpe_core::{ClusterRaw, ProjectRepository, Record, RecordRepository};
+use dpe_core::{ClusterRaw, ContributorLookup, Organization, Person, ProjectRepository, Record, RecordRepository};
+
+/// In-memory contributor lookup for testing.
+#[derive(Default)]
+pub struct InMemoryContributorLookup {
+    persons: HashMap<String, Person>,
+    organizations: HashMap<String, Organization>,
+}
+
+impl InMemoryContributorLookup {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn with_person(mut self, person: Person) -> Self {
+        self.persons.insert(person.id.clone(), person);
+        self
+    }
+
+    pub fn with_organization(mut self, org: Organization) -> Self {
+        self.organizations.insert(org.id.clone(), org);
+        self
+    }
+}
+
+impl ContributorLookup for InMemoryContributorLookup {
+    fn person(&self, id: &str) -> Option<Person> {
+        self.persons.get(id).cloned()
+    }
+
+    fn organization(&self, id: &str) -> Option<Organization> {
+        self.organizations.get(id).cloned()
+    }
+}
+
+/// Builds a person fixture matching the incunabula project attribution `0803-person-000`.
+pub fn incunabula_person() -> Person {
+    Person {
+        id: "0803-person-000".to_string(),
+        given_names: vec!["Heinrich".to_string()],
+        family_names: vec!["Holzmann".to_string()],
+        job_titles: vec!["Professor".to_string()],
+        affiliations: vec!["0803-organization-000".to_string()],
+        same_as: vec![AuthorityFileReference {
+            type_: "ORCID".to_string(),
+            url: "https://orcid.org/0000-0002-1825-0097".to_string(),
+            text: None,
+        }],
+        email: None,
+    }
+}
+
+/// Builds a person fixture matching the incunabula project-leader attribution
+/// `0803-person-001`.
+pub fn incunabula_project_leader() -> Person {
+    Person {
+        id: "0803-person-001".to_string(),
+        given_names: vec!["Susanne".to_string()],
+        family_names: vec!["Vogel".to_string()],
+        job_titles: vec![],
+        affiliations: vec![],
+        same_as: vec![],
+        email: None,
+    }
+}
+
+/// Builds an organization fixture matching the incunabula affiliation and funder
+/// `0803-organization-000`.
+pub fn incunabula_organization() -> Organization {
+    Organization {
+        id: "0803-organization-000".to_string(),
+        name: "Universität Basel".to_string(),
+        same_as: vec![],
+        url: "https://www.unibas.ch/".to_string(),
+        address: None,
+        email: None,
+        alternative_name: None,
+    }
+}
+
+/// Contributor lookup pre-populated with the incunabula person and organization.
+pub fn incunabula_lookup() -> InMemoryContributorLookup {
+    InMemoryContributorLookup::empty()
+        .with_person(incunabula_person())
+        .with_person(incunabula_project_leader())
+        .with_organization(incunabula_organization())
+}
 
 /// In-memory repository for testing.
 pub struct InMemoryProjectRepository {
@@ -93,10 +181,20 @@ pub fn incunabula_project() -> Project {
             url: "https://www.geonames.org/2661604/basel.html".to_string(),
             text: Some("Basel".to_string()),
         }],
-        attributions: vec![Attribution {
-            contributor: "0803-person-000".to_string(),
-            contributor_type: vec!["Applicant".to_string()],
-        }],
+        attributions: vec![
+            Attribution {
+                contributor: "0803-person-000".to_string(),
+                contributor_type: vec!["Applicant".to_string()],
+            },
+            Attribution {
+                contributor: "0803-person-001".to_string(),
+                contributor_type: vec!["Project Leader".to_string()],
+            },
+            Attribution {
+                contributor: "0803-organization-000".to_string(),
+                contributor_type: vec!["Hosting Institution".to_string()],
+            },
+        ],
         abstract_text: Some({
             let mut map = std::collections::HashMap::new();
             map.insert(

--- a/modules/dpe/api-oai/src/metadata/datacite.rs
+++ b/modules/dpe/api-oai/src/metadata/datacite.rs
@@ -1,11 +1,12 @@
 //! Transformation of Research Projects into DataCite 4.6 metadata.
 
-use dpe_core::{Discipline, Funding, Project, TemporalCoverage};
+use dpe_core::{ContributorLookup, Discipline, Funding, Project, TemporalCoverage};
 
 use super::helpers::{
     access_rights_to_string, extract_year, format_date_range, get_multilingual_value, infer_subject_scheme, is_creator,
     license_identifier_to_label, map_contributor_type,
 };
+use super::resolve::resolve_agent;
 use super::types::{
     DataCiteContributor, DataCiteCreator, DataCiteDate, DataCiteDescription, DataCiteFundingReference,
     DataCiteGeoLocation, DataCiteRecord, DataCiteRights, DataCiteSubject, DataCiteTitle,
@@ -13,7 +14,7 @@ use super::types::{
 
 const PUBLISHER: &str = "DaSCH";
 
-pub fn project_to_datacite(project: &Project) -> DataCiteRecord {
+pub fn project_to_datacite(project: &Project, lookup: &dyn ContributorLookup) -> DataCiteRecord {
     let mut record = DataCiteRecord::default();
 
     // Identifier (mandatory) - use PID or generate from shortcode
@@ -28,9 +29,14 @@ pub fn project_to_datacite(project: &Project) -> DataCiteRecord {
     // Creators (mandatory) - principal investigators and project leaders
     for attr in &project.attributions {
         if is_creator(&attr.contributor_type) {
+            let agent = resolve_agent(&attr.contributor, lookup);
             record.creators.push(DataCiteCreator {
-                name: attr.contributor.clone(),
-                name_type: Some("Personal".to_string()),
+                name: agent.name,
+                name_type: Some(agent.name_type.to_string()),
+                given_name: agent.given_name,
+                family_name: agent.family_name,
+                name_identifiers: agent.name_identifiers,
+                affiliations: agent.affiliations,
             });
         }
     }
@@ -39,6 +45,7 @@ pub fn project_to_datacite(project: &Project) -> DataCiteRecord {
         record.creators.push(DataCiteCreator {
             name: "DaSCH".to_string(),
             name_type: Some("Organizational".to_string()),
+            ..Default::default()
         });
     }
 
@@ -50,10 +57,15 @@ pub fn project_to_datacite(project: &Project) -> DataCiteRecord {
                 .first()
                 .map(|t| map_contributor_type(t))
                 .unwrap_or("Other");
+            let agent = resolve_agent(&attr.contributor, lookup);
             record.contributors.push(DataCiteContributor {
-                name: attr.contributor.clone(),
-                name_type: Some("Personal".to_string()),
+                name: agent.name,
+                name_type: Some(agent.name_type.to_string()),
                 contributor_type: datacite_type.to_string(),
+                given_name: agent.given_name,
+                family_name: agent.family_name,
+                name_identifiers: agent.name_identifiers,
+                affiliations: agent.affiliations,
             });
         }
     }
@@ -246,14 +258,12 @@ pub fn project_to_datacite(project: &Project) -> DataCiteRecord {
         }
     }
 
-    // FundingReferences from grants
-    // Note: funder names are currently internal IDs (e.g., "0801-organization-000"),
-    // not human-readable names. This is a data quality issue to resolve upstream.
+    // FundingReferences from grants; funder IDs resolved to organization names
     if let Funding::Grants(ref grants) = project.funding {
         for grant in grants {
             for funder in &grant.funders {
                 record.funding_references.push(DataCiteFundingReference {
-                    funder_name: funder.clone(),
+                    funder_name: resolve_agent(funder, lookup).name,
                     award_number: grant.number.clone(),
                     award_title: grant.name.clone(),
                     award_uri: grant.url.clone(),

--- a/modules/dpe/api-oai/src/metadata/dublin_core.rs
+++ b/modules/dpe/api-oai/src/metadata/dublin_core.rs
@@ -1,13 +1,14 @@
 //! Transformation of Research Projects into Dublin Core metadata.
 
-use dpe_core::{Discipline, Project, TemporalCoverage};
+use dpe_core::{ContributorLookup, Discipline, Project, TemporalCoverage};
 
 use super::helpers::{access_rights_to_string, get_multilingual_value, is_creator};
+use super::resolve::resolve_agent;
 use super::types::DublinCoreRecord;
 
 const PUBLISHER: &str = "DaSCH";
 
-pub fn project_to_dublin_core(project: &Project) -> DublinCoreRecord {
+pub fn project_to_dublin_core(project: &Project, lookup: &dyn ContributorLookup) -> DublinCoreRecord {
     let mut record = DublinCoreRecord::default();
 
     // dc:title - prefer officialName, fallback to name
@@ -65,17 +66,18 @@ pub fn project_to_dublin_core(project: &Project) -> DublinCoreRecord {
         }
     }
 
-    // dc:creator from attributions (principal investigators and project leaders)
+    // dc:creator from attributions (principal investigators and project leaders),
+    // resolved to display names
     for attr in &project.attributions {
         if is_creator(&attr.contributor_type) {
-            record.creators.push(attr.contributor.clone());
+            record.creators.push(resolve_agent(&attr.contributor, lookup).name);
         }
     }
 
-    // dc:contributor from other attributions
+    // dc:contributor from other attributions, resolved to display names
     for attr in &project.attributions {
         if !is_creator(&attr.contributor_type) {
-            record.contributors.push(attr.contributor.clone());
+            record.contributors.push(resolve_agent(&attr.contributor, lookup).name);
         }
     }
 

--- a/modules/dpe/api-oai/src/metadata/mod.rs
+++ b/modules/dpe/api-oai/src/metadata/mod.rs
@@ -9,15 +9,16 @@ mod dublin_core;
 mod helpers;
 mod record_datacite;
 mod record_dublin_core;
+mod resolve;
 mod types;
 
 use datacite::project_to_datacite;
 use dpe_core::cluster_cache::clusters_for_shortcode_in;
-use dpe_core::{record_datestamp, ClusterRaw, Project, Record, ARK_PATH_PREFIX};
+use dpe_core::{record_datestamp, ClusterRaw, ContributorLookup, Project, Record, ARK_PATH_PREFIX};
 use dublin_core::project_to_dublin_core;
 use record_datacite::record_to_datacite;
 use record_dublin_core::record_to_dublin_core;
-pub use types::{DataCiteRecord, DublinCoreRecord, OaiRecord, OaiRecordHeader};
+pub use types::{DataCiteNameIdentifier, DataCiteRecord, DublinCoreRecord, OaiRecord, OaiRecordHeader};
 
 const OAI_IDENTIFIER_PREFIX: &str = "oai:meta.dasch.swiss:";
 
@@ -56,7 +57,12 @@ fn membership_set_specs(entity_type: &str, shortcode: &str, clusters: &[ClusterR
 }
 
 /// Creates an OAI record from a project for the given metadata prefix.
-pub fn to_oai_record(project: &Project, metadata_prefix: &str, clusters: &[ClusterRaw]) -> OaiRecord {
+pub fn to_oai_record(
+    project: &Project,
+    metadata_prefix: &str,
+    clusters: &[ClusterRaw],
+    lookup: &dyn ContributorLookup,
+) -> OaiRecord {
     let identifier = if !dpe_core::is_placeholder(&project.pid) && !project.pid.is_empty() {
         make_oai_identifier_from_pid(&project.pid).unwrap_or_else(|| make_oai_identifier(&project.shortcode))
     } else {
@@ -73,13 +79,13 @@ pub fn to_oai_record(project: &Project, metadata_prefix: &str, clusters: &[Clust
     };
 
     let dublin_core = if metadata_prefix == "oai_dc" {
-        Some(project_to_dublin_core(project))
+        Some(project_to_dublin_core(project, lookup))
     } else {
         None
     };
 
     let datacite = if metadata_prefix == "oai_datacite" {
-        Some(project_to_datacite(project))
+        Some(project_to_datacite(project, lookup))
     } else {
         None
     };

--- a/modules/dpe/api-oai/src/metadata/record_datacite.rs
+++ b/modules/dpe/api-oai/src/metadata/record_datacite.rs
@@ -27,12 +27,17 @@ pub fn record_to_datacite(record: &Record) -> DataCiteRecord {
         .legal_info
         .authorship
         .iter()
-        .map(|name| DataCiteCreator { name: name.clone(), name_type: Some("Personal".to_string()) })
+        .map(|name| DataCiteCreator {
+            name: name.clone(),
+            name_type: Some("Personal".to_string()),
+            ..Default::default()
+        })
         .collect();
     if creators.is_empty() {
         creators.push(DataCiteCreator {
             name: PUBLISHER.to_string(),
             name_type: Some("Organizational".to_string()),
+            ..Default::default()
         });
     }
 

--- a/modules/dpe/api-oai/src/metadata/resolve.rs
+++ b/modules/dpe/api-oai/src/metadata/resolve.rs
@@ -1,0 +1,245 @@
+//! Resolution of internal contributor IDs (e.g. `person-028`,
+//! `0803-organization-000`) to person and organization details for
+//! metadata output.
+
+use dpe_core::{is_organization_id, ContributorLookup, Person};
+
+use super::types::DataCiteNameIdentifier;
+
+/// Name details for a creator, contributor, or funder resolved from an
+/// internal ID.
+pub struct ResolvedAgent {
+    /// Display name: `Family, Given` for persons, the organization name for
+    /// organizations, or the raw ID if unresolvable.
+    pub name: String,
+    /// DataCite nameType: `Personal` or `Organizational`.
+    pub name_type: &'static str,
+    pub given_name: Option<String>,
+    pub family_name: Option<String>,
+    pub name_identifiers: Vec<DataCiteNameIdentifier>,
+    /// Resolved affiliation organization names.
+    pub affiliations: Vec<String>,
+}
+
+/// Resolves a contributor ID to name details. Unresolvable IDs fall back to
+/// the raw ID so no attribution is lost.
+pub fn resolve_agent(id: &str, lookup: &dyn ContributorLookup) -> ResolvedAgent {
+    if is_organization_id(id) {
+        if let Some(org) = lookup.organization(id) {
+            return ResolvedAgent {
+                name: org.name,
+                name_type: "Organizational",
+                given_name: None,
+                family_name: None,
+                name_identifiers: vec![],
+                affiliations: vec![],
+            };
+        }
+    } else if let Some(person) = lookup.person(id) {
+        return person_to_agent(&person, lookup);
+    }
+
+    ResolvedAgent {
+        name: id.to_string(),
+        name_type: if is_organization_id(id) {
+            "Organizational"
+        } else {
+            "Personal"
+        },
+        given_name: None,
+        family_name: None,
+        name_identifiers: vec![],
+        affiliations: vec![],
+    }
+}
+
+fn person_to_agent(person: &Person, lookup: &dyn ContributorLookup) -> ResolvedAgent {
+    let given_name = non_empty(person.given_names.join(" "));
+    let family_name = non_empty(person.family_names.join(" "));
+
+    let name = match (&family_name, &given_name) {
+        (Some(family), Some(given)) => format!("{}, {}", family, given),
+        (Some(family), None) => family.clone(),
+        (None, Some(given)) => given.clone(),
+        (None, None) => person.id.clone(),
+    };
+
+    let name_identifiers = person
+        .same_as
+        .iter()
+        .filter_map(|r| {
+            let scheme_uri = match r.type_.as_str() {
+                "ORCID" => "https://orcid.org",
+                "GND" => "https://d-nb.info/gnd",
+                _ => return None,
+            };
+            Some(DataCiteNameIdentifier {
+                identifier: r.url.clone(),
+                scheme: r.type_.clone(),
+                scheme_uri: Some(scheme_uri.to_string()),
+            })
+        })
+        .collect();
+
+    let affiliations = person
+        .affiliations
+        .iter()
+        .filter_map(|aff_id| lookup.organization(aff_id).map(|org| org.name))
+        .collect();
+
+    ResolvedAgent {
+        name,
+        name_type: "Personal",
+        given_name,
+        family_name,
+        name_identifiers,
+        affiliations,
+    }
+}
+
+fn non_empty(s: String) -> Option<String> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dpe_core::models::AuthorityFileReference;
+    use dpe_core::{Organization, Person};
+
+    use super::*;
+    use crate::handlers::test_utils::InMemoryContributorLookup;
+
+    fn person(id: &str) -> Person {
+        Person {
+            id: id.to_string(),
+            given_names: vec!["Anna".to_string()],
+            family_names: vec!["Müller".to_string()],
+            job_titles: vec![],
+            affiliations: vec![],
+            same_as: vec![],
+            email: None,
+        }
+    }
+
+    fn organization(id: &str, name: &str) -> Organization {
+        Organization {
+            id: id.to_string(),
+            name: name.to_string(),
+            same_as: vec![],
+            url: String::new(),
+            address: None,
+            email: None,
+            alternative_name: None,
+        }
+    }
+
+    #[test]
+    fn resolves_person_to_family_comma_given() {
+        let lookup = InMemoryContributorLookup::empty().with_person(person("person-001"));
+        let agent = resolve_agent("person-001", &lookup);
+        assert_eq!(agent.name, "Müller, Anna");
+        assert_eq!(agent.name_type, "Personal");
+        assert_eq!(agent.given_name.as_deref(), Some("Anna"));
+        assert_eq!(agent.family_name.as_deref(), Some("Müller"));
+    }
+
+    #[test]
+    fn joins_multiple_given_and_family_names_with_spaces() {
+        let mut p = person("person-001");
+        p.given_names = vec!["Anna".to_string(), "Maria".to_string()];
+        p.family_names = vec!["Roca".to_string(), "Escoda".to_string()];
+        let lookup = InMemoryContributorLookup::empty().with_person(p);
+        let agent = resolve_agent("person-001", &lookup);
+        assert_eq!(agent.name, "Roca Escoda, Anna Maria");
+        assert_eq!(agent.given_name.as_deref(), Some("Anna Maria"));
+        assert_eq!(agent.family_name.as_deref(), Some("Roca Escoda"));
+    }
+
+    #[test]
+    fn maps_orcid_and_gnd_but_not_url_to_name_identifiers() {
+        let mut p = person("person-001");
+        p.same_as = vec![
+            AuthorityFileReference {
+                type_: "ORCID".to_string(),
+                url: "https://orcid.org/0000-0002-1825-0097".to_string(),
+                text: None,
+            },
+            AuthorityFileReference {
+                type_: "GND".to_string(),
+                url: "https://d-nb.info/gnd/118540238".to_string(),
+                text: None,
+            },
+            AuthorityFileReference {
+                type_: "URL".to_string(),
+                url: "https://example.com/anna".to_string(),
+                text: None,
+            },
+        ];
+        let lookup = InMemoryContributorLookup::empty().with_person(p);
+        let agent = resolve_agent("person-001", &lookup);
+        assert_eq!(agent.name_identifiers.len(), 2);
+        assert_eq!(agent.name_identifiers[0].scheme, "ORCID");
+        assert_eq!(agent.name_identifiers[0].identifier, "https://orcid.org/0000-0002-1825-0097");
+        assert_eq!(agent.name_identifiers[0].scheme_uri.as_deref(), Some("https://orcid.org"));
+        assert_eq!(agent.name_identifiers[1].scheme, "GND");
+        assert_eq!(agent.name_identifiers[1].scheme_uri.as_deref(), Some("https://d-nb.info/gnd"));
+    }
+
+    #[test]
+    fn resolves_affiliations_to_organization_names() {
+        let mut p = person("person-001");
+        p.affiliations = vec!["organization-001".to_string(), "organization-999".to_string()];
+        let lookup = InMemoryContributorLookup::empty()
+            .with_person(p)
+            .with_organization(organization("organization-001", "Université de Lausanne"));
+        let agent = resolve_agent("person-001", &lookup);
+        // Unresolvable affiliation IDs are skipped, not emitted as raw IDs.
+        assert_eq!(agent.affiliations, vec!["Université de Lausanne"]);
+    }
+
+    #[test]
+    fn resolves_organization_contributor() {
+        let lookup = InMemoryContributorLookup::empty()
+            .with_organization(organization("0803-organization-000", "Universität Basel"));
+        let agent = resolve_agent("0803-organization-000", &lookup);
+        assert_eq!(agent.name, "Universität Basel");
+        assert_eq!(agent.name_type, "Organizational");
+        assert_eq!(agent.given_name, None);
+        assert_eq!(agent.family_name, None);
+    }
+
+    #[test]
+    fn unresolvable_person_id_falls_back_to_raw_id() {
+        let lookup = InMemoryContributorLookup::empty();
+        let agent = resolve_agent("person-028", &lookup);
+        assert_eq!(agent.name, "person-028");
+        assert_eq!(agent.name_type, "Personal");
+        assert!(agent.name_identifiers.is_empty());
+        assert!(agent.affiliations.is_empty());
+    }
+
+    #[test]
+    fn unresolvable_organization_id_falls_back_to_raw_id() {
+        let lookup = InMemoryContributorLookup::empty();
+        let agent = resolve_agent("0803-organization-000", &lookup);
+        assert_eq!(agent.name, "0803-organization-000");
+        assert_eq!(agent.name_type, "Organizational");
+    }
+
+    #[test]
+    fn person_with_no_names_falls_back_to_id_as_name() {
+        let mut p = person("person-001");
+        p.given_names = vec![];
+        p.family_names = vec![];
+        let lookup = InMemoryContributorLookup::empty().with_person(p);
+        let agent = resolve_agent("person-001", &lookup);
+        assert_eq!(agent.name, "person-001");
+        assert_eq!(agent.given_name, None);
+        assert_eq!(agent.family_name, None);
+    }
+}

--- a/modules/dpe/api-oai/src/metadata/resolve.rs
+++ b/modules/dpe/api-oai/src/metadata/resolve.rs
@@ -1,5 +1,5 @@
 //! Resolution of internal contributor IDs (e.g. `person-028`,
-//! `0803-organization-000`) to person and organization details for
+//! `organization-001`) to person and organization details for
 //! metadata output.
 
 use dpe_core::{is_organization_id, ContributorLookup, Person};
@@ -204,9 +204,9 @@ mod tests {
 
     #[test]
     fn resolves_organization_contributor() {
-        let lookup = InMemoryContributorLookup::empty()
-            .with_organization(organization("0803-organization-000", "Universität Basel"));
-        let agent = resolve_agent("0803-organization-000", &lookup);
+        let lookup =
+            InMemoryContributorLookup::empty().with_organization(organization("organization-000", "Universität Basel"));
+        let agent = resolve_agent("organization-000", &lookup);
         assert_eq!(agent.name, "Universität Basel");
         assert_eq!(agent.name_type, "Organizational");
         assert_eq!(agent.given_name, None);
@@ -226,8 +226,8 @@ mod tests {
     #[test]
     fn unresolvable_organization_id_falls_back_to_raw_id() {
         let lookup = InMemoryContributorLookup::empty();
-        let agent = resolve_agent("0803-organization-000", &lookup);
-        assert_eq!(agent.name, "0803-organization-000");
+        let agent = resolve_agent("organization-000", &lookup);
+        assert_eq!(agent.name, "organization-000");
         assert_eq!(agent.name_type, "Organizational");
     }
 

--- a/modules/dpe/api-oai/src/metadata/types.rs
+++ b/modules/dpe/api-oai/src/metadata/types.rs
@@ -44,6 +44,10 @@ pub struct DataCiteRecord {
 pub struct DataCiteCreator {
     pub name: String,
     pub name_type: Option<String>,
+    pub given_name: Option<String>,
+    pub family_name: Option<String>,
+    pub name_identifiers: Vec<DataCiteNameIdentifier>,
+    pub affiliations: Vec<String>,
 }
 
 #[derive(Debug, Default)]
@@ -51,6 +55,18 @@ pub struct DataCiteContributor {
     pub name: String,
     pub name_type: Option<String>,
     pub contributor_type: String,
+    pub given_name: Option<String>,
+    pub family_name: Option<String>,
+    pub name_identifiers: Vec<DataCiteNameIdentifier>,
+    pub affiliations: Vec<String>,
+}
+
+/// A nameIdentifier element (e.g. ORCID or GND) for a creator or contributor.
+#[derive(Debug, Default)]
+pub struct DataCiteNameIdentifier {
+    pub identifier: String,
+    pub scheme: String,
+    pub scheme_uri: Option<String>,
 }
 
 #[derive(Debug, Default)]

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_oai_datacite.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_oai_datacite.xml
@@ -18,7 +18,9 @@
               <identifier identifierType="ARK">https://ark.dasch.swiss/ark:/72163/1/0803</identifier>
               <creators>
                 <creator>
-                  <creatorName nameType="Organizational">DaSCH</creatorName>
+                  <creatorName nameType="Personal">Vogel, Susanne</creatorName>
+                  <givenName>Susanne</givenName>
+                  <familyName>Vogel</familyName>
                 </creator>
               </creators>
               <titles>
@@ -34,7 +36,14 @@
               </subjects>
               <contributors>
                 <contributor contributorType="Other">
-                  <contributorName nameType="Personal">0803-person-000</contributorName>
+                  <contributorName nameType="Personal">Holzmann, Heinrich</contributorName>
+                  <givenName>Heinrich</givenName>
+                  <familyName>Holzmann</familyName>
+                  <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org">https://orcid.org/0000-0002-1825-0097</nameIdentifier>
+                  <affiliation>Universität Basel</affiliation>
+                </contributor>
+                <contributor contributorType="HostingInstitution">
+                  <contributorName nameType="Organizational">Universität Basel</contributorName>
                 </contributor>
               </contributors>
               <descriptions>
@@ -56,7 +65,7 @@
               </geoLocations>
               <fundingReferences>
                 <fundingReference>
-                  <funderName>0803-organization-000</funderName>
+                  <funderName>Universität Basel</funderName>
                   <awardNumber awardURI="https://data.snf.ch/grants/grant/120378">120378</awardNumber>
                   <awardTitle>Project funding</awardTitle>
                 </fundingReference>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_oai_dc.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_oai_dc.xml
@@ -13,12 +13,14 @@
         <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
           <dc:title>Die Bilderfolgen der Basler Frühdrucke: Spätmittelalterliche Didaxe als Bild-Text-Lektüre</dc:title>
           <dc:title>Incunabula</dc:title>
+          <dc:creator>Vogel, Susanne</dc:creator>
           <dc:subject>Letterpress Printing</dc:subject>
           <dc:subject>10404 Visual arts and Art history</dc:subject>
           <dc:description>A description of early prints in Basel.</dc:description>
           <dc:description>An interdisciplinary research project on image sequences of Basel&apos;s early prints.</dc:description>
           <dc:publisher>DaSCH</dc:publisher>
-          <dc:contributor>0803-person-000</dc:contributor>
+          <dc:contributor>Holzmann, Heinrich</dc:contributor>
+          <dc:contributor>Universität Basel</dc:contributor>
           <dc:date>2008-06-01</dc:date>
           <dc:type>Project</dc:type>
           <dc:identifier>https://ark.dasch.swiss/ark:/72163/1/0803</dc:identifier>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_mixed_oai_dc.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_mixed_oai_dc.xml
@@ -13,12 +13,14 @@
         <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
           <dc:title>Die Bilderfolgen der Basler Frühdrucke: Spätmittelalterliche Didaxe als Bild-Text-Lektüre</dc:title>
           <dc:title>Incunabula</dc:title>
+          <dc:creator>Vogel, Susanne</dc:creator>
           <dc:subject>Letterpress Printing</dc:subject>
           <dc:subject>10404 Visual arts and Art history</dc:subject>
           <dc:description>A description of early prints in Basel.</dc:description>
           <dc:description>An interdisciplinary research project on image sequences of Basel&apos;s early prints.</dc:description>
           <dc:publisher>DaSCH</dc:publisher>
-          <dc:contributor>0803-person-000</dc:contributor>
+          <dc:contributor>Holzmann, Heinrich</dc:contributor>
+          <dc:contributor>Universität Basel</dc:contributor>
           <dc:date>2008-06-01</dc:date>
           <dc:type>Project</dc:type>
           <dc:identifier>https://ark.dasch.swiss/ark:/72163/1/0803</dc:identifier>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_oai_datacite.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_oai_datacite.xml
@@ -18,7 +18,9 @@
               <identifier identifierType="ARK">https://ark.dasch.swiss/ark:/72163/1/0803</identifier>
               <creators>
                 <creator>
-                  <creatorName nameType="Organizational">DaSCH</creatorName>
+                  <creatorName nameType="Personal">Vogel, Susanne</creatorName>
+                  <givenName>Susanne</givenName>
+                  <familyName>Vogel</familyName>
                 </creator>
               </creators>
               <titles>
@@ -34,7 +36,14 @@
               </subjects>
               <contributors>
                 <contributor contributorType="Other">
-                  <contributorName nameType="Personal">0803-person-000</contributorName>
+                  <contributorName nameType="Personal">Holzmann, Heinrich</contributorName>
+                  <givenName>Heinrich</givenName>
+                  <familyName>Holzmann</familyName>
+                  <nameIdentifier nameIdentifierScheme="ORCID" schemeURI="https://orcid.org">https://orcid.org/0000-0002-1825-0097</nameIdentifier>
+                  <affiliation>Universität Basel</affiliation>
+                </contributor>
+                <contributor contributorType="HostingInstitution">
+                  <contributorName nameType="Organizational">Universität Basel</contributorName>
                 </contributor>
               </contributors>
               <descriptions>
@@ -56,7 +65,7 @@
               </geoLocations>
               <fundingReferences>
                 <fundingReference>
-                  <funderName>0803-organization-000</funderName>
+                  <funderName>Universität Basel</funderName>
                   <awardNumber awardURI="https://data.snf.ch/grants/grant/120378">120378</awardNumber>
                   <awardTitle>Project funding</awardTitle>
                 </fundingReference>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_oai_dc.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_oai_dc.xml
@@ -13,12 +13,14 @@
         <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
           <dc:title>Die Bilderfolgen der Basler Frühdrucke: Spätmittelalterliche Didaxe als Bild-Text-Lektüre</dc:title>
           <dc:title>Incunabula</dc:title>
+          <dc:creator>Vogel, Susanne</dc:creator>
           <dc:subject>Letterpress Printing</dc:subject>
           <dc:subject>10404 Visual arts and Art history</dc:subject>
           <dc:description>A description of early prints in Basel.</dc:description>
           <dc:description>An interdisciplinary research project on image sequences of Basel&apos;s early prints.</dc:description>
           <dc:publisher>DaSCH</dc:publisher>
-          <dc:contributor>0803-person-000</dc:contributor>
+          <dc:contributor>Holzmann, Heinrich</dc:contributor>
+          <dc:contributor>Universität Basel</dc:contributor>
           <dc:date>2008-06-01</dc:date>
           <dc:type>Project</dc:type>
           <dc:identifier>https://ark.dasch.swiss/ark:/72163/1/0803</dc:identifier>

--- a/modules/dpe/api-oai/src/xml.rs
+++ b/modules/dpe/api-oai/src/xml.rs
@@ -5,7 +5,7 @@ use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
 use quick_xml::Writer;
 
 use super::error::OaiError;
-use super::metadata::{DataCiteRecord, DublinCoreRecord, OaiRecord};
+use super::metadata::{DataCiteNameIdentifier, DataCiteRecord, DublinCoreRecord, OaiRecord};
 
 pub const BASE_URL: &str = "https://meta.dasch.swiss/oai";
 
@@ -257,6 +257,33 @@ impl OaiXmlBuilder {
         self.end_element("metadata");
     }
 
+    /// Writes the name detail elements shared by creator and contributor:
+    /// givenName, familyName, nameIdentifier*, affiliation* (DataCite kernel-4 order).
+    fn write_name_details(
+        &mut self,
+        given_name: Option<&str>,
+        family_name: Option<&str>,
+        name_identifiers: &[DataCiteNameIdentifier],
+        affiliations: &[String],
+    ) {
+        if let Some(given) = given_name {
+            self.write_element("givenName", given);
+        }
+        if let Some(family) = family_name {
+            self.write_element("familyName", family);
+        }
+        for ni in name_identifiers {
+            let mut attrs = vec![("nameIdentifierScheme", ni.scheme.as_str())];
+            if let Some(ref scheme_uri) = ni.scheme_uri {
+                attrs.push(("schemeURI", scheme_uri.as_str()));
+            }
+            self.write_element_with_attrs("nameIdentifier", &attrs, &ni.identifier);
+        }
+        for affiliation in affiliations {
+            self.write_element("affiliation", affiliation);
+        }
+    }
+
     /// Writes DataCite 4.6 metadata.
     pub fn write_datacite_metadata(&mut self, datacite: &DataCiteRecord) {
         self.start_element("metadata");
@@ -293,6 +320,12 @@ impl OaiXmlBuilder {
                 attrs.push(("nameType", name_type.as_str()));
             }
             self.write_element_with_attrs("creatorName", &attrs, &creator.name);
+            self.write_name_details(
+                creator.given_name.as_deref(),
+                creator.family_name.as_deref(),
+                &creator.name_identifiers,
+                &creator.affiliations,
+            );
             self.end_element("creator");
         }
         self.end_element("creators");
@@ -355,6 +388,12 @@ impl OaiXmlBuilder {
                     attrs.push(("nameType", name_type.as_str()));
                 }
                 self.write_element_with_attrs("contributorName", &attrs, &contributor.name);
+                self.write_name_details(
+                    contributor.given_name.as_deref(),
+                    contributor.family_name.as_deref(),
+                    &contributor.name_identifiers,
+                    &contributor.affiliations,
+                );
                 self.end_element("contributor");
             }
             self.end_element("contributors");

--- a/modules/dpe/core/src/contributors.rs
+++ b/modules/dpe/core/src/contributors.rs
@@ -21,6 +21,37 @@ pub enum ResolvedContributor {
     },
 }
 
+/// Heuristic for distinguishing organization IDs (e.g. `organization-001`,
+/// `0803-organization-000`) from person IDs (e.g. `person-028`).
+pub fn is_organization_id(id: &str) -> bool {
+    id.starts_with("organization-") || id.contains("-organization-")
+}
+
+/// Lookup of persons and organizations by their internal ID.
+///
+/// Abstracted as a trait so consumers (e.g. OAI-PMH metadata transforms) can
+/// be tested without the disk-backed caches.
+pub trait ContributorLookup {
+    fn person(&self, id: &str) -> Option<Person>;
+    fn organization(&self, id: &str) -> Option<Organization>;
+}
+
+/// Production [`ContributorLookup`] backed by the in-process person and
+/// organization caches.
+#[cfg(not(target_arch = "wasm32"))]
+pub struct CachedContributorLookup;
+
+#[cfg(not(target_arch = "wasm32"))]
+impl ContributorLookup for CachedContributorLookup {
+    fn person(&self, id: &str) -> Option<Person> {
+        load_person(id)
+    }
+
+    fn organization(&self, id: &str) -> Option<Organization> {
+        load_organization(id)
+    }
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 pub fn load_person(id: &str) -> Option<Person> {
     super::person_cache::all_persons().get(id).cloned()

--- a/modules/dpe/core/src/contributors.rs
+++ b/modules/dpe/core/src/contributors.rs
@@ -21,10 +21,10 @@ pub enum ResolvedContributor {
     },
 }
 
-/// Heuristic for distinguishing organization IDs (e.g. `organization-001`,
-/// `0803-organization-000`) from person IDs (e.g. `person-028`).
+/// Heuristic for distinguishing organization IDs (e.g. `organization-001`)
+/// from person IDs (e.g. `person-028`).
 pub fn is_organization_id(id: &str) -> bool {
-    id.starts_with("organization-") || id.contains("-organization-")
+    id.starts_with("organization-")
 }
 
 /// Lookup of persons and organizations by their internal ID.
@@ -60,4 +60,20 @@ pub fn load_person(id: &str) -> Option<Person> {
 #[cfg(not(target_arch = "wasm32"))]
 pub fn load_organization(id: &str) -> Option<Organization> {
     super::organization_cache::all_organizations().get(id).cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_organization_id;
+
+    #[test]
+    fn organization_ids_are_recognised() {
+        assert!(is_organization_id("organization-000"));
+        assert!(is_organization_id("organization-142"));
+    }
+
+    #[test]
+    fn person_ids_are_not_organizations() {
+        assert!(!is_organization_id("person-028"));
+    }
 }

--- a/modules/dpe/core/src/lib.rs
+++ b/modules/dpe/core/src/lib.rs
@@ -25,9 +25,9 @@ pub mod utils;
 pub use cluster::ClusterRaw;
 pub use cluster::ClusterRef;
 pub use collection::CollectionRef;
-pub use contributors::ResolvedContributor;
+pub use contributors::{is_organization_id, ContributorLookup, ResolvedContributor};
 #[cfg(not(target_arch = "wasm32"))]
-pub use contributors::{load_organization, load_person};
+pub use contributors::{load_organization, load_person, CachedContributorLookup};
 pub use models::{AuthorityFileReference, Page};
 pub use organization::Organization;
 pub use person::Person;

--- a/modules/dpe/web/src/domain/contributors.rs
+++ b/modules/dpe/web/src/domain/contributors.rs
@@ -13,13 +13,13 @@ use dpe_core::project::Attribution;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub fn get_contributors(attributions: Vec<Attribution>) -> Vec<ResolvedContributor> {
-    use dpe_core::contributors::{load_organization, load_person};
+    use dpe_core::contributors::{is_organization_id, load_organization, load_person};
 
     let mut result = Vec::with_capacity(attributions.len());
     for attr in attributions {
         let roles = (!attr.contributor_type.is_empty()).then(|| attr.contributor_type.join(", "));
         let id = &attr.contributor;
-        if id.starts_with("organization-") || id.contains("-organization-") {
+        if is_organization_id(id) {
             match load_organization(id) {
                 Some(org) => result.push(ResolvedContributor::Organization { org, roles }),
                 None => result.push(ResolvedContributor::Unknown { id: id.clone(), roles }),


### PR DESCRIPTION
## Personal Acceptance Criteria

* In the ListRecords request in OAI, the contributors seem to have the right information
* An edge case is mentioned in the Linear issue, but doesn't seem to be applicable
* The PR mostly consists of ResolvedAgent lookups, XML changes, DI and golden test updates, seems correct

## Motivation
OAI-PMH metadata exposed contributors, creators, and funders as internal IDs (`person-028`, `0803-organization-000`), which is useless for harvesters. Person and organization data (names, ORCID/GND identifiers, affiliations) already exists in the dataset and is shown by the DPE web UI, but the OAI module never resolved it.

## Summary
- DataCite creators/contributors now carry the resolved name ("Family, Given"), `givenName`/`familyName`, ORCID/GND `nameIdentifier`, and `affiliation` elements; organizations get `nameType="Organizational"`
- DataCite `funderName` and Dublin Core `dc:creator`/`dc:contributor` are resolved to display names
- Unresolvable IDs fall back to the raw ID so no attribution is lost

## Key Changes
### dpe-core
- New `ContributorLookup` trait with a production `CachedContributorLookup` backed by the existing person/organization caches
- Person-vs-organization ID heuristic extracted to `is_organization_id()` and shared with dpe-web (previously duplicated)

### dpe-api-oai
- New `metadata/resolve.rs`: resolves an ID to display name, nameType, given/family names, ORCID/GND name identifiers, and affiliation organization names
- `project_to_datacite` / `project_to_dublin_core` take a `&dyn ContributorLookup`, threaded through the verb handlers like the existing repository parameters
- XML writer emits `givenName`, `familyName`, `nameIdentifier`, `affiliation` in DataCite kernel-4 element order

## Challenges and Decisions
### Testability of the disk-backed caches
**Problem:** person/organization caches are global `OnceLock`s loaded from the data directory; transforms calling them directly would be untestable.
**Solution:** repository-style trait injection (`&dyn ContributorLookup`), matching how handlers already receive `ProjectRepository`/`RecordRepository`. Tests use an in-memory lookup with fixtures.

### What identifier data exists
- Person `sameAs` carries ORCID (96), URL (58), GND (5). `URL` entries are deliberately not emitted as `nameIdentifier` (not an identifier scheme).
- No organization has a ROR `sameAs` entry yet, so `affiliationIdentifier` and `funderIdentifier` are not emitted. Add once the data exists.

### Creator detection left unchanged (deliberate)
38 of 83 projects have no attribution matching the `is_creator` rules (free-text role vocabulary: "Applicant", "PI", "Projektleitung", compound strings like "Project Leader, Data Collector") and fall back to `creatorName=DaSCH`. Out of scope here; documented separately.

## Gotchas
- Records (vs. projects) use free-text `legal_info.authorship` names, not IDs — they need no resolution and are untouched.
- Golden files were regenerated; all responses still validate against the DataCite kernel-4 XSD via xmllint.

## Test Plan
- 8 unit tests for the resolver (name formatting, ORCID/GND mapping, affiliation resolution, org contributors, raw-ID fallbacks)
- Golden tests now cover a personal creator, personal contributor with ORCID + affiliation, organizational contributor, and resolved funder
- `just check` and `just test` pass (232 tests)