### PR TITLE
fix(dpe-api-oai): classify DaSCH record creator as Organizational (DEV-6524)

### DIFF
--- a/modules/dpe/api-oai/src/metadata/record_datacite.rs
+++ b/modules/dpe/api-oai/src/metadata/record_datacite.rs
@@ -10,6 +10,19 @@ use super::types::{
 
 const PUBLISHER: &str = "DaSCH";
 
+/// Determines the DataCite `nameType` for an authorship entry.
+///
+/// Record authorship is a free-text name with no structured person/organization
+/// flag, so the type is inferred from the name. DaSCH itself is an organization;
+/// every other authorship name is treated as a person.
+fn authorship_name_type(name: &str) -> &'static str {
+    if name == PUBLISHER {
+        "Organizational"
+    } else {
+        "Personal"
+    }
+}
+
 /// Maps typeOfData to a DataCite resourceTypeGeneral value.
 fn type_of_data_to_general(type_of_data: &str) -> String {
     match type_of_data {
@@ -29,7 +42,7 @@ pub fn record_to_datacite(record: &Record) -> DataCiteRecord {
         .iter()
         .map(|name| DataCiteCreator {
             name: name.clone(),
-            name_type: Some("Personal".to_string()),
+            name_type: Some(authorship_name_type(name).to_string()),
             ..Default::default()
         })
         .collect();
@@ -207,6 +220,33 @@ mod tests {
         assert_eq!(dc.creators.len(), 2);
         assert_eq!(dc.creators[0].name, "Dr. Anna Müller");
         assert_eq!(dc.creators[1].name, "Prof. Hans Bauer");
+    }
+
+    #[test]
+    fn personal_authorship_keeps_personal_name_type() {
+        let dc = record_to_datacite(&test_record());
+        assert_eq!(dc.creators[0].name_type.as_deref(), Some("Personal"));
+        assert_eq!(dc.creators[1].name_type.as_deref(), Some("Personal"));
+    }
+
+    #[test]
+    fn dasch_authorship_is_organizational() {
+        let mut record = test_record();
+        record.legal_info.authorship = vec!["DaSCH".to_string()];
+        let dc = record_to_datacite(&record);
+        assert_eq!(dc.creators.len(), 1);
+        assert_eq!(dc.creators[0].name, "DaSCH");
+        assert_eq!(dc.creators[0].name_type.as_deref(), Some("Organizational"));
+    }
+
+    #[test]
+    fn empty_authorship_falls_back_to_organizational_dasch() {
+        let mut record = test_record();
+        record.legal_info.authorship = vec![];
+        let dc = record_to_datacite(&record);
+        assert_eq!(dc.creators.len(), 1);
+        assert_eq!(dc.creators[0].name, "DaSCH");
+        assert_eq!(dc.creators[0].name_type.as_deref(), Some("Organizational"));
     }
 
     #[test]

--- a/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_record_oai_datacite.xml
+++ b/modules/dpe/api-oai/src/oai/handlers/testdata/golden/get_record_record_oai_datacite.xml
@@ -18,7 +18,7 @@
               <identifier identifierType="ARK">ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh</identifier>
               <creators>
                 <creator>
-                  <creatorName nameType="Personal">DaSCH</creatorName>
+                  <creatorName nameType="Organizational">DaSCH</creatorName>
                 </creator>
               </creators>
               <titles>


### PR DESCRIPTION
Fixes DEV-6524

## Motivation
The OAI-PMH DataCite output for records emitted `<creatorName nameType="Personal">DaSCH</creatorName>`. DaSCH is an organization, not a person, so the type should be `Organizational` per the [DataCite schema](https://datacite-metadata-schema.readthedocs.io/en/4.7/properties/creator/#a-nametype). A `ListRecords` dump showed ~51k records (50,994) with the wrong `Personal` type vs only 38 correct `Organizational`.

## Summary
- Record creators named `DaSCH` are now emitted as `nameType="Organizational"`.
- All other (personal) authorship names are unchanged (`Personal`).

## Key Changes
### Record → DataCite transform (`record_datacite.rs`)
- Added `authorship_name_type(name)`: returns `Organizational` for the publisher (`DaSCH`), `Personal` otherwise.
- Wired it into the creator mapping, replacing the hardcoded `Personal`.

## Challenges and Decisions
### Where the bad data comes from
**Problem:** Every record's `legalInfo.authorship` is the literal string `"DaSCH"`, and the records transform hardcoded `nameType="Personal"` for every authorship entry.
**Solution:** Record authorship is free-text with no structured person/organization flag, so the type must be inferred from the name. The projects transform already infers this via the newer `resolve_agent` layer (keyed on `organization-`/`person-` IDs), but records carry plain name strings. A conservative name-based rule — only the exact publisher string `DaSCH` is reclassified — resolves all 50,994 cases without risking misclassification of real personal names.

## Gotchas
- The rule matches `DaSCH` exactly. If records ever carry other organization names in `authorship`, they would still be tagged `Personal` and the rule would need extending. Today the data is uniformly `"DaSCH"`.
- Scope is limited to Q3 of the issue. Q4 (a person name appearing in a record/project title) is a source-data entry issue, not a transform bug, and is not addressed here.

## Test Plan
- [x] `just check` (fmt + clippy) clean
- [x] `just test` green
- [x] New unit tests: personal names stay `Personal`, `DaSCH` becomes `Organizational`, empty authorship falls back to `Organizational` DaSCH
- [x] Updated golden XML (`get_record_record_oai_datacite.xml`) reflects `Organizational`