### PR TITLE
fix(dpe-data): update Eva Pibiri's job title to Associate Professor

### DIFF
--- a/modules/dpe/server/data/persons/person-062.json
+++ b/modules/dpe/server/data/persons/person-062.json
@@ -14,7 +14,7 @@
         "Pibiri"
     ],
     "jobTitles": [
-        "Senior lecturer"
+        "Associate Professor"
     ],
     "affiliations": [
         "organization-001"


### PR DESCRIPTION
## Motivation
Eva Pibiri (contributor to the Société-Savoie project, 0121) requested that her
job title be corrected. She has been promoted from "Senior lecturer" to
"Associate Professor" and asked for the metadata shown on the platform to
reflect this.

## Summary
- Update Eva Pibiri's job title from "Senior lecturer" to "Associate Professor".

## Key Changes
### Person metadata
- `modules/dpe/server/data/persons/person-062.json`: `jobTitles` changed from
  `"Senior lecturer"` to `"Associate Professor"`. All other fields (ORCID,
  email, affiliation) are unchanged.

## Challenges and Decisions
None — a single-value metadata correction.

## Gotchas
- The person record (`person-062`) is referenced by the Société-Savoie project
  (`modules/dpe/server/data/projects/0121_societesavoie.json`) as a contributor;
  the title is stored once on the person and reused wherever the person is
  referenced.

## Test Plan
- [x] `cargo test --tests` passes (person data loads and validates)
- [ ] Verify the updated title renders on the project/person page
