### PR TITLE
fix(dpe-api-oai): Make OAI-PMH baseURL configurable; correct identifier namespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,6 +887,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tracing",
 ]
 
 [[package]]

--- a/docs/src/dpe/oai-pmh.md
+++ b/docs/src/dpe/oai-pmh.md
@@ -12,7 +12,9 @@ Usage guide for the DPE [OAI-PMH 2.0](https://www.openarchives.org/OAI/openarchi
 |-------------|----------|
 | Local development (`just watch-dpe`) | `http://localhost:4000/dpe/oai` |
 | DEV | `https://api.dev.dasch.swiss/dpe/oai` |
-| Production | Not yet deployed; see [Known Limitations](#known-limitations) regarding the advertised `baseURL` |
+| Production | `https://repository.dasch.swiss/dpe/oai` |
+
+The `baseURL` advertised by `Identify` (and echoed in every `<request>` element) is configured per environment via the `DPE_OAI_BASE_URL` environment variable, so it matches the URL harvesters actually use (see [operations](./operations.md)). If unset it defaults to the production endpoint above.
 
 ## Verbs
 
@@ -39,10 +41,10 @@ Abbreviated example response (values vary by environment):
 
 ```xml
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" ...>
-  <request verb="Identify">https://meta.dasch.swiss/oai</request>
+  <request verb="Identify">https://repository.dasch.swiss/dpe/oai</request>
   <Identify>
     <repositoryName>DaSCH Service Platform Repository</repositoryName>
-    <baseURL>https://meta.dasch.swiss/oai</baseURL>
+    <baseURL>https://repository.dasch.swiss/dpe/oai</baseURL>
     <protocolVersion>2.0</protocolVersion>
     <adminEmail>info@dasch.swiss</adminEmail>
     <earliestDatestamp>2008-06-01</earliestDatestamp>
@@ -70,7 +72,7 @@ Abbreviated example response — the full response also contains one `project:{s
 
 ```xml
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" ...>
-  <request verb="ListSets">https://meta.dasch.swiss/oai</request>
+  <request verb="ListSets">https://repository.dasch.swiss/dpe/oai</request>
   <ListSets>
     <set>
       <setSpec>entityType:ProjectCluster</setSpec>
@@ -110,8 +112,8 @@ OAI identifiers are derived from DaSCH [ARK](https://arks.org/) identifiers:
 
 | Item type | Pattern | Example |
 |-----------|---------|---------|
-| Research project | `oai:meta.dasch.swiss:ark:/72163/1/{shortcode}` | `oai:meta.dasch.swiss:ark:/72163/1/0803` |
-| Record | `oai:meta.dasch.swiss:ark:/72163/1/{shortcode}/{record_id}` | `oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh` |
+| Research project | `oai:dasch.swiss:ark:/72163/1/{shortcode}` | `oai:dasch.swiss:ark:/72163/1/0803` |
+| Record | `oai:dasch.swiss:ark:/72163/1/{shortcode}/{record_id}` | `oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh` |
 
 These differ from the resolvable ARK URLs (`https://ark.dasch.swiss/ark:/72163/1/...`), which appear in the metadata payloads as `dc:identifier` / DataCite `identifier`.
 
@@ -171,21 +173,21 @@ List responses are returned complete and unpaged — there is no `resumptionToke
 
 ```bash
 # A research project
-curl "https://api.dev.dasch.swiss/dpe/oai?verb=GetRecord&metadataPrefix=oai_dc&identifier=oai:meta.dasch.swiss:ark:/72163/1/0803"
+curl "https://api.dev.dasch.swiss/dpe/oai?verb=GetRecord&metadataPrefix=oai_dc&identifier=oai:dasch.swiss:ark:/72163/1/0803"
 
 # A record within a project
-curl "https://api.dev.dasch.swiss/dpe/oai?verb=GetRecord&metadataPrefix=oai_dc&identifier=oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"
+curl "https://api.dev.dasch.swiss/dpe/oai?verb=GetRecord&metadataPrefix=oai_dc&identifier=oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"
 ```
 
 Abbreviated example response:
 
 ```xml
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" ...>
-  <request verb="GetRecord" identifier="oai:meta.dasch.swiss:ark:/72163/1/0803" metadataPrefix="oai_dc">https://meta.dasch.swiss/oai</request>
+  <request verb="GetRecord" identifier="oai:dasch.swiss:ark:/72163/1/0803" metadataPrefix="oai_dc">https://repository.dasch.swiss/dpe/oai</request>
   <GetRecord>
     <record>
       <header>
-        <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>
+        <identifier>oai:dasch.swiss:ark:/72163/1/0803</identifier>
         <datestamp>2008-06-01</datestamp>
         <setSpec>entityType:ResearchProject</setSpec>
         <setSpec>project:0803</setSpec>
@@ -240,7 +242,7 @@ Errors are returned as OAI `<error>` elements with HTTP status `200`:
 ## Known Limitations
 
 - **No resumption tokens.** List responses are complete and unpaged; any `resumptionToken` argument yields `badResumptionToken`.
-- **Advertised `baseURL` differs from the actual endpoint.** `Identify` reports `https://meta.dasch.swiss/oai`, while the endpoint is mounted at `/dpe/oai`. Automated OAI validators and harvest managers that compare the `baseURL` against the request URL will flag this.
+- **`baseURL` is a fixed configured value.** It is set per environment via `DPE_OAI_BASE_URL` rather than derived from each incoming request. Deploying behind a hostname that does not match the configured value will make the advertised `baseURL` disagree with the request URL, which OAI validators flag — keep the env var in sync with the public endpoint.
 - **No deleted-record tracking** (`deletedRecord: no`). Items that disappear are not announced; see the re-harvesting recommendation above.
 - **GET only.** OAI-PMH 2.0 also requires POST; harvesters that default to POST will not get an OAI response.
 - **`ListMetadataFormats` with a record identifier** returns `idDoesNotExist`, even for records that `GetRecord` resolves.

--- a/docs/src/dpe/operations.md
+++ b/docs/src/dpe/operations.md
@@ -60,6 +60,7 @@ dpe healthcheck --url http://localhost:9090/healthz # custom URL
 | `DPE_DATA_DIR` | No | `modules/dpe/server/data` | Path to project/record JSON data files. Legacy alias: `DATA_DIR` (checked if `DPE_DATA_DIR` is unset) |
 | `DPE_FATHOM_SITE_ID` | No | *(none)* | Fathom Analytics site ID (not a secret) |
 | `DPE_SHOW_PLACEHOLDER_VALUES` | No | `false` | Show placeholder values (MISSING, CALCULATED) in the UI, styled in red. Enable on DEV/STAGE for QA visibility. |
+| `DPE_OAI_BASE_URL` | No | `https://repository.dasch.swiss/dpe/oai` | Public base URL emitted as the OAI-PMH `baseURL` and echoed in `<request>` elements. Set per environment to match the public endpoint (e.g. `https://api.dev.dasch.swiss/dpe/oai` on DEV, `http://localhost:4000/dpe/oai` locally). See [OAI-PMH](./oai-pmh.md). |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | No | *(none)* | OTLP gRPC endpoint (e.g., `http://alloy:4317`). When unset, OTel falls back to no-op export. |
 | `OTEL_SERVICE_NAME` | No | *(none)* | Service name for OTel resource attributes (e.g., `dpe`) |
 | `OTEL_RESOURCE_ATTRIBUTES` | No | *(none)* | Comma-separated OTel resource attributes (e.g., `service.namespace=dpe,service.version=0.2.1,deployment.environment=prod`) |

--- a/modules/dpe/api-oai/Cargo.toml
+++ b/modules/dpe/api-oai/Cargo.toml
@@ -11,6 +11,7 @@ chrono.workspace = true
 quick-xml.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/modules/dpe/api-oai/src/handlers/get_record.rs
+++ b/modules/dpe/api-oai/src/handlers/get_record.rs
@@ -154,7 +154,7 @@ mod tests {
 
     #[test]
     fn missing_metadata_prefix_returns_bad_argument() {
-        let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), None);
+        let params = make_params(Some("oai:dasch.swiss:ark:/72163/1/0803"), None);
         let xml = handle_get_record(
             &params,
             &repo_with_incunabula(),
@@ -168,7 +168,7 @@ mod tests {
 
     #[test]
     fn unsupported_metadata_prefix_returns_cannot_disseminate() {
-        let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), Some("marc21"));
+        let params = make_params(Some("oai:dasch.swiss:ark:/72163/1/0803"), Some("marc21"));
         let xml = handle_get_record(
             &params,
             &repo_with_incunabula(),
@@ -181,7 +181,7 @@ mod tests {
 
     #[test]
     fn unknown_id_not_in_either_repo_returns_id_does_not_exist() {
-        let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/9999"), Some("oai_dc"));
+        let params = make_params(Some("oai:dasch.swiss:ark:/72163/1/9999"), Some("oai_dc"));
         let xml = handle_get_record(
             &params,
             &repo_with_incunabula(),
@@ -194,7 +194,7 @@ mod tests {
 
     #[test]
     fn unexpected_argument_returns_bad_argument() {
-        let mut params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), Some("oai_dc"));
+        let mut params = make_params(Some("oai:dasch.swiss:ark:/72163/1/0803"), Some("oai_dc"));
         params.set = Some("entityType:ResearchProject".to_string());
         let xml = handle_get_record(
             &params,
@@ -210,7 +210,7 @@ mod tests {
 
     #[test]
     fn golden_oai_dc_response() {
-        let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), Some("oai_dc"));
+        let params = make_params(Some("oai:dasch.swiss:ark:/72163/1/0803"), Some("oai_dc"));
         let xml = handle_get_record(
             &params,
             &repo_with_incunabula(),
@@ -224,7 +224,7 @@ mod tests {
 
     #[test]
     fn golden_oai_datacite_response() {
-        let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), Some("oai_datacite"));
+        let params = make_params(Some("oai:dasch.swiss:ark:/72163/1/0803"), Some("oai_datacite"));
         let xml = handle_get_record(
             &params,
             &repo_with_incunabula(),
@@ -241,7 +241,7 @@ mod tests {
     #[test]
     fn record_golden_oai_dc_response() {
         let params = make_params(
-            Some("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
+            Some("oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             Some("oai_dc"),
         );
         let xml = handle_get_record(
@@ -258,7 +258,7 @@ mod tests {
     #[test]
     fn record_golden_oai_datacite_response() {
         let params = make_params(
-            Some("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
+            Some("oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             Some("oai_datacite"),
         );
         let xml = handle_get_record(
@@ -276,7 +276,7 @@ mod tests {
 
     #[test]
     fn get_record_oai_dc_response_is_valid_oai_pmh() {
-        let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), Some("oai_dc"));
+        let params = make_params(Some("oai:dasch.swiss:ark:/72163/1/0803"), Some("oai_dc"));
         let xml = handle_get_record(
             &params,
             &repo_with_incunabula(),
@@ -289,7 +289,7 @@ mod tests {
 
     #[test]
     fn get_record_oai_datacite_response_is_valid_oai_pmh() {
-        let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/0803"), Some("oai_datacite"));
+        let params = make_params(Some("oai:dasch.swiss:ark:/72163/1/0803"), Some("oai_datacite"));
         let xml = handle_get_record(
             &params,
             &repo_with_incunabula(),
@@ -303,7 +303,7 @@ mod tests {
     #[test]
     fn record_get_record_oai_dc_response_is_valid_oai_pmh() {
         let params = make_params(
-            Some("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
+            Some("oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             Some("oai_dc"),
         );
         let xml = handle_get_record(
@@ -319,7 +319,7 @@ mod tests {
     #[test]
     fn record_get_record_oai_datacite_response_is_valid_oai_pmh() {
         let params = make_params(
-            Some("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
+            Some("oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             Some("oai_datacite"),
         );
         let xml = handle_get_record(

--- a/modules/dpe/api-oai/src/handlers/identify.rs
+++ b/modules/dpe/api-oai/src/handlers/identify.rs
@@ -81,6 +81,25 @@ mod tests {
         );
     }
 
+    // ---- base URL ----
+
+    #[test]
+    fn identify_emits_configured_base_url_in_both_request_and_base_url() {
+        // The base URL resolves from the process-global / DPE_OAI_BASE_URL / default
+        // (here the default). It must appear in BOTH the <request> text and <baseURL>,
+        // and must no longer be the obsolete meta.dasch.swiss host.
+        let params = make_params();
+        let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
+        let xml = handle_identify(&params, &repo);
+        let base = crate::base_url();
+        assert!(xml.contains(&format!("<baseURL>{base}</baseURL>")), "got: {xml}");
+        assert!(
+            xml.contains(&format!("\">{base}</request>")),
+            "request text must be the base URL, got: {xml}"
+        );
+        assert!(!xml.contains("meta.dasch.swiss"), "obsolete host must be gone, got: {xml}");
+    }
+
     // ---- golden tests ----
 
     #[test]

--- a/modules/dpe/api-oai/src/handlers/list_identifiers.rs
+++ b/modules/dpe/api-oai/src/handlers/list_identifiers.rs
@@ -112,12 +112,12 @@ mod tests {
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
         let xml = handle_list_identifiers(&params, &repo, &record_repo, &[], &incunabula_lookup());
         assert!(
-            xml.contains("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
+            xml.contains("oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             "record identifier should be present, got: {}",
             xml
         );
         assert!(
-            !xml.contains("<identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>"),
+            !xml.contains("<identifier>oai:dasch.swiss:ark:/72163/1/0803</identifier>"),
             "project entry should be absent (records only), got: {}",
             xml
         );
@@ -133,12 +133,12 @@ mod tests {
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
         let xml = handle_list_identifiers(&params, &repo, &record_repo, &clusters, &incunabula_lookup());
         assert!(
-            xml.contains("<identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>"),
+            xml.contains("<identifier>oai:dasch.swiss:ark:/72163/1/0803</identifier>"),
             "project entry should be present, got: {}",
             xml
         );
         assert!(
-            xml.contains("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
+            xml.contains("oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             "member record should be present, got: {}",
             xml
         );
@@ -162,12 +162,12 @@ mod tests {
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
         let xml = handle_list_identifiers(&params, &repo, &record_repo, &[], &incunabula_lookup());
         assert!(
-            xml.contains("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
+            xml.contains("oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             "record identifier should be present, got: {}",
             xml
         );
         assert!(
-            !xml.contains("oai:meta.dasch.swiss:ark:/72163/1/0803\""),
+            !xml.contains("oai:dasch.swiss:ark:/72163/1/0803\""),
             "project identifier should be absent, got: {}",
             xml
         );

--- a/modules/dpe/api-oai/src/handlers/list_metadata_formats.rs
+++ b/modules/dpe/api-oai/src/handlers/list_metadata_formats.rs
@@ -69,7 +69,7 @@ mod tests {
 
     #[test]
     fn unknown_identifier_returns_id_does_not_exist() {
-        let params = make_params(Some("oai:meta.dasch.swiss:ark:/72163/1/9999"));
+        let params = make_params(Some("oai:dasch.swiss:ark:/72163/1/9999"));
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
         let xml = handle_list_metadata_formats(&params, &repo);
         assert!(xml.contains("<error code=\"idDoesNotExist\">"), "got: {}", xml);

--- a/modules/dpe/api-oai/src/handlers/list_records.rs
+++ b/modules/dpe/api-oai/src/handlers/list_records.rs
@@ -125,12 +125,12 @@ mod tests {
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
         let xml = handle_list_records(&params, &repo, &record_repo, &[], &incunabula_lookup());
         assert!(
-            xml.contains("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
+            xml.contains("oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             "record identifier should be present, got: {}",
             xml
         );
         assert!(
-            !xml.contains("oai:meta.dasch.swiss:ark:/72163/1/0803\""),
+            !xml.contains("oai:dasch.swiss:ark:/72163/1/0803\""),
             "project entry should be absent (records only), got: {}",
             xml
         );
@@ -167,12 +167,12 @@ mod tests {
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
         let xml = handle_list_records(&params, &repo, &record_repo, &[], &incunabula_lookup());
         assert!(
-            xml.contains("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
+            xml.contains("oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             "record identifier should be present, got: {}",
             xml
         );
         assert!(
-            !xml.contains("oai:meta.dasch.swiss:ark:/72163/1/0803\""),
+            !xml.contains("oai:dasch.swiss:ark:/72163/1/0803\""),
             "project identifier should be absent, got: {}",
             xml
         );
@@ -191,13 +191,13 @@ mod tests {
         let xml = handle_list_records(&params, &repo, &record_repo, &clusters, &incunabula_lookup());
         // project entry present (identifier closes with </identifier>)
         assert!(
-            xml.contains("<identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>"),
+            xml.contains("<identifier>oai:dasch.swiss:ark:/72163/1/0803</identifier>"),
             "project entry should be present, got: {}",
             xml
         );
         // record present
         assert!(
-            xml.contains("oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
+            xml.contains("oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
             "member record should be present, got: {}",
             xml
         );
@@ -224,7 +224,7 @@ mod tests {
             &incunabula_lookup(),
         );
         assert!(
-            xml.contains("<identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>"),
+            xml.contains("<identifier>oai:dasch.swiss:ark:/72163/1/0803</identifier>"),
             "project entry should be present even with no records, got: {}",
             xml
         );

--- a/modules/dpe/api-oai/src/lib.rs
+++ b/modules/dpe/api-oai/src/lib.rs
@@ -8,4 +8,63 @@ mod handlers;
 mod metadata;
 mod xml;
 
+use std::sync::OnceLock;
+
 pub use handlers::oai_handler;
+
+/// Fallback OAI-PMH base URL when neither [`set_base_url`] nor `DPE_OAI_BASE_URL` is set.
+/// The production canonical endpoint; mirrors the `DpeConfig::oai_base_url` default.
+const DEFAULT_BASE_URL: &str = "https://repository.dasch.swiss/dpe/oai";
+
+static BASE_URL: OnceLock<String> = OnceLock::new();
+
+/// Resolves the base URL from an optional explicit value, falling back to the default.
+/// Pure helper so the precedence is unit-testable without touching the process-global.
+fn resolve_base_url(explicit: Option<String>) -> String {
+    explicit
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_BASE_URL.to_string())
+}
+
+/// Sets the public OAI-PMH base URL at startup. Must be called before the first request.
+/// Thread-safe: uses OnceLock (first call wins, subsequent calls are no-ops), matching
+/// `dpe_core::set_data_dir`.
+pub fn set_base_url(url: &str) {
+    if BASE_URL.set(resolve_base_url(Some(url.to_string()))).is_err() {
+        tracing::warn!(new = url, current = %base_url(), "set_base_url called again but base URL is already set");
+    }
+}
+
+/// The public OAI-PMH base URL emitted as `baseURL` and in `<request>` elements.
+///
+/// Priority: OnceLock (set by main.rs from `DpeConfig`) → `DPE_OAI_BASE_URL` env var →
+/// [`DEFAULT_BASE_URL`]. The env fallback keeps the value correct in contexts that do not
+/// call [`set_base_url`] (e.g. tests).
+pub(crate) fn base_url() -> &'static str {
+    BASE_URL.get_or_init(|| resolve_base_url(std::env::var("DPE_OAI_BASE_URL").ok()))
+}
+
+#[cfg(test)]
+mod base_url_tests {
+    use super::{resolve_base_url, DEFAULT_BASE_URL};
+
+    #[test]
+    fn explicit_value_is_used() {
+        assert_eq!(
+            resolve_base_url(Some("https://api.dev.dasch.swiss/dpe/oai".to_string())),
+            "https://api.dev.dasch.swiss/dpe/oai"
+        );
+    }
+
+    #[test]
+    fn empty_or_absent_falls_back_to_default() {
+        assert_eq!(resolve_base_url(None), DEFAULT_BASE_URL);
+        assert_eq!(resolve_base_url(Some(String::new())), DEFAULT_BASE_URL);
+    }
+
+    #[test]
+    fn default_is_the_production_endpoint_not_meta() {
+        assert_eq!(DEFAULT_BASE_URL, "https://repository.dasch.swiss/dpe/oai");
+        assert!(!DEFAULT_BASE_URL.contains("meta.dasch.swiss"));
+    }
+}

--- a/modules/dpe/api-oai/src/metadata/mod.rs
+++ b/modules/dpe/api-oai/src/metadata/mod.rs
@@ -20,7 +20,10 @@ use record_datacite::record_to_datacite;
 use record_dublin_core::record_to_dublin_core;
 pub use types::{DataCiteNameIdentifier, DataCiteRecord, DublinCoreRecord, OaiRecord, OaiRecordHeader};
 
-const OAI_IDENTIFIER_PREFIX: &str = "oai:meta.dasch.swiss:";
+// Namespace identifier for OAI record identifiers (OAI identifier format:
+// `oai:<namespace-identifier>:<local-identifier>`). This is a persistent, host-independent
+// identifier authority and is deliberately distinct from the access `baseURL`.
+const OAI_IDENTIFIER_PREFIX: &str = "oai:dasch.swiss:";
 
 /// Creates an OAI identifier from a project shortcode.
 pub fn make_oai_identifier(shortcode: &str) -> String {
@@ -168,12 +171,12 @@ mod tests {
     #[test]
     fn test_make_oai_identifier() {
         let id = make_oai_identifier("0801");
-        assert_eq!(id, "oai:meta.dasch.swiss:ark:/72163/1/0801");
+        assert_eq!(id, "oai:dasch.swiss:ark:/72163/1/0801");
     }
 
     #[test]
     fn test_parse_oai_identifier() {
-        let shortcode = parse_oai_identifier("oai:meta.dasch.swiss:ark:/72163/1/0801");
+        let shortcode = parse_oai_identifier("oai:dasch.swiss:ark:/72163/1/0801");
         assert_eq!(shortcode, Some("0801".to_string()));
     }
 

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_oai_datacite.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_oai_datacite.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
-  <request verb="GetRecord" identifier="oai:meta.dasch.swiss:ark:/72163/1/0803" metadataPrefix="oai_datacite">https://meta.dasch.swiss/oai</request>
+  <request verb="GetRecord" identifier="oai:dasch.swiss:ark:/72163/1/0803" metadataPrefix="oai_datacite">https://repository.dasch.swiss/dpe/oai</request>
   <GetRecord>
     <record>
       <header>
-        <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>
+        <identifier>oai:dasch.swiss:ark:/72163/1/0803</identifier>
         <datestamp>2008-06-01</datestamp>
         <setSpec>entityType:ResearchProject</setSpec>
         <setSpec>project:0803</setSpec>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_oai_dc.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_oai_dc.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
-  <request verb="GetRecord" identifier="oai:meta.dasch.swiss:ark:/72163/1/0803" metadataPrefix="oai_dc">https://meta.dasch.swiss/oai</request>
+  <request verb="GetRecord" identifier="oai:dasch.swiss:ark:/72163/1/0803" metadataPrefix="oai_dc">https://repository.dasch.swiss/dpe/oai</request>
   <GetRecord>
     <record>
       <header>
-        <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>
+        <identifier>oai:dasch.swiss:ark:/72163/1/0803</identifier>
         <datestamp>2008-06-01</datestamp>
         <setSpec>entityType:ResearchProject</setSpec>
         <setSpec>project:0803</setSpec>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_record_oai_datacite.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_record_oai_datacite.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
-  <request verb="GetRecord" identifier="oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh" metadataPrefix="oai_datacite">https://meta.dasch.swiss/oai</request>
+  <request verb="GetRecord" identifier="oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh" metadataPrefix="oai_datacite">https://repository.dasch.swiss/dpe/oai</request>
   <GetRecord>
     <record>
       <header>
-        <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh</identifier>
+        <identifier>oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh</identifier>
         <datestamp>2012-06-19T14:33:33Z</datestamp>
         <setSpec>entityType:Record</setSpec>
         <setSpec>project:0803</setSpec>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_record_oai_dc.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_record_oai_dc.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
-  <request verb="GetRecord" identifier="oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh" metadataPrefix="oai_dc">https://meta.dasch.swiss/oai</request>
+  <request verb="GetRecord" identifier="oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh" metadataPrefix="oai_dc">https://repository.dasch.swiss/dpe/oai</request>
   <GetRecord>
     <record>
       <header>
-        <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh</identifier>
+        <identifier>oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh</identifier>
         <datestamp>2012-06-19T14:33:33Z</datestamp>
         <setSpec>entityType:Record</setSpec>
         <setSpec>project:0803</setSpec>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/identify.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/identify.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
-  <request verb="Identify">https://meta.dasch.swiss/oai</request>
+  <request verb="Identify">https://repository.dasch.swiss/dpe/oai</request>
   <Identify>
     <repositoryName>DaSCH Service Platform Repository</repositoryName>
-    <baseURL>https://meta.dasch.swiss/oai</baseURL>
+    <baseURL>https://repository.dasch.swiss/dpe/oai</baseURL>
     <protocolVersion>2.0</protocolVersion>
     <adminEmail>info@dasch.swiss</adminEmail>
     <earliestDatestamp>2008-06-01</earliestDatestamp>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/identify_empty_repo.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/identify_empty_repo.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
-  <request verb="Identify">https://meta.dasch.swiss/oai</request>
+  <request verb="Identify">https://repository.dasch.swiss/dpe/oai</request>
   <Identify>
     <repositoryName>DaSCH Service Platform Repository</repositoryName>
-    <baseURL>https://meta.dasch.swiss/oai</baseURL>
+    <baseURL>https://repository.dasch.swiss/dpe/oai</baseURL>
     <protocolVersion>2.0</protocolVersion>
     <adminEmail>info@dasch.swiss</adminEmail>
     <earliestDatestamp>2015-01-01</earliestDatestamp>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_identifiers_mixed_oai_dc.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_identifiers_mixed_oai_dc.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
-  <request verb="ListIdentifiers" metadataPrefix="oai_dc">https://meta.dasch.swiss/oai</request>
+  <request verb="ListIdentifiers" metadataPrefix="oai_dc">https://repository.dasch.swiss/dpe/oai</request>
   <ListIdentifiers>
     <header>
-      <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>
+      <identifier>oai:dasch.swiss:ark:/72163/1/0803</identifier>
       <datestamp>2008-06-01</datestamp>
       <setSpec>entityType:ResearchProject</setSpec>
       <setSpec>project:0803</setSpec>
     </header>
     <header>
-      <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh</identifier>
+      <identifier>oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh</identifier>
       <datestamp>2012-06-19T14:33:33Z</datestamp>
       <setSpec>entityType:Record</setSpec>
       <setSpec>project:0803</setSpec>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_identifiers_oai_datacite.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_identifiers_oai_datacite.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
-  <request verb="ListIdentifiers" metadataPrefix="oai_datacite">https://meta.dasch.swiss/oai</request>
+  <request verb="ListIdentifiers" metadataPrefix="oai_datacite">https://repository.dasch.swiss/dpe/oai</request>
   <ListIdentifiers>
     <header>
-      <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>
+      <identifier>oai:dasch.swiss:ark:/72163/1/0803</identifier>
       <datestamp>2008-06-01</datestamp>
       <setSpec>entityType:ResearchProject</setSpec>
       <setSpec>project:0803</setSpec>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_identifiers_oai_dc.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_identifiers_oai_dc.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
-  <request verb="ListIdentifiers" metadataPrefix="oai_dc">https://meta.dasch.swiss/oai</request>
+  <request verb="ListIdentifiers" metadataPrefix="oai_dc">https://repository.dasch.swiss/dpe/oai</request>
   <ListIdentifiers>
     <header>
-      <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>
+      <identifier>oai:dasch.swiss:ark:/72163/1/0803</identifier>
       <datestamp>2008-06-01</datestamp>
       <setSpec>entityType:ResearchProject</setSpec>
       <setSpec>project:0803</setSpec>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_identifiers_record_only_oai_dc.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_identifiers_record_only_oai_dc.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
-  <request verb="ListIdentifiers" metadataPrefix="oai_dc" set="entityType:Record">https://meta.dasch.swiss/oai</request>
+  <request verb="ListIdentifiers" metadataPrefix="oai_dc" set="entityType:Record">https://repository.dasch.swiss/dpe/oai</request>
   <ListIdentifiers>
     <header>
-      <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh</identifier>
+      <identifier>oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh</identifier>
       <datestamp>2012-06-19T14:33:33Z</datestamp>
       <setSpec>entityType:Record</setSpec>
       <setSpec>project:0803</setSpec>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_metadata_formats.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_metadata_formats.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
-  <request verb="ListMetadataFormats">https://meta.dasch.swiss/oai</request>
+  <request verb="ListMetadataFormats">https://repository.dasch.swiss/dpe/oai</request>
   <ListMetadataFormats>
     <metadataFormat>
       <metadataPrefix>oai_dc</metadataPrefix>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_mixed_oai_dc.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_mixed_oai_dc.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
-  <request verb="ListRecords" metadataPrefix="oai_dc">https://meta.dasch.swiss/oai</request>
+  <request verb="ListRecords" metadataPrefix="oai_dc">https://repository.dasch.swiss/dpe/oai</request>
   <ListRecords>
     <record>
       <header>
-        <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>
+        <identifier>oai:dasch.swiss:ark:/72163/1/0803</identifier>
         <datestamp>2008-06-01</datestamp>
         <setSpec>entityType:ResearchProject</setSpec>
         <setSpec>project:0803</setSpec>
@@ -34,7 +34,7 @@
     </record>
     <record>
       <header>
-        <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh</identifier>
+        <identifier>oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh</identifier>
         <datestamp>2012-06-19T14:33:33Z</datestamp>
         <setSpec>entityType:Record</setSpec>
         <setSpec>project:0803</setSpec>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_oai_datacite.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_oai_datacite.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
-  <request verb="ListRecords" metadataPrefix="oai_datacite">https://meta.dasch.swiss/oai</request>
+  <request verb="ListRecords" metadataPrefix="oai_datacite">https://repository.dasch.swiss/dpe/oai</request>
   <ListRecords>
     <record>
       <header>
-        <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>
+        <identifier>oai:dasch.swiss:ark:/72163/1/0803</identifier>
         <datestamp>2008-06-01</datestamp>
         <setSpec>entityType:ResearchProject</setSpec>
         <setSpec>project:0803</setSpec>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_oai_dc.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_oai_dc.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
-  <request verb="ListRecords" metadataPrefix="oai_dc">https://meta.dasch.swiss/oai</request>
+  <request verb="ListRecords" metadataPrefix="oai_dc">https://repository.dasch.swiss/dpe/oai</request>
   <ListRecords>
     <record>
       <header>
-        <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803</identifier>
+        <identifier>oai:dasch.swiss:ark:/72163/1/0803</identifier>
         <datestamp>2008-06-01</datestamp>
         <setSpec>entityType:ResearchProject</setSpec>
         <setSpec>project:0803</setSpec>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_record_only_oai_dc.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_records_record_only_oai_dc.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
-  <request verb="ListRecords" metadataPrefix="oai_dc" set="entityType:Record">https://meta.dasch.swiss/oai</request>
+  <request verb="ListRecords" metadataPrefix="oai_dc" set="entityType:Record">https://repository.dasch.swiss/dpe/oai</request>
   <ListRecords>
     <record>
       <header>
-        <identifier>oai:meta.dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh</identifier>
+        <identifier>oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh</identifier>
         <datestamp>2012-06-19T14:33:33Z</datestamp>
         <setSpec>entityType:Record</setSpec>
         <setSpec>project:0803</setSpec>

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_sets.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/list_sets.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
-  <request verb="ListSets">https://meta.dasch.swiss/oai</request>
+  <request verb="ListSets">https://repository.dasch.swiss/dpe/oai</request>
   <ListSets>
     <set>
       <setSpec>entityType:ProjectCluster</setSpec>

--- a/modules/dpe/api-oai/src/xml.rs
+++ b/modules/dpe/api-oai/src/xml.rs
@@ -7,8 +7,6 @@ use quick_xml::Writer;
 use super::error::OaiError;
 use super::metadata::{DataCiteNameIdentifier, DataCiteRecord, DublinCoreRecord, OaiRecord};
 
-pub const BASE_URL: &str = "https://meta.dasch.swiss/oai";
-
 /// Earliest datestamp (fallback)
 pub const EARLIEST_DATESTAMP: &str = "2015-01-01";
 
@@ -99,14 +97,14 @@ impl OaiXmlBuilder {
             request.push_attribute((*key, *value));
         }
         self.write(Event::Start(request));
-        self.write(Event::Text(BytesText::new(BASE_URL)));
+        self.write(Event::Text(BytesText::new(crate::base_url())));
         self.end_element("request");
     }
 
     /// Writes the request element for badVerb error responses (no verb attribute).
     pub fn write_error_request(&mut self) {
         self.start_element("request");
-        self.write(Event::Text(BytesText::new(BASE_URL)));
+        self.write(Event::Text(BytesText::new(crate::base_url())));
         self.end_element("request");
     }
 
@@ -115,7 +113,7 @@ impl OaiXmlBuilder {
         let mut request = BytesStart::new("request");
         request.push_attribute(("verb", verb));
         self.write(Event::Start(request));
-        self.write(Event::Text(BytesText::new(BASE_URL)));
+        self.write(Event::Text(BytesText::new(crate::base_url())));
         self.end_element("request");
     }
 
@@ -129,7 +127,7 @@ impl OaiXmlBuilder {
     pub fn write_identify(&mut self, earliest_datestamp: &str) {
         self.start_element("Identify");
         self.write_element("repositoryName", "DaSCH Service Platform Repository");
-        self.write_element("baseURL", BASE_URL);
+        self.write_element("baseURL", crate::base_url());
         self.write_element("protocolVersion", "2.0");
         self.write_element("adminEmail", "info@dasch.swiss");
         self.write_element("earliestDatestamp", earliest_datestamp);

--- a/modules/dpe/server/src/config.rs
+++ b/modules/dpe/server/src/config.rs
@@ -31,6 +31,12 @@ pub struct DpeConfig {
     /// When true (DEV/STAGE), they are shown styled in red for QA visibility.
     /// Set via `DPE_SHOW_PLACEHOLDER_VALUES`.
     pub show_placeholder_values: bool,
+
+    /// Public base URL at which the OAI-PMH endpoint is reachable. Emitted as the
+    /// OAI-PMH `baseURL` and echoed in every `<request>` element, so it must match the
+    /// URL harvesters actually use (e.g. `https://repository.dasch.swiss/dpe/oai` in
+    /// production, `https://api.dev.dasch.swiss/dpe/oai` on DEV). Set via `DPE_OAI_BASE_URL`.
+    pub oai_base_url: String,
 }
 
 impl Default for DpeConfig {
@@ -39,6 +45,7 @@ impl Default for DpeConfig {
             data_dir: PathBuf::from("modules/dpe/server/data"),
             fathom_site_id: None,
             show_placeholder_values: false,
+            oai_base_url: "https://repository.dasch.swiss/dpe/oai".to_string(),
         }
     }
 }
@@ -67,6 +74,7 @@ mod tests {
         assert_eq!(config.data_dir, PathBuf::from("modules/dpe/server/data"));
         assert!(config.fathom_site_id.is_none());
         assert!(!config.show_placeholder_values);
+        assert_eq!(config.oai_base_url, "https://repository.dasch.swiss/dpe/oai");
     }
 
     #[test]

--- a/modules/dpe/server/src/main.rs
+++ b/modules/dpe/server/src/main.rs
@@ -134,6 +134,10 @@ async fn serve() -> ExitCode {
     // Set data directory for dpe-core (thread-safe OnceLock, no env mutation)
     dpe_core::set_data_dir(dpe_config.data_dir.to_str().expect("data_dir path must be valid UTF-8"));
 
+    // Set the public OAI-PMH base URL (thread-safe OnceLock), emitted as baseURL / <request>.
+    dpe_api_oai::set_base_url(&dpe_config.oai_base_url);
+    tracing::info!(oai_base_url = %dpe_config.oai_base_url, "OAI-PMH base URL set");
+
     // Set placeholder visibility flag for dpe-core
     dpe_core::set_show_placeholder_values(dpe_config.show_placeholder_values);
     if dpe_config.show_placeholder_values {


### PR DESCRIPTION
## Motivation

The OAI-PMH endpoint is live in production at `https://repository.dasch.swiss/dpe/oai`, but the `Identify` response advertised wrong information. The `baseURL` — and every `<request>` element — was hardcoded to `https://meta.dasch.swiss/oai`, a host that does not match the real endpoint. OAI validators and harvest managers compare the advertised `baseURL` against the request URL and reject the repository on this mismatch, so the data provider was effectively unharvestable by conformant clients.

## Summary

- `Identify` now advertises a `baseURL` (and `<request>` URL) that matches the real endpoint, configurable per environment via `DPE_OAI_BASE_URL`.
- OAI record identifiers use the host-independent namespace `oai:dasch.swiss:` instead of `oai:meta.dasch.swiss:`.
- Documentation corrected: production marked as deployed, examples fixed, new env var documented.

## Key Changes

### Configurable base URL
- New `DpeConfig.oai_base_url` field reads `DPE_OAI_BASE_URL`; default `https://repository.dasch.swiss/dpe/oai`.
- `main.rs` sets it at startup via `dpe_api_oai::set_base_url(...)`, next to `set_data_dir`.
- The api-oai crate stores it in a process-global `OnceLock` (`base_url()`), read by the XML builder for `baseURL` and every `<request>` element (including error responses).

### OAI identifier namespace
- `OAI_IDENTIFIER_PREFIX` changed to `oai:dasch.swiss:`. Serialization and `GetRecord` parsing share the single constant, so emitted identifiers resolve.

### Docs
- `oai-pmh.md`: production endpoint table, corrected examples, `DPE_OAI_BASE_URL` note, replaced the resolved baseURL-mismatch limitation with a "keep the env var in sync with the public hostname" caveat.
- `operations.md`: added `DPE_OAI_BASE_URL` to the env-var table.

### Tests
- Updated golden XML and inline identifier assertions.
- Added `resolve_base_url` precedence unit tests and an end-to-end `Identify` assertion (base URL in both `<request>` and `<baseURL>`, no `meta.dasch.swiss`).

## Challenges and Decisions

### How to thread the configurable base URL
**Problem:** `baseURL` is emitted deep in the XML builder, reached by every verb handler and `build_error_response`.
**Tried:** Threading `base_url` as a parameter through all six handlers plus a closure in `main.rs` (the original plan). This would have required updating ~60 test call sites and added noise to every handler signature.
**Solution:** A process-global `OnceLock` set once at startup, mirroring the codebase's existing `dpe_core::set_data_dir` / `set_show_placeholder_values` pattern. Same external contract (`DPE_OAI_BASE_URL` env var with a default), far less churn, consistent with established conventions. A pure `resolve_base_url` helper keeps the precedence unit-testable without fighting the global.

### Datestamp semantics left as-is (scope decision)
**Problem:** `earliestDatestamp` is `1980-04-01`, derived from the minimum project `start_date`. OAI datestamps should reflect when a record changed *in the repository*, not a property of the described resource — so incremental harvesting by `from`/`until` is unreliable.
**Solution:** Out of scope here. A correct fix needs repository ingest/modification timestamps that the data model does not yet carry. The behavior is left unchanged and remains documented as a known limitation (including the `YYYY-MM-DD` granularity caveat).

## Gotchas

- **Set `DPE_OAI_BASE_URL` per environment.** The default is the production URL. DEV must set `https://api.dev.dasch.swiss/dpe/oai`; local dev `http://localhost:4000/dpe/oai`. If the configured value disagrees with the public hostname, validators will flag the mismatch again.
- The golden test files live under `src/oai/handlers/testdata/golden/` (note the `oai/` segment), not `src/handlers/testdata/`, because that is where the `golden()` helper reads from.

## Test Plan

- [x] `just check` (fmt + clippy) passes
- [x] `just test` passes — golden XML, OAI-PMH XSD validation (xmllint), new base-URL tests
- [x] Live server with `DPE_OAI_BASE_URL=https://example.test/custom/oai`: custom value appears in both `<request>` and `<baseURL>`
- [x] `ListIdentifiers`/`GetRecord` use and resolve `oai:dasch.swiss:` identifiers
- [x] Zero `meta.dasch.swiss` in a full `ListRecords` response
- [ ] Set `DPE_OAI_BASE_URL` on DEV/PROD deployment configs before/after merge

## Review Notes

Reviewing the two commits/diff hunks separately helps: the mechanical string replacements in golden files and test assertions are noise; the substantive changes are in `lib.rs`, `xml.rs`, `config.rs`, `main.rs`, and `metadata/mod.rs`.
