### PR TITLE
feat: browser live-reload in the DPE & playground dev loops (DEV-6728)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ just install-requirements
 ## Key Commands
 
 ```bash
-just dev                        # Run DPE with hot reload (Tailwind --watch + bacon serve)
+just dev                        # Run DPE with hot reload (Tailwind --watch + bacon serve + browser live-reload)
 just watch-mosaic-playground    # Run Mosaic playground with hot reload
 just check                      # Run fmt checks and clippy
 just fmt                        # Format all code (maudfmt for html! macros, then cargo +nightly fmt)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,7 @@ dependencies = [
  "insta",
  "maud",
  "mosaic-tiles",
+ "notify",
  "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
@@ -632,6 +633,7 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
+ "tower-livereload",
  "tower_governor",
  "tracing",
  "tracing-opentelemetry",
@@ -827,6 +829,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures"
@@ -1561,6 +1572,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
+name = "inotify"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+dependencies = [
+ "bitflags 2.11.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "insta"
 version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,6 +1673,26 @@ checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
 ]
 
 [[package]]
@@ -1817,6 +1868,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1828,8 +1880,11 @@ dependencies = [
  "axum",
  "maud",
  "mosaic-tiles",
+ "notify",
  "tokio",
+ "tower",
  "tower-http",
+ "tower-livereload",
 ]
 
 [[package]]
@@ -1868,6 +1923,33 @@ name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.11.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -2117,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -3262,6 +3344,20 @@ name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-livereload"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df210bd982165dee3c20e31deed79a3585ee6b255c070d9c73ae015cc40d2f3"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tokio",
+ "tower",
+]
 
 [[package]]
 name = "tower-service"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,10 @@ tokio = { version = "1", features = ["full"] }
 tower = "0.5.3"
 tower_governor = "0.6"
 tower-http = { version = "0.6.11", features = ["trace", "fs", "cors"] }
+# Dev-loop live-reload (dev feature only): browser auto-refresh layer + asset-dir watcher.
+# tower-livereload injects only into text/html, never text/event-stream (Datastar-safe).
+tower-livereload = "0.10.3"
+notify = "8.2"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 # OpenTelemetry

--- a/bacon.toml
+++ b/bacon.toml
@@ -7,7 +7,7 @@ command = ["cargo", "check", "--all-targets", "--color", "always"]
 need_stdout = false
 
 [jobs.serve]
-command = ["cargo", "run", "--bin", "dpe-server", "--", "serve"]
+command = ["cargo", "run", "--bin", "dpe-server", "--features", "dev", "--", "serve"]
 need_stdout = true
 background = false
 on_change_strategy = "kill_then_restart"

--- a/justfile
+++ b/justfile
@@ -53,7 +53,7 @@ check:
     done < <(git ls-files -z '*.rs')
     [ "$rc" -eq 0 ] || { echo "run 'just fmt' to fix Maud formatting" >&2; exit 1; }
     cargo +nightly fmt --check --all
-    cargo clippy -- -D warnings
+    cargo clippy --all-features -- -D warnings
 
 # Format all code: maudfmt for the `html!` Maud macros, then cargo +nightly fmt for the rest.
 fmt:
@@ -81,6 +81,8 @@ validate-data:
 # Run all tests
 test:
     cargo test --tests
+    # The dev-only live-reload code is feature-gated, so its tests need the feature enabled.
+    cargo test -p dpe-server -p mosaic-playground --features dpe-server/dev,mosaic-playground/dev --tests
 
 # Clean all build artifacts
 clean:
@@ -164,7 +166,7 @@ watch-mosaic-playground:
     "$bin" -i modules/mosaic/playground/style/main.css -o modules/mosaic/playground/public/assets/app.css --watch &
     tw=$!
     trap 'kill $tw 2>/dev/null || true' EXIT
-    MOSAIC_PUBLIC_DIR=modules/mosaic/playground/public cargo watch -x 'run -p mosaic-playground'
+    MOSAIC_PUBLIC_DIR=modules/mosaic/playground/public cargo watch -x 'run -p mosaic-playground --features dev'
 
 # Build Docker image for mosaic playground
 [group('mosaic')]

--- a/modules/dpe/server/Cargo.toml
+++ b/modules/dpe/server/Cargo.toml
@@ -4,6 +4,11 @@ version.workspace = true
 edition = "2021"
 publish = false
 
+[features]
+# Dev-loop live-reload: browser auto-refresh on server restart + asset changes.
+# Enabled by the dev loop (bacon.toml / `just dev`); never in release builds.
+dev = ["dep:tower-livereload", "dep:notify"]
+
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 ureq = "3"
@@ -33,6 +38,8 @@ futures = "0.3"
 tower.workspace = true
 tower-http.workspace = true
 tower_governor.workspace = true
+tower-livereload = { workspace = true, optional = true }
+notify = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 url.workspace = true

--- a/modules/dpe/server/src/dev_reload.rs
+++ b/modules/dpe/server/src/dev_reload.rs
@@ -1,0 +1,151 @@
+//! Dev-only browser live-reload (`dev` feature).
+//!
+//! Wraps the router in `tower_livereload::LiveReloadLayer` and watches the
+//! asset dir, so the browser reloads both when the server restarts (bacon's
+//! `kill_then_restart` — the injected client reconnects and reloads) and when
+//! a CSS-only rebuild lands (Tailwind `--watch` rewrites `app.css` without a
+//! server restart, which the file watcher turns into a reload push).
+//!
+//! Datastar-safe: the layer's default response predicate injects only into
+//! `text/html` responses, never `text/event-stream`, so SSE morphing is
+//! untouched. Do not replace the default response predicate.
+
+use std::path::Path;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use axum::Router;
+use notify::Watcher;
+use tower_livereload::{LiveReloadLayer, Reloader};
+
+/// Suppress reload bursts: one asset write can emit several filesystem events
+/// (temp file + rename), and one browser reload per write is plenty.
+const DEBOUNCE: Duration = Duration::from_millis(200);
+
+/// Wrap `router` with the live-reload layer and spawn a watcher on
+/// `asset_dir` that pushes a browser reload on any file change under it.
+pub(crate) fn apply<S: Clone + Send + Sync + 'static>(router: Router<S>, asset_dir: &Path) -> Router<S> {
+    let layer = LiveReloadLayer::new();
+    spawn_asset_watcher(asset_dir, layer.reloader());
+    router.layer(layer)
+}
+
+fn spawn_asset_watcher(asset_dir: &Path, reloader: Reloader) {
+    let last_reload = Mutex::new(Instant::now() - DEBOUNCE);
+    let mut watcher = match notify::recommended_watcher(move |event: Result<notify::Event, notify::Error>| {
+        if event.is_err() {
+            return;
+        }
+        let mut last = last_reload.lock().expect("live-reload debounce lock poisoned");
+        if last.elapsed() >= DEBOUNCE {
+            *last = Instant::now();
+            reloader.reload();
+        }
+    }) {
+        Ok(watcher) => watcher,
+        Err(e) => {
+            tracing::warn!("live-reload: failed to create asset watcher: {e}");
+            return;
+        }
+    };
+    if let Err(e) = watcher.watch(asset_dir, notify::RecursiveMode::Recursive) {
+        tracing::warn!("live-reload: failed to watch {}: {e}", asset_dir.display());
+        return;
+    }
+    tracing::info!("live-reload: watching {} for asset changes", asset_dir.display());
+    // The watcher stops on drop; keep it alive for the (dev-only) process lifetime.
+    std::mem::forget(watcher);
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{header, Request, StatusCode};
+    use axum::response::{Html, IntoResponse};
+    use axum::routing::get;
+    use axum::Router;
+    use tower::ServiceExt;
+
+    use super::*;
+
+    const PAGE: &str = "<html><head></head><body>hello</body></html>";
+    const SSE_BODY: &str = "event: datastar-patch-elements\ndata: elements <div id=\"x\"></div>\n\n";
+
+    fn test_router() -> Router {
+        let router = Router::new().route("/page", get(|| async { Html(PAGE) })).route(
+            "/sse",
+            get(|| async { ([(header::CONTENT_TYPE, "text/event-stream")], SSE_BODY).into_response() }),
+        );
+        apply(router, Path::new("."))
+    }
+
+    async fn body_string(router: Router, uri: &str) -> (StatusCode, String) {
+        let response = router
+            .oneshot(Request::get(uri).body(Body::empty()).expect("request"))
+            .await
+            .expect("response");
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.expect("body");
+        (status, String::from_utf8(bytes.to_vec()).expect("utf8 body"))
+    }
+
+    /// HTML pages get the live-reload client injected (script under the
+    /// layer's `/_tower-livereload` prefix).
+    #[tokio::test]
+    async fn injects_livereload_script_into_html_responses() {
+        let (status, body) = body_string(test_router(), "/page").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body.contains("hello"), "page content must survive: {body}");
+        assert!(
+            body.contains("/_tower-livereload"),
+            "expected injected live-reload script: {body}"
+        );
+    }
+
+    /// SSE responses pass through byte-identical — the injection predicate
+    /// must never touch `text/event-stream` (Datastar morphing).
+    #[tokio::test]
+    async fn leaves_sse_responses_untouched() {
+        let (status, body) = body_string(test_router(), "/sse").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, SSE_BODY, "SSE body must not be modified by live-reload");
+    }
+
+    /// Writing a file into the watched asset dir pushes a `reload` event on
+    /// the layer's event stream — the CSS-only reload path (Tailwind rewrites
+    /// app.css without a server restart, so only the watcher can trigger it).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn asset_change_emits_reload_event() {
+        let dir = std::env::temp_dir().join(format!("dpe-livereload-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create watch dir");
+
+        let router = apply(Router::new().route("/page", get(|| async { Html(PAGE) })), &dir);
+        let response = router
+            .oneshot(
+                Request::get("/_tower-livereload/event-stream")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("event-stream response");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // The stream body ends after the first reload event, so collecting it
+        // completes exactly when the watcher fires.
+        let collect = tokio::spawn(axum::body::to_bytes(response.into_body(), usize::MAX));
+
+        // Give the watcher a moment, then simulate a Tailwind write.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        std::fs::write(dir.join("app.css"), "body{}").expect("write asset");
+
+        let bytes = tokio::time::timeout(Duration::from_secs(5), collect)
+            .await
+            .expect("event stream must complete after the asset write")
+            .expect("task")
+            .expect("body");
+        let body = String::from_utf8(bytes.to_vec()).expect("utf8 body");
+        assert!(body.contains("event: reload"), "expected a reload event, got: {body}");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/modules/dpe/server/src/main.rs
+++ b/modules/dpe/server/src/main.rs
@@ -4,6 +4,8 @@ use std::process::ExitCode;
 use clap::{Parser, Subcommand};
 
 mod config;
+#[cfg(feature = "dev")]
+mod dev_reload;
 mod fragments;
 mod telemetry_collector;
 mod traceparent;
@@ -344,7 +346,14 @@ async fn serve() -> ExitCode {
         // - OtelInResponseLayer (declared first) runs INNER — injects traceparent into response headers
         // - OtelAxumLayer (declared second) runs OUTER — creates the server span from the request
         .layer(OtelInResponseLayer)
-        .layer(OtelAxumLayer::default())
+        .layer(OtelAxumLayer::default());
+
+    // Dev-only browser live-reload (`dev` feature): wraps the page/static
+    // routes declared above; the untraced routes below stay outside it.
+    #[cfg(feature = "dev")]
+    let app = dev_reload::apply(app, &dpe_config.public_dir);
+
+    let app = app
         // --- Untraced routes ---
         // Routes declared AFTER .layer() calls are NOT wrapped by those layers.
         .route("/healthz", get(|| async { StatusCode::OK }))

--- a/modules/mosaic/CLAUDE.md
+++ b/modules/mosaic/CLAUDE.md
@@ -26,7 +26,7 @@ The `/add-mosaic-component` skill walks through this. In short:
 
 - There is no `build.rs` CSS pipeline. Each component's CSS is self-contained (`@apply` on the design tokens, no DaisyUI) and lives next to its source.
 - The consuming app's Tailwind entry `@import`s `tokens.css` + the component CSS files, then runs a single standalone Tailwind invocation.
-- Playground stylesheet: `just css-mosaic` → `playground/public/assets/app.css` (gitignored). Dev loop: `just watch-mosaic-playground` (Tailwind `--watch` + `cargo watch`).
+- Playground stylesheet: `just css-mosaic` → `playground/public/assets/app.css` (gitignored). Dev loop: `just watch-mosaic-playground` (Tailwind `--watch` + `cargo watch` + browser live-reload via the `dev` feature).
 
 ## Testing and Verification
 

--- a/modules/mosaic/playground/Cargo.toml
+++ b/modules/mosaic/playground/Cargo.toml
@@ -7,9 +7,20 @@ publish = false
 # Plain Axum + Maud server. No cdylib/WASM: the playground is a
 # server-rendered MPA showcase, like DPE.
 
+[features]
+# Dev-loop live-reload: browser auto-refresh on server restart + asset changes.
+# Enabled by `just watch-mosaic-playground`; never in release builds.
+dev = ["dep:tower-livereload", "dep:notify"]
+
 [dependencies]
 axum.workspace = true
 maud.workspace = true
 tokio.workspace = true
 tower-http.workspace = true
 mosaic-tiles = { path = "../tiles" }
+tower-livereload = { workspace = true, optional = true }
+notify = { workspace = true, optional = true }
+
+[dev-dependencies]
+# `ServiceExt::oneshot` for router tests
+tower = { workspace = true, features = ["util"] }

--- a/modules/mosaic/playground/src/dev_reload.rs
+++ b/modules/mosaic/playground/src/dev_reload.rs
@@ -1,0 +1,110 @@
+//! Dev-only browser live-reload (`dev` feature) — same shape as
+//! `dpe-server/src/dev_reload.rs`: the layer reloads the browser after a
+//! server restart (cargo-watch), and the asset watcher covers CSS-only
+//! rebuilds (Tailwind `--watch` rewrites `app.css` without a restart).
+//!
+//! Datastar-safe by the layer's default response predicate: injects only into
+//! `text/html`, never `text/event-stream`. Do not replace the predicate.
+
+use std::path::Path;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use axum::Router;
+use notify::Watcher;
+use tower_livereload::{LiveReloadLayer, Reloader};
+
+/// Suppress reload bursts: one asset write can emit several filesystem events.
+const DEBOUNCE: Duration = Duration::from_millis(200);
+
+/// Wrap `router` with the live-reload layer and spawn a watcher on
+/// `asset_dir` that pushes a browser reload on any file change under it.
+pub(crate) fn apply(router: Router, asset_dir: &Path) -> Router {
+    let layer = LiveReloadLayer::new();
+    spawn_asset_watcher(asset_dir, layer.reloader());
+    router.layer(layer)
+}
+
+fn spawn_asset_watcher(asset_dir: &Path, reloader: Reloader) {
+    let last_reload = Mutex::new(Instant::now() - DEBOUNCE);
+    let mut watcher = match notify::recommended_watcher(move |event: Result<notify::Event, notify::Error>| {
+        if event.is_err() {
+            return;
+        }
+        let mut last = last_reload.lock().expect("live-reload debounce lock poisoned");
+        if last.elapsed() >= DEBOUNCE {
+            *last = Instant::now();
+            reloader.reload();
+        }
+    }) {
+        Ok(watcher) => watcher,
+        Err(e) => {
+            eprintln!("live-reload: failed to create asset watcher: {e}");
+            return;
+        }
+    };
+    if let Err(e) = watcher.watch(asset_dir, notify::RecursiveMode::Recursive) {
+        eprintln!("live-reload: failed to watch {}: {e}", asset_dir.display());
+        return;
+    }
+    println!("live-reload: watching {} for asset changes", asset_dir.display());
+    // The watcher stops on drop; keep it alive for the (dev-only) process lifetime.
+    std::mem::forget(watcher);
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::{header, Request, StatusCode};
+    use axum::response::{Html, IntoResponse};
+    use axum::routing::get;
+    use axum::Router;
+    use tower::ServiceExt;
+
+    use super::*;
+
+    // The watcher→reload wiring itself is covered by
+    // `dpe-server::dev_reload::tests::asset_change_emits_reload_event`
+    // (identical code); here we pin the injection predicate on this router.
+
+    const PAGE: &str = "<html><head></head><body>showcase</body></html>";
+    const SSE_BODY: &str = "event: datastar-patch-elements\ndata: elements <div id=\"x\"></div>\n\n";
+
+    fn test_router() -> Router {
+        let router = Router::new().route("/page", get(|| async { Html(PAGE) })).route(
+            "/sse",
+            get(|| async { ([(header::CONTENT_TYPE, "text/event-stream")], SSE_BODY).into_response() }),
+        );
+        apply(router, Path::new("."))
+    }
+
+    async fn body_string(router: Router, uri: &str) -> (StatusCode, String) {
+        let response = router
+            .oneshot(Request::get(uri).body(Body::empty()).expect("request"))
+            .await
+            .expect("response");
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.expect("body");
+        (status, String::from_utf8(bytes.to_vec()).expect("utf8 body"))
+    }
+
+    /// HTML pages get the live-reload client injected.
+    #[tokio::test]
+    async fn injects_livereload_script_into_html_responses() {
+        let (status, body) = body_string(test_router(), "/page").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body.contains("showcase"), "page content must survive: {body}");
+        assert!(
+            body.contains("/_tower-livereload"),
+            "expected injected live-reload script: {body}"
+        );
+    }
+
+    /// SSE responses pass through byte-identical.
+    #[tokio::test]
+    async fn leaves_sse_responses_untouched() {
+        let (status, body) = body_string(test_router(), "/sse").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, SSE_BODY, "SSE body must not be modified by live-reload");
+    }
+}

--- a/modules/mosaic/playground/src/main.rs
+++ b/modules/mosaic/playground/src/main.rs
@@ -2,6 +2,8 @@
 //! showcase as a server-rendered MPA.
 
 mod app;
+#[cfg(feature = "dev")]
+mod dev_reload;
 mod showcase;
 
 #[tokio::main]
@@ -12,7 +14,11 @@ async fn main() {
     let addr = std::env::var("MOSAIC_SITE_ADDR").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     let public_dir = std::env::var("MOSAIC_PUBLIC_DIR").unwrap_or_else(|_| "public".to_string());
 
-    let router = app::router(public_dir.into());
+    let router = app::router(public_dir.clone().into());
+
+    // Dev-only browser live-reload (`dev` feature).
+    #[cfg(feature = "dev")]
+    let router = dev_reload::apply(router, std::path::Path::new(&public_dir));
 
     let listener = tokio::net::TcpListener::bind(&addr)
         .await


### PR DESCRIPTION
Fixes DEV-6728

## Motivation

The Leptos removal (DEV-6642) replaced `cargo leptos watch` — which bundled rebuild **and** browser reload — with a composed dev loop. The plan's Q8 design had three legs (bacon + Tailwind `--watch` + tower-livereload); the third was explicitly deferred from Phase 0 to Phase 2 and silently fell through the session handoff (write-up: dasch-specs `learnings/best-practices/deferred-work-lost-across-phase-handoffs.md`). This PR completes it: **edit code or CSS under `just dev` / `just watch-mosaic-playground` and the browser refreshes itself.**

## Summary

- New `dev_reload` module in **dpe-server** and **mosaic-playground**, behind a new `dev` cargo feature (optional deps — `tower-livereload` 0.10.3 + `notify` 8.2 — fully absent from release builds): `LiveReloadLayer` + a file watcher on the asset dir, 200 ms debounce.
- **Two reload paths**: server restarts (bacon `kill_then_restart` / cargo-watch — the injected client reconnects and reloads) and **CSS-only rebuilds** (Tailwind `--watch` rewrites `app.css` without a restart; the watcher pushes the reload).
- **Datastar-safe**: the layer's default predicate injects only into `text/html`, never `text/event-stream`.
- Wiring: bacon's serve job and `watch-mosaic-playground` run `--features dev`; `just test` also runs the feature-gated tests; `just check` clippy → `--all-features` so the dev code is linted. In dpe-server the layer sits after the OTel layers and before the untraced routes (`/healthz`, `/telemetry/collect` stay outside).

## Tests

Feature-gated unit tests pin the acceptance criteria:
- `injects_livereload_script_into_html_responses` (both apps)
- `leaves_sse_responses_untouched` — SSE bodies byte-identical (both apps)
- `asset_change_emits_reload_event` — a write into the watched dir completes the layer's event stream with `event: reload` (dpe-server; identical watcher code in the playground)

## Test Plan

- [x] `just check` green (fmt + maudfmt gate + clippy `--all-features`)
- [x] `just test` green (9 suites, incl. the two `--features dev` runs)
- [x] Live smoke test: script present on `/dpe/about`, absent from the SSE tab fragment, watcher logs + reloads on an `app.css` write
- [ ] Manual: `just dev`, edit a Maud view → browser refreshes after rebuild; edit `tokens.css` → refresh without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0138s9RpuxVEHFJHMYCb9j82