### PR TITLE
docs: clarify that PRs should default to a single commit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,8 +82,11 @@ Before considering ANY change as "done":
 - **Check if documentation needs updating** —
   Consider `docs/src/`, `CLAUDE.md`, `CONVENTIONS.md`, and `REVIEW.md`.
   Update documentation to reflect the changes.
-- **Ask before committing** —
-  Never run git add or commit without explicit permission.
+- **One commit per PR by default** —
+  We use rebase-merge, so every branch commit lands on main verbatim.
+  Clean up working commits before the PR is merged; aim for a single commit.
+  Use multiple commits only when the work is genuinely several
+  independent, self-contained changes. See `docs/src/workflows.md`.
 - **PR creation** — See `docs/src/workflows.md` for the PR workflow and template.
 
 ## Testing Guidelines

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -40,7 +40,7 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/). Scopes matc
 | `style:` | Formatting | hidden | none |
 | `chore:` | Maintenance | hidden | none |
 
-Group commits by user-visible impact. Each `feat:` or `fix:` = one changelog entry. Internal work → squash aggressively. See `docs/src/workflows.md` for full details.
+A PR should land as **one commit by default**. Rebase-merge puts every branch commit on main verbatim, so clean up working commits (interactive rebase) before merging — split into multiple commits only when the work is genuinely several independent, self-contained changes. Group by user-visible impact: each `feat:` or `fix:` = one changelog entry; internal work → squash aggressively. See `docs/src/workflows.md` for full details.
 
 ## PR Template
 

--- a/docs/src/workflows.md
+++ b/docs/src/workflows.md
@@ -27,8 +27,11 @@ For any interaction or coding-related workflow, the justfile is the primary sour
 
 We use a **rebase workflow**. All changes are made on a branch, then rebased onto main before being merged. This keeps a clean, linear commit history.
 
-- **Rebase-merge**: PRs are integrated using rebase-merge (not squash or merge commits). Every commit on a branch becomes a commit on main.
-- **Clean commit history**: Before merging, clean up the branch so that each commit represents one logical unit of change. Squash fixups, reword messages, and reorder commits so the history reads well on main.
+The goal is a **meaningful history on `main`**: every commit on main should be a deliberate, self-contained unit of change. Working commits ("WIP", "fix typo", "address review feedback") do not belong on main.
+
+- **Rebase-merge**: PRs are integrated using rebase-merge (not squash or merge commits). Every commit on the branch lands on main verbatim — so the branch history _is_ the main history. There is no squash-on-merge safety net; whatever you leave on the branch is what ships.
+- **Clean up before merging (mandatory)**: before a PR is merged, rewrite the branch (interactive rebase) so its commits read well on main. Squash working commits, reword messages, reorder as needed.
+- **Default to a single commit**: almost always, a PR should end up as **one** clean commit. Split into multiple commits only when the work genuinely represents several independent, self-contained changes that each deserve their own line in the history — and each must stand on its own. When in doubt, squash to one.
 
 ## Commit Conventions
 
@@ -52,7 +55,7 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/). Scopes matc
 
 ### Commit Organization
 
-Group commits by user-visible impact, not by implementation journey.
+Group commits by user-visible impact, not by implementation journey. Start from the assumption that the whole PR is **one commit**, and only split it up if the work below genuinely divides into multiple self-contained changes.
 
 1. Each `feat:` or `fix:` commit = one changelog entry visible to deployers
 2. Internal work (`build:`, `ci:`, `refactor:`, `docs:`, `chore:`, `test:`) is hidden from changelog — squash aggressively


### PR DESCRIPTION
## Motivation
The rebase-merge Git workflow was being consistently misread as "multiple commits are expected on main". The docs stated *how* the workflow runs (rebase-merge, every branch commit lands on main) but never stated the *intended outcome*: a meaningful history where the default is one clean commit per PR.

## Summary
- Make the single-commit-by-default intent explicit and unmissable in the three places contributors and the agent read: `docs/src/workflows.md`, `CONVENTIONS.md`, and `CLAUDE.md`.
- Frame multiple commits as the special case, reserved for genuinely independent, self-contained changes.

## Key Changes
### docs/src/workflows.md
- Git Workflow section now leads with the goal (meaningful history on `main`; working commits don't belong there), notes rebase-merge has no squash safety net, marks cleanup as mandatory, and adds a "Default to a single commit" rule.
- Commit Organization now starts from "assume the whole PR is one commit; split only if it genuinely divides".

### CONVENTIONS.md
- Commit one-liner now opens with "A PR should land as one commit by default" and explains the rebase-merge-verbatim reason.

### CLAUDE.md
- Added a "One commit per PR by default" bullet to the Development Workflow checklist.
- Removed the redundant "Ask before committing" bullet (per request).

## Gotchas
Purely documentation. No code or behavior changes.

## Test Plan
- [ ] Read through the three files and confirm the single-commit-default intent is clear and consistent.

## Review Notes
Single commit; doc-only.