### PR TITLE
chore: Docker Scout & Dependabot housekeeping; distroless Mosaic runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,8 +23,29 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
   - package-ecosystem: "docker"
-    # Look for a `Dockerfile` in the `root` directory
-    directory: "/"
+    # Dockerfiles live under the module directories, not the repo root
+    directories:
+      - "/modules/dpe"
+      - "/modules/mosaic/playground"
     # Check for updates once a week
     schedule:
       interval: "weekly"
+  - package-ecosystem: "npm"
+    # The Playwright e2e suites are the only Node footprint in the repo
+    directories:
+      - "/modules/dpe/web-e2e-tests"
+      - "/modules/mosaic/playground-e2e-tests"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    groups:
+      e2e-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+    ignore:
+      # Ignore major updates for all dependencies
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/scout-dpe.yml
+++ b/.github/workflows/scout-dpe.yml
@@ -20,6 +20,7 @@ jobs:
     name: Docker Scout / DPE
     if: >-
       github.event.action != 'closed' &&
+      github.actor != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/scout-mosaic-playground.yml
+++ b/.github/workflows/scout-mosaic-playground.yml
@@ -20,6 +20,7 @@ jobs:
     name: Docker Scout / Mosaic Playground
     if: >-
       github.event.action != 'closed' &&
+      github.actor != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:

--- a/modules/mosaic/playground/Dockerfile
+++ b/modules/mosaic/playground/Dockerfile
@@ -44,14 +44,13 @@ RUN tailwindcss -i modules/mosaic/playground/style/main.css \
 # Build the server binary.
 RUN cargo build --release -p mosaic-playground
 
-FROM debian:bookworm-slim AS runtime
+# Distroless runtime — glibc + C/C++ runtime only, no shell, no apt, no perl.
+# The server is a plain Axum binary serving static files; it makes no outbound
+# TLS calls, so it needs no extra OS packages. This keeps the image minimal and
+# free of the OS-package CVEs that ship with debian-slim (e.g. perl's
+# CVE-2026-12087, "Not Fixed" in bookworm).
+FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
 WORKDIR /app
-RUN apt-get update -y \
-  && apt-get upgrade -y --no-install-recommends \
-  && apt-get install -y --no-install-recommends ca-certificates \
-  && apt-get autoremove -y \
-  && apt-get clean -y \
-  && rm -rf /var/lib/apt/lists/*
 
 # The server binary and the public dir (static assets + the built app.css).
 COPY --from=builder /app/target/release/mosaic-playground /app/mosaic-playground
@@ -61,4 +60,4 @@ ENV MOSAIC_SITE_ADDR="0.0.0.0:8080"
 ENV MOSAIC_PUBLIC_DIR="/app/public"
 EXPOSE 8080
 
-CMD ["/app/mosaic-playground"]
+ENTRYPOINT ["/app/mosaic-playground"]


### PR DESCRIPTION
_No Linear ticket — ad-hoc repository housekeeping._

> [!NOTE]
> #261 (Leptos → Maud) has landed and this PR is **rebased on top of it** —
> the distroless change was re-applied to the rewritten (cargo-chef +
> standalone-Tailwind) Dockerfile.

## Motivation

A recurring Docker Scout "security warning" turned up on PRs, and a Dependabot
PR was stuck red. Investigation showed two distinct, unrelated causes plus a
latent config bug — all in the same Docker Scout / Dependabot area.

## Summary

- Stop Docker Scout from failing (red) on every weekly Dependabot PR.
- Remove a critical + two high CVEs from the published Mosaic Playground image.
- Make Dependabot actually watch the Docker base images.

## Key Changes

### Skip Docker Scout on Dependabot PRs
Dependabot-triggered workflows don't receive repo Actions secrets, so
`docker/login-action` fails with *"Username and password required"* and the
Scout jobs go red — a login failure, not a vulnerability. Both Scout jobs are
now guarded with `github.actor != 'dependabot[bot]'`. No coverage is lost:
crate CVEs are reported by Dependabot alerts (which read `Cargo.lock`), not by
Docker Scout, which scans the image's OS packages.

### Distroless runtime for Mosaic Playground
The image was built on `debian:bookworm-slim`, whose `perl` package carries
**CVE-2026-12087 (critical)** + two highs. The critical is *"Not Fixed"*
upstream in Debian bookworm, so `apt upgrade` cannot clear it. Switched the
runtime stage to `gcr.io/distroless/cc-debian12:nonroot`, removing perl, apt,
the shell, and ~120 OS packages. The post-#261 server is a plain Axum binary
serving static files with no outbound TLS calls, so the runtime needs only
glibc + the C/C++ runtime.

### Fix Dependabot docker ecosystem directories
The `docker` ecosystem pointed at `directory: "/"`, where there is no
Dockerfile, so base-image updates were never proposed. Now points at
`/modules/dpe` and `/modules/mosaic/playground`.

### Add npm ecosystem for the Playwright e2e suites
Post-#261 the two e2e dirs (`modules/dpe/web-e2e-tests`,
`modules/mosaic/playground-e2e-tests`) are the repo's only Node footprint, but
Dependabot had no `npm` entry — Playwright/Biome/axe-core never received
update PRs. Added weekly, grouped, minor+patch-only (same policy as the cargo
entry).

## Challenges and Decisions

### Verifying the distroless runtime
Originally (pre-#261) the image couldn't build on Apple Silicon, so runtime
compatibility was verified at the shared-library level (`ldd`: only `libc`,
`libm`, `libgcc_s`, `ld-linux` — all in `distroless/cc-debian12`). After the
rebase onto #261's rewritten Dockerfile (arch-aware Tailwind download), the
image **builds and runs locally**: pages and `app.css` serve, no shell in the
container, runs as nonroot (uid 65532).

## Gotchas

- Docker Scout is **not** a required status check, so its red ❌ never actually
  blocked merges — but it reads as a "security warning". Don't treat a red
  Scout check on a Dependabot PR as a vulnerability; check whether it's the
  login step that failed.
- Scout only fails the build on a *login* error, not on CVEs (no `exit-code`
  set on the action), so critical CVEs surface as a PR comment + SARIF, not a
  red check.

## Test Plan

- [x] `just check` and `just test` pass (verified locally against the merged
      dependency bumps).
- [x] YAML for both Scout workflows and `dependabot.yml` parses.
- [x] Mosaic binary's required libs confirmed present in `distroless/cc`.
- [x] Distroless image built and exercised locally post-rebase (serves pages +
      CSS, no shell, nonroot).
- [ ] CI builds and publishes the Mosaic Playground image on `ubuntu-latest`.
- [ ] Next Dependabot PR shows no red Scout checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7AdBJhCTxycoiWr7JKCvN

