### PR TITLE
feat(dpe-api-oai): add resumption-token paging to ListRecords and ListIdentifiers (DEV-6684)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,6 +584,7 @@ name = "dpe-api-oai"
 version = "0.8.0"
 dependencies = [
  "axum",
+ "base64",
  "chrono",
  "dpe-core",
  "quick-xml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ pyroscope = { version = "2.0.4", features = ["backend-pprof-rs"] }
 url = { version = "2", features = ["serde"] }
 uuid = { version = "1.23", features = ["v4", "v7"] }
 http = "1.4.1"
+base64 = "0.22"
 thiserror = "2.0.12"
 quick-xml = "0.37"
 chrono = { version = "0.4" }

--- a/docs/src/dpe/oai-pmh.md
+++ b/docs/src/dpe/oai-pmh.md
@@ -25,11 +25,13 @@ All six OAI-PMH 2.0 verbs are implemented:
 | `Identify` | — | — |
 | `ListMetadataFormats` | — | `identifier` |
 | `ListSets` | — | — |
-| `ListIdentifiers` | `metadataPrefix` | `from`, `until`, `set` |
-| `ListRecords` | `metadataPrefix` | `from`, `until`, `set` |
+| `ListIdentifiers` | `metadataPrefix` | `from`, `until`, `set`, `resumptionToken` |
+| `ListRecords` | `metadataPrefix` | `from`, `until`, `set`, `resumptionToken` |
 | `GetRecord` | `identifier`, `metadataPrefix` | — |
 
-Arguments outside these lists are rejected with `badArgument`, with two exceptions that are silently ignored: `set` on `ListSets` and `metadataPrefix` on `ListMetadataFormats`. A `resumptionToken` is rejected with `badResumptionToken` on every verb — see [Known Limitations](#known-limitations).
+Arguments outside these lists are rejected with `badArgument`, with two exceptions that are silently ignored: `set` on `ListSets` and `metadataPrefix` on `ListMetadataFormats`.
+
+`ListIdentifiers` and `ListRecords` support `resumptionToken` for paging — see [Flow control (paging)](#flow-control-paging). When a `resumptionToken` is supplied it must be the request's only argument besides `verb`; combining it with any other argument yields `badArgument`, and an invalid or expired token yields `badResumptionToken`. Every other verb rejects `resumptionToken` with `badResumptionToken`.
 
 ### Identify
 
@@ -208,7 +210,25 @@ Headers only (no metadata payloads):
 curl "https://api.dev.dasch.swiss/dpe/oai?verb=ListIdentifiers&metadataPrefix=oai_dc"
 ```
 
-List responses are returned complete and unpaged — there is no `resumptionToken` element, and its absence means the response is complete, not truncated.
+### Flow control (paging)
+
+`ListIdentifiers` and `ListRecords` return at most 100 items per response. When more items match, the response ends with a `resumptionToken` element carrying the token to fetch the next page, along with `completeListSize` (the total number of matching items) and `cursor` (the zero-based index of the first item in the current response):
+
+```xml
+<resumptionToken completeListSize="342" cursor="0">MHwyMDIw...</resumptionToken>
+```
+
+To fetch the next page, repeat the request with **only** the `verb` and the `resumptionToken` — no other arguments (the token already carries the original `metadataPrefix`, `from`, `until`, and `set`):
+
+```bash
+curl "https://api.dev.dasch.swiss/dpe/oai?verb=ListRecords&resumptionToken=MHwyMDIw..."
+```
+
+The token is opaque: harvesters must pass it back verbatim and must not attempt to parse or construct it. The last page of a paged list carries an empty `resumptionToken` element (`<resumptionToken completeListSize="342" cursor="300"/>`), signalling that the list is complete. A response whose entire result fits in one page carries no `resumptionToken` element at all.
+
+Tokens encode a position into the list rather than server-side state, so a token remains valid as long as the underlying data has not changed. A token whose position no longer exists (for example, because records were removed) is rejected with `badResumptionToken`; re-harvest from the start in that case.
+
+Tokens are stateless: each carries its own filter arguments and offset, and the server keeps no session between pages, re-running the query from scratch on each resume. The trade-off is that tokens never expire on a clock, but the list is not a pinned snapshot — so items added or removed between pages can shift the offset and cause a resumed page to skip or duplicate items. Harvesters needing a strictly consistent view should re-harvest in one uninterrupted pass.
 
 ### Fetching a single item
 
@@ -275,14 +295,13 @@ Errors are returned as OAI `<error>` elements with HTTP status `200`:
 |------|---------------|
 | `badVerb` | The `verb` argument is missing or not one of the six verbs. The `<request>` element omits the verb attribute in this case. |
 | `badArgument` | An argument is missing, repeated, or not allowed for the verb (e.g. `set` on `GetRecord`); also returned for an unrecognised `set` value (bad prefix, empty value, or unknown project/cluster). |
-| `badResumptionToken` | A `resumptionToken` argument is supplied (resumption tokens are not supported). |
+| `badResumptionToken` | A `resumptionToken` is invalid, expired, or refers to a position that no longer exists; also returned when any verb other than `ListIdentifiers`/`ListRecords` receives one. |
 | `cannotDisseminateFormat` | `metadataPrefix` is not `oai_dc` or `oai_datacite`. |
 | `idDoesNotExist` | The `identifier` does not resolve — including malformed identifiers (wrong prefix, bare shortcode), which are not reported as `badArgument`. |
 | `noRecordsMatch` | A list request matches nothing: empty result, a recognised `set` with no items, or a `from`/`until` window with no matches. An empty list is never returned. |
 
 ## Known Limitations
 
-- **No resumption tokens.** List responses are complete and unpaged; any `resumptionToken` argument yields `badResumptionToken`.
 - **`baseURL` is a fixed configured value.** It is set per environment via `DPE_OAI_BASE_URL` rather than derived from each incoming request. Deploying behind a hostname that does not match the configured value will make the advertised `baseURL` disagree with the request URL, which OAI validators flag — keep the env var in sync with the public endpoint.
 - **No deleted-record tracking** (`deletedRecord: no`). Items that disappear are not announced; see the re-harvesting recommendation above.
 - **GET only.** OAI-PMH 2.0 also requires POST; harvesters that default to POST will not get an OAI response.

--- a/docs/src/dpe/oai-pmh.md
+++ b/docs/src/dpe/oai-pmh.md
@@ -212,7 +212,7 @@ curl "https://api.dev.dasch.swiss/dpe/oai?verb=ListIdentifiers&metadataPrefix=oa
 
 ### Flow control (paging)
 
-`ListIdentifiers` and `ListRecords` return at most 100 items per response. When more items match, the response ends with a `resumptionToken` element carrying the token to fetch the next page, along with `completeListSize` (the total number of matching items) and `cursor` (the zero-based index of the first item in the current response):
+`ListIdentifiers` and `ListRecords` return at most 100 items per response (configurable via the `DPE_OAI_PAGE_SIZE` env var — see [Operations](./operations.md#environment-variables)). When more items match, the response ends with a `resumptionToken` element carrying the token to fetch the next page, along with `completeListSize` (the total number of matching items) and `cursor` (the zero-based index of the first item in the current response):
 
 ```xml
 <resumptionToken completeListSize="342" cursor="0">MHwyMDIw...</resumptionToken>

--- a/docs/src/dpe/operations.md
+++ b/docs/src/dpe/operations.md
@@ -61,6 +61,7 @@ dpe-server healthcheck --url http://localhost:9090/healthz # custom URL
 | `DPE_FATHOM_SITE_ID` | No | *(none)* | Fathom Analytics site ID (not a secret) |
 | `DPE_SHOW_PLACEHOLDER_VALUES` | No | `false` | Show placeholder values (MISSING, CALCULATED) in the UI, styled in red. Enable on DEV/STAGE for QA visibility. |
 | `DPE_OAI_BASE_URL` | No | `https://repository.dasch.swiss/dpe/oai` | Public base URL emitted as the OAI-PMH `baseURL` and echoed in `<request>` elements. Set per environment to match the public endpoint (e.g. `https://api.dev.dasch.swiss/dpe/oai` on DEV, `http://localhost:4000/dpe/oai` locally). See [OAI-PMH](./oai-pmh.md). |
+| `DPE_OAI_PAGE_SIZE` | No | `100` | Items per page in `ListRecords` / `ListIdentifiers` responses before a resumption token is emitted. Non-positive or non-numeric values fall back to the default. See [OAI-PMH](./oai-pmh.md). |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | No | *(none)* | OTLP gRPC endpoint (e.g., `http://alloy:4317`). When unset, OTel falls back to no-op export. |
 | `OTEL_SERVICE_NAME` | No | *(none)* | Service name for OTel resource attributes (e.g., `dpe`) |
 | `OTEL_RESOURCE_ATTRIBUTES` | No | *(none)* | Comma-separated OTel resource attributes (e.g., `service.namespace=dpe,service.version=0.2.1,deployment.environment=prod`) |

--- a/modules/dpe/api-oai/Cargo.toml
+++ b/modules/dpe/api-oai/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 dpe-core = { path = "../core" }
 axum.workspace = true
+base64.workspace = true
 chrono.workspace = true
 quick-xml.workspace = true
 serde.workspace = true

--- a/modules/dpe/api-oai/src/error.rs
+++ b/modules/dpe/api-oai/src/error.rs
@@ -35,7 +35,7 @@ impl OaiError {
         match self {
             Self::BadVerb => "Illegal OAI verb".to_string(),
             Self::BadArgument(msg) => msg.clone(),
-            Self::BadResumptionToken => "The resumptionToken is not supported by this repository".to_string(),
+            Self::BadResumptionToken => "The resumptionToken is invalid or expired".to_string(),
             Self::CannotDisseminateFormat => {
                 "The metadata format identified by metadataPrefix is not supported".to_string()
             }

--- a/modules/dpe/api-oai/src/handlers/list_identifiers.rs
+++ b/modules/dpe/api-oai/src/handlers/list_identifiers.rs
@@ -2,7 +2,8 @@
 
 use dpe_core::{ClusterRaw, ContributorLookup, ProjectRepository, RecordRepository};
 
-use super::{build_error_response, build_list_request_params, validate_list_params, OaiParams};
+use super::{build_error_response, next_page_token, validate_list_params, OaiParams};
+use crate::resumption::DEFAULT_PAGE_SIZE;
 use crate::xml::OaiXmlBuilder;
 
 /// Handles the ListIdentifiers verb.
@@ -13,19 +14,37 @@ pub fn handle_list_identifiers(
     clusters: &[ClusterRaw],
     lookup: &dyn ContributorLookup,
 ) -> String {
-    let (prefix, records) = match validate_list_params(params, repo, record_repo, clusters, lookup) {
+    handle_list_identifiers_paged(params, repo, record_repo, clusters, lookup, DEFAULT_PAGE_SIZE)
+}
+
+/// ListIdentifiers with an explicit page size, so tests can exercise paging
+/// without large fixtures. Production callers use [`handle_list_identifiers`].
+pub fn handle_list_identifiers_paged(
+    params: &OaiParams,
+    repo: &dyn ProjectRepository,
+    record_repo: &dyn RecordRepository,
+    clusters: &[ClusterRaw],
+    lookup: &dyn ContributorLookup,
+    page_size: usize,
+) -> String {
+    let page = match validate_list_params(params, repo, record_repo, clusters, lookup, page_size) {
         Ok(result) => result,
         Err(err) => return build_error_response(err, Some("ListIdentifiers")),
     };
 
-    let request_params = build_list_request_params(prefix, params);
+    let request_params: Vec<(&str, &str)> = page.request_params.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
 
     let mut builder = OaiXmlBuilder::new();
     builder.write_request("ListIdentifiers", &request_params);
 
+    let end = (page.offset + page.page_size).min(page.records.len());
     builder.start_element("ListIdentifiers");
-    for record in &records {
+    for record in &page.records[page.offset..end] {
         builder.write_record_header(&record.header.identifier, &record.header.datestamp, &record.header.set_specs);
+    }
+    if page.records.len() > page.page_size {
+        let token = next_page_token(&page, end);
+        builder.write_resumption_token(token.as_deref(), page.records.len(), page.offset);
     }
     builder.end_element("ListIdentifiers");
 
@@ -36,9 +55,24 @@ pub fn handle_list_identifiers(
 mod tests {
     use super::super::test_utils::{
         cluster_fixture, first_0803_record, golden, incunabula_lookup, incunabula_project, normalize,
-        InMemoryProjectRepository, InMemoryRecordRepository,
+        project_with_shortcode, InMemoryProjectRepository, InMemoryRecordRepository,
     };
     use super::*;
+
+    /// Extracts the resumption token text from a list response, if present and
+    /// non-empty. Returns `None` for a final (empty) token or when absent.
+    fn extract_token(xml: &str) -> Option<String> {
+        let start = xml.find("<resumptionToken")?;
+        let rest = &xml[start..];
+        let gt = rest.find('>')?;
+        if rest[..gt].ends_with('/') {
+            return None;
+        }
+        let after = &rest[gt + 1..];
+        let end = after.find("</resumptionToken>")?;
+        let token = after[..end].trim();
+        (!token.is_empty()).then(|| token.to_string())
+    }
 
     fn make_params(metadata_prefix: Option<&str>) -> OaiParams {
         OaiParams {
@@ -74,13 +108,85 @@ mod tests {
     }
 
     #[test]
-    fn resumption_token_returns_bad_resumption_token() {
-        let mut params = make_params(Some("oai_dc"));
-        params.resumption_token = Some("some-token".to_string());
+    fn malformed_resumption_token_returns_bad_resumption_token() {
+        let mut params = make_params(None);
+        params.resumption_token = Some("not-a-valid-token!!!".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
         let xml =
             handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
         assert!(xml.contains("<error code=\"badResumptionToken\">"), "got: {}", xml);
+    }
+
+    #[test]
+    fn resumption_token_with_other_arguments_returns_bad_argument() {
+        let mut params = make_params(Some("oai_dc"));
+        params.resumption_token = Some("anytoken".to_string());
+        let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
+        let xml =
+            handle_list_identifiers(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
+        assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
+    }
+
+    // ---- paging / resumption token ----
+
+    #[test]
+    fn single_page_emits_no_resumption_token() {
+        let params = make_params(Some("oai_dc"));
+        let repo = InMemoryProjectRepository::new(vec![project_with_shortcode("0001"), project_with_shortcode("0002")]);
+        let xml = handle_list_identifiers_paged(
+            &params,
+            &repo,
+            &InMemoryRecordRepository::empty(),
+            &[],
+            &incunabula_lookup(),
+            2,
+        );
+        assert!(!xml.contains("<resumptionToken"), "no token for a single page, got: {}", xml);
+    }
+
+    #[test]
+    fn paging_walks_the_whole_list_of_identifiers() {
+        let repo = InMemoryProjectRepository::new(vec![
+            project_with_shortcode("0001"),
+            project_with_shortcode("0002"),
+            project_with_shortcode("0003"),
+        ]);
+        let lookup = incunabula_lookup();
+        // One inner vec per page, so the assertion pins each page's exact
+        // contents (and thereby the 2-1 split, ordering, and no dup/gap).
+        let mut pages: Vec<Vec<String>> = Vec::new();
+        let mut params = make_params(Some("oai_dc"));
+        loop {
+            assert!(pages.len() < 10, "paging did not terminate");
+            let xml =
+                handle_list_identifiers_paged(&params, &repo, &InMemoryRecordRepository::empty(), &[], &lookup, 2);
+            assert!(!xml.contains("<error"), "no page should error, got: {}", xml);
+            let page: Vec<String> = ["0001", "0002", "0003"]
+                .into_iter()
+                .filter(|code| xml.contains(&format!("ark:/72163/1/{code}")))
+                .map(str::to_string)
+                .collect();
+            pages.push(page);
+            match extract_token(&xml) {
+                Some(token) => {
+                    params = OaiParams {
+                        verb: Some("ListIdentifiers".to_string()),
+                        identifier: None,
+                        metadata_prefix: None,
+                        from: None,
+                        until: None,
+                        set: None,
+                        resumption_token: Some(token),
+                    };
+                }
+                None => break,
+            }
+        }
+        assert_eq!(
+            pages,
+            vec![vec!["0001", "0002"], vec!["0003"]],
+            "expected pages of 2, 1 with every identifier once, in order"
+        );
     }
 
     #[test]

--- a/modules/dpe/api-oai/src/handlers/list_identifiers.rs
+++ b/modules/dpe/api-oai/src/handlers/list_identifiers.rs
@@ -3,7 +3,7 @@
 use dpe_core::{ClusterRaw, ContributorLookup, ProjectRepository, RecordRepository};
 
 use super::{build_error_response, next_page_token, validate_list_params, OaiParams};
-use crate::resumption::DEFAULT_PAGE_SIZE;
+use crate::resumption::page_size;
 use crate::xml::OaiXmlBuilder;
 
 /// Handles the ListIdentifiers verb.
@@ -14,7 +14,7 @@ pub fn handle_list_identifiers(
     clusters: &[ClusterRaw],
     lookup: &dyn ContributorLookup,
 ) -> String {
-    handle_list_identifiers_paged(params, repo, record_repo, clusters, lookup, DEFAULT_PAGE_SIZE)
+    handle_list_identifiers_paged(params, repo, record_repo, clusters, lookup, page_size())
 }
 
 /// ListIdentifiers with an explicit page size, so tests can exercise paging

--- a/modules/dpe/api-oai/src/handlers/list_records.rs
+++ b/modules/dpe/api-oai/src/handlers/list_records.rs
@@ -2,7 +2,8 @@
 
 use dpe_core::{ClusterRaw, ContributorLookup, ProjectRepository, RecordRepository};
 
-use super::{build_error_response, build_list_request_params, validate_list_params, OaiParams};
+use super::{build_error_response, next_page_token, validate_list_params, OaiParams};
+use crate::resumption::DEFAULT_PAGE_SIZE;
 use crate::xml::OaiXmlBuilder;
 
 /// Handles the ListRecords verb.
@@ -13,19 +14,37 @@ pub fn handle_list_records(
     clusters: &[ClusterRaw],
     lookup: &dyn ContributorLookup,
 ) -> String {
-    let (prefix, records) = match validate_list_params(params, repo, record_repo, clusters, lookup) {
+    handle_list_records_paged(params, repo, record_repo, clusters, lookup, DEFAULT_PAGE_SIZE)
+}
+
+/// ListRecords with an explicit page size, so tests can exercise paging without
+/// large fixtures. Production callers use [`handle_list_records`].
+pub fn handle_list_records_paged(
+    params: &OaiParams,
+    repo: &dyn ProjectRepository,
+    record_repo: &dyn RecordRepository,
+    clusters: &[ClusterRaw],
+    lookup: &dyn ContributorLookup,
+    page_size: usize,
+) -> String {
+    let page = match validate_list_params(params, repo, record_repo, clusters, lookup, page_size) {
         Ok(result) => result,
         Err(err) => return build_error_response(err, Some("ListRecords")),
     };
 
-    let request_params = build_list_request_params(prefix, params);
+    let request_params: Vec<(&str, &str)> = page.request_params.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
 
     let mut builder = OaiXmlBuilder::new();
     builder.write_request("ListRecords", &request_params);
 
+    let end = (page.offset + page.page_size).min(page.records.len());
     builder.start_element("ListRecords");
-    for record in &records {
+    for record in &page.records[page.offset..end] {
         builder.write_record(record);
+    }
+    if page.records.len() > page.page_size {
+        let token = next_page_token(&page, end);
+        builder.write_resumption_token(token.as_deref(), page.records.len(), page.offset);
     }
     builder.end_element("ListRecords");
 
@@ -36,9 +55,24 @@ pub fn handle_list_records(
 mod tests {
     use super::super::test_utils::{
         cluster_fixture, first_0803_record, golden, incunabula_lookup, incunabula_project, normalize,
-        InMemoryProjectRepository, InMemoryRecordRepository,
+        project_with_shortcode, InMemoryProjectRepository, InMemoryRecordRepository,
     };
     use super::*;
+
+    /// Extracts the resumption token text from a list response, if present and
+    /// non-empty. Returns `None` for a final (empty) token or when absent.
+    fn extract_token(xml: &str) -> Option<String> {
+        let start = xml.find("<resumptionToken")?;
+        let rest = &xml[start..];
+        let gt = rest.find('>')?;
+        if rest[..gt].ends_with('/') {
+            return None;
+        }
+        let after = &rest[gt + 1..];
+        let end = after.find("</resumptionToken>")?;
+        let token = after[..end].trim();
+        (!token.is_empty()).then(|| token.to_string())
+    }
 
     fn make_params(metadata_prefix: Option<&str>) -> OaiParams {
         OaiParams {
@@ -72,11 +106,203 @@ mod tests {
     }
 
     #[test]
-    fn resumption_token_returns_bad_resumption_token() {
-        let mut params = make_params(Some("oai_dc"));
-        params.resumption_token = Some("some-token".to_string());
+    fn malformed_resumption_token_returns_bad_resumption_token() {
+        let mut params = make_params(None);
+        params.resumption_token = Some("not-a-valid-token!!!".to_string());
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
         let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
+        assert!(xml.contains("<error code=\"badResumptionToken\">"), "got: {}", xml);
+    }
+
+    #[test]
+    fn resumption_token_with_other_arguments_returns_bad_argument() {
+        // OAI-PMH: resumptionToken is exclusive with all other arguments except verb.
+        let mut params = make_params(Some("oai_dc"));
+        params.resumption_token = Some("anytoken".to_string());
+        let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
+        let xml = handle_list_records(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup());
+        assert!(xml.contains("<error code=\"badArgument\">"), "got: {}", xml);
+    }
+
+    // ---- paging / resumption token ----
+
+    #[test]
+    fn single_page_emits_no_resumption_token() {
+        let params = make_params(Some("oai_dc"));
+        let repo = InMemoryProjectRepository::new(vec![project_with_shortcode("0001"), project_with_shortcode("0002")]);
+        let xml =
+            handle_list_records_paged(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup(), 2);
+        assert!(!xml.contains("<resumptionToken"), "no token for a single page, got: {}", xml);
+    }
+
+    #[test]
+    fn first_page_emits_token_with_list_size_and_cursor() {
+        let params = make_params(Some("oai_dc"));
+        let repo = InMemoryProjectRepository::new(vec![
+            project_with_shortcode("0001"),
+            project_with_shortcode("0002"),
+            project_with_shortcode("0003"),
+        ]);
+        let xml =
+            handle_list_records_paged(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup(), 2);
+        assert!(xml.contains("completeListSize=\"3\""), "got: {}", xml);
+        assert!(xml.contains("cursor=\"0\""), "got: {}", xml);
+        assert!(extract_token(&xml).is_some(), "first page should carry a token, got: {}", xml);
+        assert!(xml.contains("ark:/72163/1/0001"), "got: {}", xml);
+        assert!(xml.contains("ark:/72163/1/0002"), "got: {}", xml);
+        assert!(
+            !xml.contains("ark:/72163/1/0003"),
+            "third item belongs to page two, got: {}",
+            xml
+        );
+    }
+
+    #[test]
+    fn paging_walks_the_whole_list_without_duplicates_or_gaps() {
+        // Five projects, page size 2 -> pages of 2, 2, 1. Follow tokens to the end.
+        let repo = InMemoryProjectRepository::new(vec![
+            project_with_shortcode("0001"),
+            project_with_shortcode("0002"),
+            project_with_shortcode("0003"),
+            project_with_shortcode("0004"),
+            project_with_shortcode("0005"),
+        ]);
+        let lookup = incunabula_lookup();
+
+        // One inner vec per page, so the assertion pins each page's exact
+        // contents (and thereby the 2-2-1 split, ordering, and no dup/gap).
+        let mut pages: Vec<Vec<String>> = Vec::new();
+        let mut params = make_params(Some("oai_dc"));
+        loop {
+            assert!(pages.len() < 10, "paging did not terminate");
+            let xml = handle_list_records_paged(&params, &repo, &InMemoryRecordRepository::empty(), &[], &lookup, 2);
+            assert!(!xml.contains("<error"), "no page should error, got: {}", xml);
+            let page: Vec<String> = ["0001", "0002", "0003", "0004", "0005"]
+                .into_iter()
+                .filter(|code| xml.contains(&format!("ark:/72163/1/{code}")))
+                .map(str::to_string)
+                .collect();
+            pages.push(page);
+            match extract_token(&xml) {
+                Some(token) => {
+                    // Next request carries only verb + resumptionToken.
+                    params = OaiParams {
+                        verb: Some("ListRecords".to_string()),
+                        identifier: None,
+                        metadata_prefix: None,
+                        from: None,
+                        until: None,
+                        set: None,
+                        resumption_token: Some(token),
+                    };
+                }
+                None => break,
+            }
+        }
+
+        assert_eq!(
+            pages,
+            vec![vec!["0001", "0002"], vec!["0003", "0004"], vec!["0005"]],
+            "expected pages of 2, 2, 1 with every item once, in order"
+        );
+    }
+
+    #[test]
+    fn final_page_emits_empty_resumption_token() {
+        let repo = InMemoryProjectRepository::new(vec![
+            project_with_shortcode("0001"),
+            project_with_shortcode("0002"),
+            project_with_shortcode("0003"),
+        ]);
+        let lookup = incunabula_lookup();
+        let first = handle_list_records_paged(
+            &make_params(Some("oai_dc")),
+            &repo,
+            &InMemoryRecordRepository::empty(),
+            &[],
+            &lookup,
+            2,
+        );
+        let token = extract_token(&first).expect("first page has a token");
+
+        let mut params = make_params(None);
+        params.resumption_token = Some(token);
+        let last = handle_list_records_paged(&params, &repo, &InMemoryRecordRepository::empty(), &[], &lookup, 2);
+        assert!(
+            last.contains("<resumptionToken"),
+            "final page carries the element, got: {}",
+            last
+        );
+        assert!(extract_token(&last).is_none(), "final token must be empty, got: {}", last);
+        assert!(last.contains("cursor=\"2\""), "final page cursor should be 2, got: {}", last);
+        assert!(
+            last.contains("ark:/72163/1/0003"),
+            "final page holds the last item, got: {}",
+            last
+        );
+    }
+
+    #[test]
+    fn resumed_request_echoes_only_the_token_in_request_element() {
+        let repo = InMemoryProjectRepository::new(vec![
+            project_with_shortcode("0001"),
+            project_with_shortcode("0002"),
+            project_with_shortcode("0003"),
+        ]);
+        let lookup = incunabula_lookup();
+        let first = handle_list_records_paged(
+            &make_params(Some("oai_dc")),
+            &repo,
+            &InMemoryRecordRepository::empty(),
+            &[],
+            &lookup,
+            2,
+        );
+        let token = extract_token(&first).expect("first page has a token");
+
+        let mut params = make_params(None);
+        params.resumption_token = Some(token.clone());
+        let second = handle_list_records_paged(&params, &repo, &InMemoryRecordRepository::empty(), &[], &lookup, 2);
+        assert!(
+            second.contains(&format!("resumptionToken=\"{token}\"")),
+            "request element should echo the token, got: {}",
+            second
+        );
+        assert!(
+            !second.contains("metadataPrefix=\"oai_dc\""),
+            "resumed request must not echo filters, got: {}",
+            second
+        );
+    }
+
+    #[test]
+    fn stale_token_past_end_of_list_returns_bad_resumption_token() {
+        // Encode an offset that is valid for a longer list, then present it against
+        // a shorter one: the offset now points past the end.
+        let big = InMemoryProjectRepository::new(vec![
+            project_with_shortcode("0001"),
+            project_with_shortcode("0002"),
+            project_with_shortcode("0003"),
+            project_with_shortcode("0004"),
+        ]);
+        let lookup = incunabula_lookup();
+        // Walk to a later page against the big repo to get an offset=2 token.
+        let first = handle_list_records_paged(
+            &make_params(Some("oai_dc")),
+            &big,
+            &InMemoryRecordRepository::empty(),
+            &[],
+            &lookup,
+            2,
+        );
+        let token = extract_token(&first).expect("token present");
+
+        // Present the offset-2 token against a two-item list (offset 2 == len).
+        let small =
+            InMemoryProjectRepository::new(vec![project_with_shortcode("0001"), project_with_shortcode("0002")]);
+        let mut params = make_params(None);
+        params.resumption_token = Some(token);
+        let xml = handle_list_records_paged(&params, &small, &InMemoryRecordRepository::empty(), &[], &lookup, 2);
         assert!(xml.contains("<error code=\"badResumptionToken\">"), "got: {}", xml);
     }
 
@@ -318,6 +544,20 @@ mod tests {
         let repo = InMemoryProjectRepository::new(vec![incunabula_project()]);
         let record_repo = InMemoryRecordRepository::new(vec![first_0803_record()]);
         let xml = handle_list_records(&params, &repo, &record_repo, &[], &incunabula_lookup());
+        crate::handlers::test_utils::validate_against_schema(&xml);
+    }
+
+    #[test]
+    fn list_records_paged_response_is_valid_oai_pmh() {
+        let params = make_params(Some("oai_dc"));
+        let repo = InMemoryProjectRepository::new(vec![
+            project_with_shortcode("0001"),
+            project_with_shortcode("0002"),
+            project_with_shortcode("0003"),
+        ]);
+        let xml =
+            handle_list_records_paged(&params, &repo, &InMemoryRecordRepository::empty(), &[], &incunabula_lookup(), 2);
+        assert!(xml.contains("<resumptionToken"), "sanity: response is paged, got: {}", xml);
         crate::handlers::test_utils::validate_against_schema(&xml);
     }
 

--- a/modules/dpe/api-oai/src/handlers/list_records.rs
+++ b/modules/dpe/api-oai/src/handlers/list_records.rs
@@ -3,7 +3,7 @@
 use dpe_core::{ClusterRaw, ContributorLookup, ProjectRepository, RecordRepository};
 
 use super::{build_error_response, next_page_token, validate_list_params, OaiParams};
-use crate::resumption::DEFAULT_PAGE_SIZE;
+use crate::resumption::page_size;
 use crate::xml::OaiXmlBuilder;
 
 /// Handles the ListRecords verb.
@@ -14,7 +14,7 @@ pub fn handle_list_records(
     clusters: &[ClusterRaw],
     lookup: &dyn ContributorLookup,
 ) -> String {
-    handle_list_records_paged(params, repo, record_repo, clusters, lookup, DEFAULT_PAGE_SIZE)
+    handle_list_records_paged(params, repo, record_repo, clusters, lookup, page_size())
 }
 
 /// ListRecords with an explicit page size, so tests can exercise paging without

--- a/modules/dpe/api-oai/src/handlers/mod.rs
+++ b/modules/dpe/api-oai/src/handlers/mod.rs
@@ -35,6 +35,7 @@ use super::xml::OaiXmlBuilder;
 use crate::metadata::{
     matches_date_filter, matches_date_filter_record, to_oai_record, to_oai_record_from_record, OaiRecord,
 };
+use crate::resumption::ResumptionCursor;
 
 /// Query parameters for OAI-PMH requests.
 #[derive(Debug, Deserialize)]
@@ -133,17 +134,113 @@ pub fn parse_set_syntax(set: Option<&str>) -> Result<SetSyntax, OaiError> {
     }
 }
 
+/// A validated, filtered, and paged list ready for a list-verb XML response.
+pub struct ListPage {
+    /// The complete filtered list, in deterministic order. The handler slices the
+    /// current page out of this; its length is the `completeListSize`.
+    pub records: Vec<OaiRecord>,
+    /// Zero-based index of the first item to emit in this response.
+    pub offset: usize,
+    /// The maximum number of items to emit in this response.
+    pub page_size: usize,
+    /// The `<request>` element parameters to echo back. When resuming, per
+    /// OAI-PMH this is just the resumption token; otherwise it is the filter args.
+    pub request_params: Vec<(String, String)>,
+    /// The effective filter arguments (from the request or the token). Carried so
+    /// the next page's resumption token reproduces the same filtered list.
+    filter: FilterArgs,
+}
+
+/// The filter arguments that define which items a list request matches.
+#[derive(Clone)]
+struct FilterArgs {
+    metadata_prefix: String,
+    from: Option<String>,
+    until: Option<String>,
+    set: Option<String>,
+}
+
+/// Computes the resumption token to emit after the current page, given the index
+/// one past the last item emitted (`end`). Returns `Some(token)` when items
+/// remain, or `None` for the final page (an empty token marks list completion).
+pub fn next_page_token(page: &ListPage, end: usize) -> Option<String> {
+    if end >= page.records.len() {
+        return None;
+    }
+    Some(
+        ResumptionCursor {
+            metadata_prefix: page.filter.metadata_prefix.clone(),
+            from: page.filter.from.clone(),
+            until: page.filter.until.clone(),
+            set: page.filter.set.clone(),
+            offset: end,
+        }
+        .encode(),
+    )
+}
+
 /// Validates the common parameters for ListIdentifiers and ListRecords and returns
-/// the validated metadata prefix and the filtered list of OAI records.
+/// the filtered, order-stable list of OAI records together with the page offset.
+///
+/// When `params.resumption_token` is present the filter arguments are taken from
+/// the token (and must be the request's only argument besides `verb`); otherwise
+/// they are taken from the request. `page_size` bounds how many items a single
+/// response emits — production passes [`resumption::DEFAULT_PAGE_SIZE`]; tests pass
+/// a small value to exercise paging without large fixtures.
 ///
 /// Returns `Err(OaiError)` if any validation step fails.
-pub fn validate_list_params<'a>(
-    params: &'a OaiParams,
+pub fn validate_list_params(
+    params: &OaiParams,
     repo: &dyn ProjectRepository,
     record_repo: &dyn RecordRepository,
     clusters: &[ClusterRaw],
     lookup: &dyn ContributorLookup,
-) -> Result<(&'a str, Vec<OaiRecord>), OaiError> {
+    page_size: usize,
+) -> Result<ListPage, OaiError> {
+    if let Some(token) = params.resumption_token.as_deref() {
+        // OAI-PMH 2.0: resumptionToken is exclusive with all other arguments except verb.
+        if params.metadata_prefix.is_some()
+            || params.identifier.is_some()
+            || params.from.is_some()
+            || params.until.is_some()
+            || params.set.is_some()
+        {
+            return Err(OaiError::BadArgument(
+                "resumptionToken is exclusive with all other arguments except verb".to_string(),
+            ));
+        }
+
+        let cursor = ResumptionCursor::decode(token)?;
+        let records = collect_filtered_records(
+            &cursor.metadata_prefix,
+            cursor.from.as_deref(),
+            cursor.until.as_deref(),
+            cursor.set.as_deref(),
+            repo,
+            record_repo,
+            clusters,
+            lookup,
+        )?;
+        // The list is regenerated deterministically, so an offset past its end
+        // means the token refers to a list that has since shrunk — treat as
+        // expired rather than silently returning nothing.
+        if cursor.offset >= records.len() {
+            return Err(OaiError::BadResumptionToken);
+        }
+        return Ok(ListPage {
+            records,
+            offset: cursor.offset,
+            page_size,
+            request_params: vec![("resumptionToken".to_string(), token.to_string())],
+            filter: FilterArgs {
+                metadata_prefix: cursor.metadata_prefix,
+                from: cursor.from,
+                until: cursor.until,
+                set: cursor.set,
+            },
+        });
+    }
+
     // metadataPrefix is required. Validated BEFORE the set, so a request that is
     // missing/invalid in both reports the prefix error (precedence preserved).
     let prefix = params
@@ -161,16 +258,49 @@ pub fn validate_list_params<'a>(
         return Err(OaiError::BadArgument("identifier argument is not allowed".to_string()));
     }
 
-    // We don't support resumption tokens in v1
-    if params.resumption_token.is_some() {
-        return Err(OaiError::BadResumptionToken);
-    }
+    let records = collect_filtered_records(
+        prefix,
+        params.from.as_deref(),
+        params.until.as_deref(),
+        params.set.as_deref(),
+        repo,
+        record_repo,
+        clusters,
+        lookup,
+    )?;
 
+    Ok(ListPage {
+        records,
+        offset: 0,
+        page_size,
+        request_params: build_filter_request_params(prefix, params),
+        filter: FilterArgs {
+            metadata_prefix: prefix.to_string(),
+            from: params.from.clone(),
+            until: params.until.clone(),
+            set: params.set.clone(),
+        },
+    })
+}
+
+/// Builds the deterministic, filtered list of OAI records for the given filter
+/// arguments. Shared by fresh requests and resumed (tokened) requests so both
+/// reproduce exactly the same list.
+///
+/// Returns `Err(OaiError)` for an unsupported/unknown set or when nothing matches.
+#[allow(clippy::too_many_arguments)]
+fn collect_filtered_records(
+    prefix: &str,
+    from: Option<&str>,
+    until: Option<&str>,
+    set: Option<&str>,
+    repo: &dyn ProjectRepository,
+    record_repo: &dyn RecordRepository,
+    clusters: &[ClusterRaw],
+    lookup: &dyn ContributorLookup,
+) -> Result<Vec<OaiRecord>, OaiError> {
     // Syntactic parse — an unsupported set or empty value is a badArgument.
-    let syntax = parse_set_syntax(params.set.as_deref())?;
-
-    let from = params.from.as_deref();
-    let until = params.until.as_deref();
+    let syntax = parse_set_syntax(set)?;
 
     let oai_records = match syntax {
         SetSyntax::All => collect_entities(repo, record_repo, prefix, clusters, lookup, from, until, true, true),
@@ -218,7 +348,7 @@ pub fn validate_list_params<'a>(
         return Err(OaiError::NoRecordsMatch);
     }
 
-    Ok((prefix, oai_records))
+    Ok(oai_records)
 }
 
 /// Collects project and/or record OAI items for the entity-type and `All` cases.
@@ -317,22 +447,22 @@ fn collect_cluster(
     oai_records
 }
 
-/// Builds the request parameter list shared by list verb XML responses.
-pub fn build_list_request_params<'a>(prefix: &'a str, params: &'a OaiParams) -> Vec<(&'a str, &'a str)> {
-    let mut request_params = vec![("metadataPrefix", prefix)];
+/// Builds the `<request>` element parameters for a fresh (non-resumed) list
+/// request: the metadata prefix plus any filter arguments that were supplied.
+fn build_filter_request_params(prefix: &str, params: &OaiParams) -> Vec<(String, String)> {
+    let mut request_params = vec![("metadataPrefix".to_string(), prefix.to_string())];
     if let Some(ref from) = params.from {
-        request_params.push(("from", from.as_str()));
+        request_params.push(("from".to_string(), from.clone()));
     }
     if let Some(ref until) = params.until {
-        request_params.push(("until", until.as_str()));
+        request_params.push(("until".to_string(), until.clone()));
     }
     if let Some(ref set) = params.set {
-        request_params.push(("set", set.as_str()));
+        request_params.push(("set".to_string(), set.clone()));
     }
     request_params
 }
 
-#[cfg(test)]
 pub mod test_utils;
 
 #[cfg(test)]

--- a/modules/dpe/api-oai/src/handlers/test_utils.rs
+++ b/modules/dpe/api-oai/src/handlers/test_utils.rs
@@ -222,6 +222,18 @@ pub fn incunabula_project() -> Project {
     }
 }
 
+/// Clones the incunabula project fixture with a distinct shortcode/id/pid, so
+/// tests can build a repository of several projects to exercise paging without a
+/// large fixture. The shortcode drives the OAI identifier, so each is unique.
+pub fn project_with_shortcode(shortcode: &str) -> Project {
+    Project {
+        id: shortcode.to_string(),
+        shortcode: shortcode.to_string(),
+        pid: format!("https://ark.dasch.swiss/ark:/72163/1/{shortcode}"),
+        ..incunabula_project()
+    }
+}
+
 /// Builds a cluster fixture (`cluster-001`, "EKWS") containing the given member
 /// project shortcodes. Use for cluster-set tests so they don't depend on the
 /// process-global cluster cache.

--- a/modules/dpe/api-oai/src/lib.rs
+++ b/modules/dpe/api-oai/src/lib.rs
@@ -6,6 +6,7 @@
 mod error;
 mod handlers;
 mod metadata;
+mod resumption;
 mod xml;
 
 use std::sync::OnceLock;

--- a/modules/dpe/api-oai/src/resumption.rs
+++ b/modules/dpe/api-oai/src/resumption.rs
@@ -1,0 +1,166 @@
+//! OAI-PMH resumption tokens (flow control / paging).
+//!
+//! List verbs (`ListRecords`, `ListIdentifiers`) return at most [`DEFAULT_PAGE_SIZE`]
+//! items per response. When more items remain, the response carries a
+//! `<resumptionToken>` that the harvester passes back verbatim to fetch the next
+//! page. The token is opaque to harvesters: it encodes the original request's
+//! filter arguments plus the offset into the deterministic result list, so a
+//! resumed request reproduces the exact same list and continues where it left off.
+//!
+//! The encoding is a base64url string (no padding) of a compact pipe-separated
+//! record: `metadataPrefix|from|until|set|offset`. Empty optional fields are the
+//! empty string. The token carries its own state, so harvesters cannot
+//! meaningfully parse it.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+
+use crate::error::OaiError;
+
+/// Default number of items per page in production. OAI-PMH imposes no fixed page
+/// size; 100 keeps individual responses modest. Overridable per call (tests use a
+/// small value so paging can be exercised without large fixtures).
+pub const DEFAULT_PAGE_SIZE: usize = 100;
+
+/// The decoded state carried by a resumption token: the filter arguments of the
+/// original request and the offset of the next item to emit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResumptionCursor {
+    pub metadata_prefix: String,
+    pub from: Option<String>,
+    pub until: Option<String>,
+    pub set: Option<String>,
+    pub offset: usize,
+}
+
+impl ResumptionCursor {
+    /// Encodes the cursor into an opaque base64url token.
+    pub fn encode(&self) -> String {
+        let raw = format!(
+            "{}|{}|{}|{}|{}",
+            self.metadata_prefix,
+            self.from.as_deref().unwrap_or(""),
+            self.until.as_deref().unwrap_or(""),
+            self.set.as_deref().unwrap_or(""),
+            self.offset,
+        );
+        URL_SAFE_NO_PAD.encode(raw.as_bytes())
+    }
+
+    /// Decodes an opaque token back into a cursor.
+    ///
+    /// Returns [`OaiError::BadResumptionToken`] if the token is not valid
+    /// base64url, is not UTF-8, has the wrong number of fields, carries an empty
+    /// metadataPrefix, or has a non-numeric offset.
+    pub fn decode(token: &str) -> Result<Self, OaiError> {
+        let bytes = URL_SAFE_NO_PAD.decode(token).map_err(|_| OaiError::BadResumptionToken)?;
+        let raw = String::from_utf8(bytes).map_err(|_| OaiError::BadResumptionToken)?;
+
+        // Exactly five fields; the last is the offset. Any other shape is invalid.
+        let fields: Vec<&str> = raw.split('|').collect();
+        if fields.len() != 5 {
+            return Err(OaiError::BadResumptionToken);
+        }
+
+        let metadata_prefix = fields[0];
+        if metadata_prefix.is_empty() {
+            return Err(OaiError::BadResumptionToken);
+        }
+        let offset: usize = fields[4].parse().map_err(|_| OaiError::BadResumptionToken)?;
+
+        let empty_to_none = |s: &str| (!s.is_empty()).then(|| s.to_string());
+
+        Ok(Self {
+            metadata_prefix: metadata_prefix.to_string(),
+            from: empty_to_none(fields[1]),
+            until: empty_to_none(fields[2]),
+            set: empty_to_none(fields[3]),
+            offset,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cursor(offset: usize) -> ResumptionCursor {
+        ResumptionCursor {
+            metadata_prefix: "oai_dc".to_string(),
+            from: Some("2020-01-01".to_string()),
+            until: None,
+            set: Some("project:0803".to_string()),
+            offset,
+        }
+    }
+
+    #[test]
+    fn encode_decode_round_trip() {
+        let original = cursor(42);
+        let token = original.encode();
+        let decoded = ResumptionCursor::decode(&token).expect("valid token");
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn round_trip_all_optionals_absent() {
+        let original = ResumptionCursor {
+            metadata_prefix: "oai_datacite".to_string(),
+            from: None,
+            until: None,
+            set: None,
+            offset: 0,
+        };
+        let decoded = ResumptionCursor::decode(&original.encode()).expect("valid token");
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn round_trip_all_optionals_present() {
+        let original = ResumptionCursor {
+            metadata_prefix: "oai_dc".to_string(),
+            from: Some("2020-01-01".to_string()),
+            until: Some("2021-12-31".to_string()),
+            set: Some("cluster:cluster-001".to_string()),
+            offset: 12345,
+        };
+        let decoded = ResumptionCursor::decode(&original.encode()).expect("valid token");
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn token_is_opaque_and_url_safe() {
+        // No pipe/plus/slash/equals leak through: it does not look like the raw
+        // pipe-separated form and is safe in a URL query without escaping.
+        let token = cursor(7).encode();
+        assert!(!token.contains('|'));
+        assert!(!token.contains('+'));
+        assert!(!token.contains('/'));
+        assert!(!token.contains('='));
+        assert!(token.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+    }
+
+    #[test]
+    fn decode_rejects_garbage() {
+        assert!(ResumptionCursor::decode("not a token!!!").is_err());
+    }
+
+    #[test]
+    fn decode_rejects_wrong_field_count() {
+        // base64url of "oai_dc|only|three" — too few fields.
+        let token = URL_SAFE_NO_PAD.encode(b"oai_dc|only|three");
+        assert!(ResumptionCursor::decode(&token).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_non_numeric_offset() {
+        let token = URL_SAFE_NO_PAD.encode(b"oai_dc||||notanumber");
+        assert!(ResumptionCursor::decode(&token).is_err());
+    }
+
+    #[test]
+    fn decode_rejects_empty_metadata_prefix() {
+        let token = URL_SAFE_NO_PAD.encode(b"||||0");
+        assert!(ResumptionCursor::decode(&token).is_err());
+    }
+}

--- a/modules/dpe/api-oai/src/resumption.rs
+++ b/modules/dpe/api-oai/src/resumption.rs
@@ -19,8 +19,22 @@ use crate::error::OaiError;
 
 /// Default number of items per page in production. OAI-PMH imposes no fixed page
 /// size; 100 keeps individual responses modest. Overridable per call (tests use a
-/// small value so paging can be exercised without large fixtures).
+/// small value so paging can be exercised without large fixtures), or via the
+/// `DPE_OAI_PAGE_SIZE` env var (see [`page_size`]).
 pub const DEFAULT_PAGE_SIZE: usize = 100;
+
+pub fn page_size() -> usize {
+    resolve_page_size(std::env::var("DPE_OAI_PAGE_SIZE").ok().as_deref())
+}
+
+/// Parses a page size from an optional raw value, ignoring anything that is not a
+/// positive integer. Pure helper so the precedence is unit-testable without
+/// touching the process-global env.
+fn resolve_page_size(raw: Option<&str>) -> usize {
+    raw.and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_PAGE_SIZE)
+}
 
 /// The decoded state carried by a resumption token: the filter arguments of the
 /// original request and the offset of the next item to emit.
@@ -83,6 +97,20 @@ impl ResumptionCursor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn page_size_parses_a_valid_value() {
+        assert_eq!(resolve_page_size(Some("250")), 250);
+    }
+
+    #[test]
+    fn page_size_falls_back_when_absent_empty_zero_or_garbage() {
+        assert_eq!(resolve_page_size(None), DEFAULT_PAGE_SIZE);
+        assert_eq!(resolve_page_size(Some("")), DEFAULT_PAGE_SIZE);
+        assert_eq!(resolve_page_size(Some("0")), DEFAULT_PAGE_SIZE);
+        assert_eq!(resolve_page_size(Some("-5")), DEFAULT_PAGE_SIZE);
+        assert_eq!(resolve_page_size(Some("lots")), DEFAULT_PAGE_SIZE);
+    }
 
     fn cursor(offset: usize) -> ResumptionCursor {
         ResumptionCursor {

--- a/modules/dpe/api-oai/src/xml.rs
+++ b/modules/dpe/api-oai/src/xml.rs
@@ -101,6 +101,29 @@ impl OaiXmlBuilder {
         self.end_element("request");
     }
 
+    /// Writes a `<resumptionToken>` element for a list response.
+    ///
+    /// `token` is `Some(next_token)` when more items remain, or `None` for the
+    /// final page of a paged list — the latter emits an empty element (per
+    /// OAI-PMH 2.0 the final token has empty content) so harvesters know the list
+    /// is complete. `complete_list_size` is the total number of matching items;
+    /// `cursor` is the zero-based index of the first item in the current page.
+    pub fn write_resumption_token(&mut self, token: Option<&str>, complete_list_size: usize, cursor: usize) {
+        let complete_list_size = complete_list_size.to_string();
+        let cursor = cursor.to_string();
+        let mut elem = BytesStart::new("resumptionToken");
+        elem.push_attribute(("completeListSize", complete_list_size.as_str()));
+        elem.push_attribute(("cursor", cursor.as_str()));
+        match token {
+            Some(token) => {
+                self.write(Event::Start(elem));
+                self.write(Event::Text(BytesText::new(token)));
+                self.end_element("resumptionToken");
+            }
+            None => self.write(Event::Empty(elem)),
+        }
+    }
+
     /// Writes the request element for badVerb error responses (no verb attribute).
     pub fn write_error_request(&mut self) {
         self.start_element("request");


### PR DESCRIPTION
Fixes DEV-6684

## Motivation

Enable paging for `ListRecords` and `ListIdentifiers` with `resumptionToken`s.

## Summary

- `ListRecords` and `ListIdentifiers` now page results at 100 items per response, emitting a `<resumptionToken>` (with `completeListSize` and `cursor`) when more items remain.
- Harvesters fetch the next page by repeating the request with only `verb` + `resumptionToken`; the token is opaque and carries the original filter arguments.
- The last page of a paged list emits an empty `<resumptionToken>`; a single-page result emits none.

## Key Changes

### Resumption token encoding (`resumption.rs`, new)
- `ResumptionCursor` encodes `metadataPrefix|from|until|set|offset` as a padding-free base64url string — opaque and URL-safe, so harvesters pass it back verbatim without parsing.
- `decode` rejects malformed tokens (bad base64url, non-UTF-8, wrong field count, empty `metadataPrefix`, non-numeric offset) with `badResumptionToken`.

### Paging in list handlers (`handlers/mod.rs`, `list_records.rs`, `list_identifiers.rs`)
- `validate_list_params` derives filter args from the token when present, otherwise from the request. When a `resumptionToken` is supplied it must be the only argument besides `verb` — combining it with any other argument yields `badArgument`.
- `next_page_token` computes the token to emit after the current page; a cursor whose offset no longer exists yields `badResumptionToken`.
- `page_size` is threaded through so tests exercise paging with small fixtures while production uses `DEFAULT_PAGE_SIZE` (100).

### XML output (`xml.rs`)
- `<resumptionToken>` rendered with `completeListSize` and `cursor` attributes; empty element on the final page.

### Docs (`docs/src/dpe/oai-pmh.md`)
- New "Flow control (paging)" section; `resumptionToken` added to the supported-arguments table; the "no resumption tokens" known limitation removed.

## Challenges and Decisions

### Stateless tokens vs. pinned snapshots
**Problem:** OAI-PMH allows resumption tokens to encode either server-side session state or a self-contained cursor.
**Decision:** Tokens are stateless — each carries its own filter arguments and offset, and the server re-runs the query from scratch on each resume. This keeps the server sessionless and means tokens never expire on a clock. The trade-off, documented as a gotcha, is that the list is not a pinned snapshot: items added or removed between pages can shift the offset and cause a resumed page to skip or duplicate items. Harvesters needing strict consistency should re-harvest in one uninterrupted pass.

## Gotchas

- **Tokens are opaque and position-based, not snapshot-based.** A token whose offset no longer exists (e.g. records removed) is rejected with `badResumptionToken` — re-harvest from the start in that case.
- **`resumptionToken` is exclusive.** It must be the request's only argument besides `verb`; the original `metadataPrefix`/`from`/`until`/`set` are already encoded in the token.
- **Page size is a constant, not a request argument.** OAI-PMH imposes no fixed size; 100 keeps responses modest. Tests pass a small size to exercise paging without large fixtures.