### PR TITLE
fix(ci): keep release-please release PRs to a single commit

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -61,5 +61,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Cargo.lock
-          git commit -m "chore: update Cargo.lock for release"
-          git push
+          # Amend release-please's commit instead of adding a second one, so the
+          # release PR stays a single commit. With rebase-only merge this keeps
+          # the release to one commit on main. --no-edit preserves the
+          # "chore(main): release X.Y.Z" message that release-please matches on.
+          git commit --amend --no-edit
+          git push --force-with-lease


### PR DESCRIPTION
## Motivation
release-please release PRs were landing **two** commits on `main`:

```
chore(main): release X.Y.Z          ← release-please
chore: update Cargo.lock for release ← this workflow
```

Because `main` uses a **rebase-only** merge policy (ruleset), both commits are replayed into history on every release. The second commit exists only because we regenerate `Cargo.lock` ourselves — release-please can't (`release-type: simple`, since the native `cargo-workspace` plugin doesn't support `version.workspace = true`, upstream #2111).

## Summary
- Release PRs now stay a **single commit**, so a release adds exactly one commit to `main`.

## Key Changes
### `.github/workflows/release-please.yml`
- The "Update Cargo.lock on release PR" step now **amends** release-please's commit instead of adding a second one:
  - `git commit --amend --no-edit` (preserves the `chore(main): release X.Y.Z` message that release-please matches on)
  - `git push --force-with-lease`

## Challenges and Decisions
**Problem:** rebase-only merge means every PR commit lands on `main`; the extra lockfile commit was pure noise.
**Alternative considered:** squash-merging the release PR — rejected because it conflicts with the rebase-only ruleset on `main`.
**Solution:** fold the lockfile into the existing release commit via `--amend`. Behaviorally equivalent to before — the lockfile step already runs right after release-please in the same run, and release-please force-pushes a fresh commit each run that this step re-amends.

## Gotchas
- Keep `--no-edit` on the amend: release-please identifies the release commit by its message + the `autorelease: pending` label. Changing the message would break release detection on merge.
- The push must be `--force-with-lease` because amending rewrites the branch tip.

## Test Plan
- [ ] On the next release cycle, confirm the release PR shows a single commit including both the version bump and the `Cargo.lock` update.
- [ ] Confirm merging the release PR adds exactly one commit to `main` and the GitHub release/tag is still created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)