### PR TITLE
fix(ci): pass release-please PR JSON via env to survive shell quoting

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,9 +33,10 @@ jobs:
         id: find-pr
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          RELEASE_PR: ${{ steps.release.outputs.pr }}
         run: |
-          if [ -n '${{ steps.release.outputs.pr }}' ]; then
-            BRANCH=$(echo '${{ steps.release.outputs.pr }}' | jq -r '.headBranchName')
+          if [ -n "$RELEASE_PR" ]; then
+            BRANCH=$(echo "$RELEASE_PR" | jq -r '.headBranchName')
           else
             BRANCH=$(gh pr list --repo "${{ github.repository }}" --label "autorelease: pending" --json headRefName --jq '.[0].headRefName // empty')
           fi


### PR DESCRIPTION
## Problem

The Release Please workflow's **Find release PR branch** step failed on the 0.8.0 release ([run](https://github.com/dasch-swiss/dsp-repository/actions/runs/28649247462/job/84963032209)) with:

```
line 1: syntax error near unexpected token `('
```

The step interpolated `${{ steps.release.outputs.pr }}` — the release-please PR JSON, including the changelog body — directly into the shell script inside single quotes:

```bash
if [ -n '${{ steps.release.outputs.pr }}' ]; then
```

This release's changelog contained `update Eva Pibiri's job title`. The apostrophe in `Pibiri's` closed the single quote, and the following changelog markdown link parentheses `([4946a7d](...))` hit bash unquoted → syntax error.

## Impact

Because the step exited non-zero, `steps.find-pr.outputs.branch` was never set. Every downstream step is guarded by `if: steps.find-pr.outputs.branch`, so **Update Cargo.lock on release PR** never ran. `Cargo.toml` was bumped to `0.8.0` but `Cargo.lock` stayed at `0.7.1`, which failed the `test --locked` job on PR #258 (and would recur on any release whose changelog contains an apostrophe or parens).

## Fix

Pass the output through an env var and reference it double-quoted, so bash never re-parses the JSON contents. This is also the GitHub Actions script-injection-safe pattern.

## Follow-up

After this merges, PR #258 still needs its `Cargo.lock` refreshed once — the next push to `main` re-triggers release-please and the (now-working) lockfile step will commit it, or it can be regenerated manually with `cargo update --workspace`.

## Other repos

Checked the other active repos — dsp-tools already uses the safe pattern (PR data in a shell var, never interpolated), and no other release workflow interpolates release-please output into a shell body. dsp-repository was the only affected repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)