### PR TITLE
build: add cargo-machete unused-dependency check to just check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -40,8 +40,8 @@ jobs:
         uses: extractions/setup-just@v4
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@main
-      - name: Install maudfmt
-        run: cargo binstall -y maudfmt@0.1.8
+      - name: Install maudfmt and cargo-machete
+        run: cargo binstall -y maudfmt@0.1.8 cargo-machete@0.9.2
       - name: just check
         run: just check
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ just install-requirements
 ```bash
 just dev                        # Run DPE with hot reload (Tailwind --watch + bacon serve + browser live-reload)
 just watch-mosaic-playground    # Run Mosaic playground with hot reload
-just check                      # Run fmt checks and clippy
+just check                      # Run fmt checks, clippy, and unused-dependency check
 just fmt                        # Format all code (maudfmt for html! macros, then cargo +nightly fmt)
 just test                       # Run all tests
 just build                      # Build all targets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,6 @@ dependencies = [
  "tower_governor",
  "tracing",
  "tracing-opentelemetry",
- "tracing-opentelemetry-instrumentation-sdk",
  "tracing-subscriber",
  "ureq",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ init-tracing-opentelemetry = { version = "0.36", features = [
     "metrics",
     "tracing_subscriber_ext",
 ] }
-tracing-opentelemetry-instrumentation-sdk = "0.32"
 opentelemetry = { version = "0.31", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.31", features = ["rt-tokio", "metrics", "logs"] }
 opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "trace", "metrics", "logs"] }

--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,7 @@
             # Maud dev tooling (DEV-6642)
             _ensure_tool bacon           bacon             3.23.0   # dev loop: kill_then_restart server
             _ensure_tool maudfmt         maudfmt           0.1.8    # Maud template formatting
+            _ensure_tool cargo-machete   cargo-machete     0.9.2    # unused-dependency check (just check)
 
             unset -f _ensure_tool
           '';

--- a/justfile
+++ b/justfile
@@ -24,6 +24,7 @@ install-requirements: install-e2e-requirements
     cargo binstall -y mdbook-mermaid@0.16.2
     cargo binstall -y bacon@3.23.0
     cargo binstall -y maudfmt@0.1.8
+    cargo binstall -y cargo-machete@0.9.2
 
 # Install Playwright browsers for E2E tests
 install-e2e-requirements: _check-node
@@ -54,6 +55,9 @@ check:
     [ "$rc" -eq 0 ] || { echo "run 'just fmt' to fix Maud formatting" >&2; exit 1; }
     cargo +nightly fmt --check --all
     cargo clippy --all-features -- -D warnings
+    # Fail on declared-but-unconsumed dependencies (a dep added "for later wiring" that never
+    # got wired survives on the strength of a comment otherwise).
+    cargo machete
 
 # Format all code: maudfmt for the `html!` Maud macros, then cargo +nightly fmt for the rest.
 fmt:

--- a/modules/dpe/server/Cargo.toml
+++ b/modules/dpe/server/Cargo.toml
@@ -27,7 +27,6 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 axum-tracing-opentelemetry.workspace = true
 init-tracing-opentelemetry.workspace = true
-tracing-opentelemetry-instrumentation-sdk.workspace = true
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
 opentelemetry-otlp.workspace = true


### PR DESCRIPTION
_No Linear ticket — check-pipeline hardening; motivated by a documented learning._

## Motivation

During the Leptos removal (DEV-6642), `tower-livereload` was added to the workspace catalog "for later wiring" — the wiring never landed, and the dep sat unreferenced for three weeks, surviving on the strength of its comment. Nothing in the check pipeline flags a declared-but-unconsumed dependency. Full write-up: dasch-specs `learnings/best-practices/deferred-work-lost-across-phase-handoffs.md` (dasch-swiss/dasch-specs#144).

## Summary

- `just check` now runs `cargo machete` as its final step — declared-but-unconsumed dependencies fail the check.
- `cargo-machete@0.9.2` installed (pinned) via `install-requirements`, the Nix dev shell, and the CI check job — same pattern as maudfmt.
- **First catch:** `tracing-opentelemetry-instrumentation-sdk` was declared in `dpe-server` (and the workspace catalog) with zero code references — removed.

## Test Plan

- [x] `just check` green end-to-end (machete step passes after the dead-dep removal)
- [x] `just test` green (7 suites)
- [x] `cargo check -p dpe-server` clean after the dep removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138s9RpuxVEHFJHMYCb9j82