### PR TITLE
fix(dpe-core): correct inverted temporal/spatial coverage in project data

### DIFF
--- a/modules/dpe/core/src/project.rs
+++ b/modules/dpe/core/src/project.rs
@@ -397,4 +397,80 @@ mod tests {
         assert!(primary.is_none());
         assert!(secondary.is_none());
     }
+
+    /// Classify an authority-file URL as a place gazetteer, a period gazetteer,
+    /// or neither, based on its host. Used to guard against temporal/spatial
+    /// coverage being swapped (a known data-migration defect, see DEV history).
+    fn url_kind(url: &str) -> &'static str {
+        let host = url
+            .trim_start_matches("https://")
+            .trim_start_matches("http://")
+            .split('/')
+            .next()
+            .unwrap_or("");
+        // Period (temporal) gazetteers.
+        if host.contains("chronontology.dainst.org") || host.contains("perio.do") || host.contains("n2t.net") {
+            "period"
+        }
+        // Place (spatial) gazetteers.
+        else if host.contains("pleiades.stoa.org")
+            || host.contains("geonames.org")
+            || host.contains("gazetteer.dainst.org")
+            || host.contains("vocab.getty.edu")
+        {
+            "place"
+        } else {
+            "unknown"
+        }
+    }
+
+    /// Guard against the temporal/spatial coverage inversion introduced during
+    /// the old-model migration: a place reference must never sit in
+    /// `temporalCoverage`, and a period reference must never sit in
+    /// `spatialCoverage`. Ambiguous URLs (free-form `URL` type) are ignored.
+    #[test]
+    fn coverage_fields_are_not_inverted() {
+        // Resolve the data dir relative to this crate, independent of the test
+        // process working directory.
+        let projects_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/../server/data/projects");
+
+        let mut violations = Vec::new();
+        let entries = std::fs::read_dir(projects_dir).expect("projects data directory should be readable");
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("").to_string();
+            let json = std::fs::read_to_string(&path).expect("project file should be readable");
+            let project = serde_json::from_str::<ProjectRaw>(&json)
+                .map(Project::from)
+                .unwrap_or_else(|e| panic!("failed to parse {filename}: {e}"));
+
+            for coverage in &project.temporal_coverage {
+                if let TemporalCoverage::Reference(reference) = coverage {
+                    if url_kind(&reference.url) == "place" {
+                        violations.push(format!(
+                            "{filename}: temporalCoverage holds a place reference (type={}, url={})",
+                            reference.type_, reference.url
+                        ));
+                    }
+                }
+            }
+            for reference in &project.spatial_coverage {
+                if url_kind(&reference.url) == "period" {
+                    violations.push(format!(
+                        "{filename}: spatialCoverage holds a period reference (type={}, url={})",
+                        reference.type_, reference.url
+                    ));
+                }
+            }
+        }
+
+        assert!(
+            violations.is_empty(),
+            "temporal/spatial coverage inversions found:\n{}",
+            violations.join("\n")
+        );
+    }
 }

--- a/modules/dpe/server/data/projects/0843_woposs.json
+++ b/modules/dpe/server/data/projects/0843_woposs.json
@@ -80,6 +80,18 @@
     ],
     "temporalCoverage": [
         {
+            "type": "Periodo",
+            "url": "http://n2t.net/ark:/99152/p08m57hmxmp",
+            "text": "Classical World"
+        },
+        {
+            "type": "Periodo",
+            "url": "http://n2t.net/ark:/99152/p08m57h8zmq",
+            "text": "Medieval"
+        }
+    ],
+    "spatialCoverage": [
+        {
             "type": "Pleiades",
             "url": "https://pleiades.stoa.org/places/1052",
             "text": "Italia"
@@ -123,18 +135,6 @@
             "type": "Pleiades",
             "url": "https://pleiades.stoa.org/places/20487",
             "text": "Hibernia"
-        }
-    ],
-    "spatialCoverage": [
-        {
-            "type": "Periodo",
-            "url": "http://n2t.net/ark:/99152/p08m57hmxmp",
-            "text": "Classical World"
-        },
-        {
-            "type": "Periodo",
-            "url": "http://n2t.net/ark:/99152/p08m57h8zmq",
-            "text": "Medieval"
         }
     ],
     "attributions": [

--- a/modules/dpe/server/data/projects/0844_mark16.json
+++ b/modules/dpe/server/data/projects/0844_mark16.json
@@ -105,62 +105,62 @@
     ],
     "spatialCoverage": [
         {
-            "type": "Chronontology",
+            "type": "Gazetteer",
             "url": "https://gazetteer.dainst.org/app/#!/show/2075626",
             "text": "Western Europe"
         },
         {
-            "type": "Chronontology",
+            "type": "Gazetteer",
             "url": "https://gazetteer.dainst.org/app/#!/show/2042602",
             "text": "Nordafrika"
         },
         {
-            "type": "Chronontology",
+            "type": "Gazetteer",
             "url": "https://gazetteer.dainst.org/app/#!/show/2070079",
             "text": "Ellada"
         },
         {
-            "type": "Chronontology",
+            "type": "Gazetteer",
             "url": "https://gazetteer.dainst.org/app/#!/show/2043735",
             "text": "Kleinasien"
         },
         {
-            "type": "Chronontology",
+            "type": "Gazetteer",
             "url": "https://gazetteer.dainst.org/app/#!/show/2359915",
             "text": "East Africa"
         },
         {
-            "type": "Chronontology",
+            "type": "Gazetteer",
             "url": "https://gazetteer.dainst.org/app/#!/show/2043054",
             "text": "India"
         },
         {
-            "type": "Chronontology",
+            "type": "Gazetteer",
             "url": "https://gazetteer.dainst.org/app/#!/show/2043065",
             "text": "Vorderasien"
         },
         {
-            "type": "Chronontology",
+            "type": "Gazetteer",
             "url": "https://gazetteer.dainst.org/app/#!/show/2043225",
             "text": "Arabien"
         },
         {
-            "type": "Chronontology",
+            "type": "Gazetteer",
             "url": "https://gazetteer.dainst.org/app/#!/show/2283256",
             "text": "Ägäis"
         },
         {
-            "type": "Chronontology",
+            "type": "Gazetteer",
             "url": "https://gazetteer.dainst.org/app/#!/show/2043307",
             "text": "Armenien"
         },
         {
-            "type": "Chronontology",
+            "type": "Gazetteer",
             "url": "https://gazetteer.dainst.org/app/#!/show/2070074",
             "text": "Southern Europe"
         },
         {
-            "type": "Chronontology",
+            "type": "Gazetteer",
             "url": "https://gazetteer.dainst.org/app/#!/show/2043344",
             "text": "Georgien"
         }


### PR DESCRIPTION
## Summary

The old-model → current-model migration swapped temporal and spatial coverage in some project metadata files. This corrects the affected files and adds a guard test.

### Findings (full blast radius)
I checked all 83 project files, classifying every coverage entry by its **URL host** (place gazetteer vs period gazetteer) rather than the unreliable `type` label:

| Host | Kind |
|------|------|
| `pleiades.stoa.org`, `geonames.org`, `gazetteer.dainst.org`, `vocab.getty.edu` | place (spatial) |
| `chronontology.dainst.org`, `perio.do` / `n2t.net` | period (temporal) |

Only **two files** were affected, in two distinct ways:

- **`0843_woposs.json`** — genuine field inversion. `temporalCoverage` held Pleiades places (Italia, Gallia, …) and `spatialCoverage` held Periodo periods (Classical World, Medieval). Fixed by swapping the two arrays.
- **`0844_mark16.json`** — `type` mislabel only. The 12 spatial entries reference the iDAI Gazetteer (`gazetteer.dainst.org`, a place service) but were tagged `"type": "Chronontology"` (the period service). Content was already in the correct field; relabeled to `"Gazetteer"`.

Everything else is correct (e.g. `URL`-typed Getty TGN places in `spatialCoverage` paired with literal date-range strings in `temporalCoverage`).

### Guard test
Added `coverage_fields_are_not_inverted` in `modules/dpe/core/src/project.rs`. It loads every project file and asserts no place reference sits in `temporalCoverage` and no period reference in `spatialCoverage`. Verified it fails on a re-introduced inversion and passes on the corrected data.

## Notes
- `type` is an unconstrained free-form string with no documented vocabulary; `"Gazetteer"` was chosen as the accurate label for the iDAI Gazetteer. If there's a canonical label, happy to adjust.

## Testing
- `just check` — clean (fmt + clippy + wasm check)
- `just test` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)