### PR TITLE
feat: OAI-PMH endpoint rate-limiting (DEV-6724)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,8 +738,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
 dependencies = [
  "atomic",
+ "parking_lot",
  "pear",
  "serde",
+ "tempfile",
  "toml",
  "uncased",
  "version_check",

--- a/docs/src/dpe/oai-pmh.md
+++ b/docs/src/dpe/oai-pmh.md
@@ -210,6 +210,10 @@ Headers only (no metadata payloads):
 curl "https://api.dev.dasch.swiss/dpe/oai?verb=ListIdentifiers&metadataPrefix=oai_dc"
 ```
 
+### Rate limiting
+
+The endpoint is rate-limited per client IP. By default a harvester may make up to 60 requests back-to-back (the burst) and then a sustained ~60 requests/minute; exceeding this yields `429 Too Many Requests` with a `Retry-After` header (and `X-RateLimit-*` headers indicating the limit and remaining budget). A well-behaved harvester that pages through resumption tokens sequentially stays well within these limits. The limits are configurable per environment via `DPE_OAI_RATE_LIMIT_PER_SECOND` and `DPE_OAI_RATE_LIMIT_BURST` (see [operations](./operations.md)).
+
 ### Flow control (paging)
 
 `ListIdentifiers` and `ListRecords` return at most 100 items per response (configurable via the `DPE_OAI_PAGE_SIZE` env var — see [Operations](./operations.md#environment-variables)). When more items match, the response ends with a `resumptionToken` element carrying the token to fetch the next page, along with `completeListSize` (the total number of matching items) and `cursor` (the zero-based index of the first item in the current response):

--- a/docs/src/dpe/operations.md
+++ b/docs/src/dpe/operations.md
@@ -61,6 +61,8 @@ dpe-server healthcheck --url http://localhost:9090/healthz # custom URL
 | `DPE_FATHOM_SITE_ID` | No | *(none)* | Fathom Analytics site ID (not a secret) |
 | `DPE_SHOW_PLACEHOLDER_VALUES` | No | `false` | Show placeholder values (MISSING, CALCULATED) in the UI, styled in red. Enable on DEV/STAGE for QA visibility. |
 | `DPE_OAI_BASE_URL` | No | `https://repository.dasch.swiss/dpe/oai` | Public base URL emitted as the OAI-PMH `baseURL` and echoed in `<request>` elements. Set per environment to match the public endpoint (e.g. `https://api.dev.dasch.swiss/dpe/oai` on DEV, `http://localhost:4000/dpe/oai` locally). See [OAI-PMH](./oai-pmh.md). |
+| `DPE_OAI_RATE_LIMIT_PER_SECOND` | No | `1` | Per-IP rate limit on `/dpe/oai`: seconds per request once the burst is spent. `1` ≈ 60 requests/minute sustained. See [OAI-PMH](./oai-pmh.md). |
+| `DPE_OAI_RATE_LIMIT_BURST` | No | `60` | Per-IP burst allowance on `/dpe/oai`: back-to-back requests before the sustained rate applies. |
 | `DPE_OAI_PAGE_SIZE` | No | `100` | Items per page in `ListRecords` / `ListIdentifiers` responses before a resumption token is emitted. Non-positive or non-numeric values fall back to the default. See [OAI-PMH](./oai-pmh.md). |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | No | *(none)* | OTLP gRPC endpoint (e.g., `http://alloy:4317`). When unset, OTel falls back to no-op export. |
 | `OTEL_SERVICE_NAME` | No | *(none)* | Service name for OTel resource attributes (e.g., `dpe`) |
@@ -69,6 +71,8 @@ dpe-server healthcheck --url http://localhost:9090/healthz # custom URL
 | `DPE_SITE_ADDR` | No | `127.0.0.1:4000` | Listen address and port. The Docker image sets `0.0.0.0:8080`. |
 | `DPE_PUBLIC_DIR` | No | `modules/dpe/public` | Directory served as static assets by `ServeDir` (favicon, logo, vendored JS, project images, and the compiled `app.<hash>.css`). |
 | `DPE_ENV` | No | `DEV` | Deployment environment (`DEV` or `PROD`). Controls OTLP log export (see [Logging](#logging)). The Docker image sets `PROD`. |
+
+> **Rate limiting and reverse proxies.** The OAI (`/dpe/oai`) and telemetry (`/telemetry/collect`) rate limits key on the client IP, taken from the **rightmost** `X-Forwarded-For` entry (the address Traefik itself appends), falling back to the connection peer address. Reading the rightmost entry — not the leftmost — is deliberate: Traefik appends the real client after any `X-Forwarded-For` value the client supplied, so the rightmost entry is proxy-authored and cannot be spoofed, while the leftmost stays attacker-controlled. This holds only while Traefik is the sole hop in front of DPE; a second proxy that appends to `X-Forwarded-For` would shift the trusted entry and require counting hops from the right.
 
 ## Health Check
 

--- a/modules/dpe/server/Cargo.toml
+++ b/modules/dpe/server/Cargo.toml
@@ -46,6 +46,8 @@ urlencoding = "2.1"
 
 [dev-dependencies]
 insta.workspace = true
+# `test` feature enables figment::Jail for isolated env-var config tests.
+figment = { version = "0.10", features = ["env", "toml", "test"] }
 tower = { workspace = true, features = ["util"] }
 http-body-util = "0.1"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/modules/dpe/server/src/config.rs
+++ b/modules/dpe/server/src/config.rs
@@ -42,6 +42,14 @@ pub struct DpeConfig {
     /// URL harvesters actually use (e.g. `https://repository.dasch.swiss/dpe/oai` in
     /// production, `https://api.dev.dasch.swiss/dpe/oai` on DEV). Set via `DPE_OAI_BASE_URL`.
     pub oai_base_url: String,
+
+    /// OAI-PMH rate limit: seconds per request once burst is spent. Set via
+    /// `DPE_OAI_RATE_LIMIT_PER_SECOND`.
+    pub oai_rate_limit_per_second: u64,
+
+    /// OAI-PMH rate limit: back-to-back requests allowed per IP. Set via
+    /// `DPE_OAI_RATE_LIMIT_BURST`.
+    pub oai_rate_limit_burst: u32,
 }
 
 impl Default for DpeConfig {
@@ -52,6 +60,8 @@ impl Default for DpeConfig {
             fathom_site_id: None,
             show_placeholder_values: false,
             oai_base_url: "https://repository.dasch.swiss/dpe/oai".to_string(),
+            oai_rate_limit_per_second: 1,
+            oai_rate_limit_burst: 60,
         }
     }
 }
@@ -82,6 +92,19 @@ mod tests {
         assert!(config.fathom_site_id.is_none());
         assert!(!config.show_placeholder_values);
         assert_eq!(config.oai_base_url, "https://repository.dasch.swiss/dpe/oai");
+        assert_eq!(config.oai_rate_limit_per_second, 1);
+        assert_eq!(config.oai_rate_limit_burst, 60);
+    }
+
+    #[test]
+    fn oai_rate_limit_burst_env_override() {
+        // Jail isolates env + cwd so DPE_* overrides are tested without touching the real environment.
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("DPE_OAI_RATE_LIMIT_BURST", 5);
+            let config = DpeConfig::load().expect("config should load");
+            assert_eq!(config.oai_rate_limit_burst, 5);
+            Ok(())
+        });
     }
 
     #[test]

--- a/modules/dpe/server/src/main.rs
+++ b/modules/dpe/server/src/main.rs
@@ -6,7 +6,8 @@ use clap::{Parser, Subcommand};
 mod config;
 #[cfg(feature = "dev")]
 mod dev_reload;
-mod fragments;
+pub(crate) mod fragments;
+mod router;
 mod telemetry_collector;
 mod traceparent;
 mod view;
@@ -14,7 +15,7 @@ mod view;
 /// Shared state for the page handlers: the (optional) Fathom site id and the
 /// resolved stylesheet href (unhashed in dev, content-hashed in release).
 #[derive(Clone)]
-struct AppState {
+pub(crate) struct AppState {
     fathom_site_id: Option<String>,
     css_href: String,
 }
@@ -26,7 +27,7 @@ struct TabQuery {
     tab: Option<String>,
 }
 
-async fn projects_page_handler(
+pub(crate) async fn projects_page_handler(
     axum::extract::State(state): axum::extract::State<AppState>,
     axum::extract::Query(query): axum::extract::Query<dpe_web::domain::ProjectQuery>,
 ) -> axum::response::Html<String> {
@@ -44,7 +45,7 @@ async fn projects_page_handler(
     )
 }
 
-async fn about_page_handler(
+pub(crate) async fn about_page_handler(
     axum::extract::State(state): axum::extract::State<AppState>,
 ) -> axum::response::Html<String> {
     let tp = traceparent::extract_traceparent();
@@ -61,7 +62,7 @@ async fn about_page_handler(
     )
 }
 
-async fn project_page_handler(
+pub(crate) async fn project_page_handler(
     axum::extract::State(state): axum::extract::State<AppState>,
     axum::extract::Path(id): axum::extract::Path<String>,
     axum::extract::Query(tab): axum::extract::Query<TabQuery>,
@@ -88,7 +89,7 @@ async fn project_page_handler(
 
 /// 404 fallback (after `ServeDir` finds no matching static file): the app shell
 /// with a "Page not found." body.
-async fn not_found(
+pub(crate) async fn not_found(
     axum::extract::State(state): axum::extract::State<AppState>,
 ) -> (axum::http::StatusCode, axum::response::Html<String>) {
     let tp = traceparent::extract_traceparent();
@@ -213,12 +214,9 @@ fn main() -> ExitCode {
 #[tokio::main]
 async fn serve() -> ExitCode {
     use axum::http::StatusCode;
-    use axum::response::Redirect;
     use axum::routing::get;
-    use axum::Router;
     use init_tracing_opentelemetry::TracingConfig;
     use opentelemetry_sdk::logs::{SdkLogger, SdkLoggerProvider};
-    use tower_http::services::ServeDir;
     use tracing_subscriber::layer::SubscriberExt;
 
     // Route panics through tracing so they appear as structured Grafana logs
@@ -318,35 +316,8 @@ async fn serve() -> ExitCode {
         css_href: resolve_css_href(&dpe_config.public_dir),
     };
 
-    use axum_tracing_opentelemetry::middleware::{OtelAxumLayer, OtelInResponseLayer};
-
-    // Static assets + 404: serve files from the public dir, falling back to the
-    // "Page not found." shell.
-    let serve_dir = ServeDir::new(&dpe_config.public_dir).not_found_service(get(not_found).with_state(state.clone()));
-
-    let app = Router::new()
-        // --- Traced routes (declared BEFORE .layer()) ---
-        // Page routes.
-        .route("/", get(|| async { Redirect::permanent("/dpe/projects") }))
-        .route("/dpe", get(|| async { Redirect::permanent("/dpe/projects") }))
-        .route("/dpe/projects", get(projects_page_handler))
-        .route("/dpe/about", get(about_page_handler))
-        .route("/dpe/projects/{id}", get(project_page_handler))
-        // OAI-PMH (note: /dpe/oai, not /oai) — XML, must stay unbroken.
-        .route("/dpe/oai", get(dpe_api_oai::oai_handler))
-        // Datastar SSE + JSON endpoints.
-        .route("/dpe/projects/{id}/tab/{tab}", get(fragments::tab_fragment_handler))
-        .route("/dpe/projects/search", get(fragments::search_fragment_handler))
-        .route("/dpe/api/v2/projects", get(fragments::projects_json_handler))
-        .route("/dpe/api/v2/projects/{id}", get(fragments::project_json_handler))
-        // Static assets + 404 fallback.
-        .fallback_service(serve_dir)
-        // --- OTel layers ---
-        // Axum layers wrap in reverse declaration order:
-        // - OtelInResponseLayer (declared first) runs INNER — injects traceparent into response headers
-        // - OtelAxumLayer (declared second) runs OUTER — creates the server span from the request
-        .layer(OtelInResponseLayer)
-        .layer(OtelAxumLayer::default());
+    // Traced routes, incl. the rate-limited /dpe/oai (limiter scoped to that route).
+    let app = router::build_router(state, &dpe_config.public_dir, router::oai_router(&dpe_config));
 
     // Dev-only browser live-reload (`dev` feature): wraps the page/static
     // routes declared above; the untraced routes below stay outside it.
@@ -361,19 +332,19 @@ async fn serve() -> ExitCode {
             "/telemetry/collect",
             axum::routing::post(telemetry_collector::collect_handler).layer({
                 use tower_governor::governor::GovernorConfigBuilder;
-                use tower_governor::key_extractor::SmartIpKeyExtractor;
                 use tower_governor::GovernorLayer;
+
+                use crate::router::RightmostXffKeyExtractor;
 
                 let governor_conf = GovernorConfigBuilder::default()
                     .per_second(1)
                     .burst_size(10)
-                    .key_extractor(SmartIpKeyExtractor)
+                    .key_extractor(RightmostXffKeyExtractor)
                     .finish()
                     .expect("GovernorConfig should build with valid defaults");
                 GovernorLayer { config: std::sync::Arc::new(governor_conf) }
             }),
-        )
-        .with_state(state);
+        );
 
     tracing::info!("listening on http://{}", &addr);
     let listener = tokio::net::TcpListener::bind(&addr)

--- a/modules/dpe/server/src/router.rs
+++ b/modules/dpe/server/src/router.rs
@@ -1,0 +1,349 @@
+//! App router assembly, kept separate from `serve()` (which does I/O + global
+//! setup) so the routing — including the per-route OAI rate limiter — is
+//! unit-testable.
+
+use std::net::{IpAddr, SocketAddr};
+
+use axum::extract::ConnectInfo;
+use axum::http::Request;
+use axum::Router;
+use tower_governor::key_extractor::KeyExtractor;
+use tower_governor::GovernorError;
+
+use crate::config::DpeConfig;
+use crate::{about_page_handler, fragments, project_page_handler, projects_page_handler, AppState};
+
+/// Rate-limit key extractor that keys on the **rightmost** `X-Forwarded-For`
+/// entry — the address our reverse proxy (Traefik) itself appended — falling back
+/// to the connection peer IP.
+///
+/// SECURITY: `tower_governor`'s stock `SmartIpKeyExtractor` reads the *leftmost*
+/// XFF entry, which is client-forgeable. Traefik appends the real client IP after
+/// any value the client supplied, so the leftmost entry stays attacker-controlled;
+/// a single client can rotate it to mint unlimited rate-limit buckets and defeat
+/// the per-IP limit. The rightmost entry is the one Traefik wrote and cannot be
+/// spoofed, given Traefik is the only hop in front of DPE. This mirrors SIPI's
+/// `client_ip` resolver, which is deployed behind the same ingress.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RightmostXffKeyExtractor;
+
+impl KeyExtractor for RightmostXffKeyExtractor {
+    type Key = IpAddr;
+
+    fn extract<T>(&self, req: &Request<T>) -> Result<Self::Key, GovernorError> {
+        req.headers()
+            .get("x-forwarded-for")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.rsplit(',').next())
+            .and_then(|s| s.trim().parse::<IpAddr>().ok())
+            .or_else(|| req.extensions().get::<ConnectInfo<SocketAddr>>().map(|ci| ci.0.ip()))
+            .ok_or(GovernorError::UnableToExtractKey)
+    }
+}
+
+/// The `/dpe/oai` route as a standalone sub-router with `limiter` applied to it.
+/// The limiter type is erased here — the result is a plain `Router<AppState>` the
+/// caller merges in — so `build_router` never has to name the `GovernorLayer`
+/// type. In production `limiter` is the real `GovernorLayer` (see [`oai_router`]);
+/// tests pass a fake to drive gating deterministically.
+pub(crate) fn oai_router_with<L>(limiter: L) -> Router<AppState>
+where
+    L: tower::Layer<axum::routing::Route> + Clone + Send + Sync + 'static,
+    L::Service: tower::Service<axum::extract::Request, Response = axum::response::Response, Error = std::convert::Infallible>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    <L::Service as tower::Service<axum::extract::Request>>::Future: Send + 'static,
+{
+    use axum::routing::get;
+    Router::new()
+        .route("/dpe/oai", get(dpe_api_oai::oai_handler))
+        .route_layer(limiter)
+}
+
+/// The production `/dpe/oai` sub-router, rate-limited per-IP from config.
+/// `use_headers()` adds `X-RateLimit-*` and `Retry-After` to 429 responses.
+pub(crate) fn oai_router(config: &DpeConfig) -> Router<AppState> {
+    use tower_governor::governor::GovernorConfigBuilder;
+    use tower_governor::GovernorLayer;
+
+    let governor_conf = GovernorConfigBuilder::default()
+        .per_second(config.oai_rate_limit_per_second)
+        .burst_size(config.oai_rate_limit_burst)
+        .key_extractor(RightmostXffKeyExtractor)
+        .use_headers()
+        .finish()
+        .expect("OAI GovernorConfig should build from valid config");
+
+    oai_router_with(GovernorLayer { config: std::sync::Arc::new(governor_conf) })
+}
+
+/// Assemble the traced app router. `oai_router` carries the (already rate-limited)
+/// `/dpe/oai` route; passing it in — rather than a bare layer — keeps this
+/// signature free of the `GovernorLayer` trait bounds, so it stays reconstructable
+/// by hand and lets tests substitute a fake-limited OAI router. Static assets are
+/// served from `public_dir`, falling back to the app's 404 shell.
+pub(crate) fn build_router(state: AppState, public_dir: &std::path::Path, oai_router: Router<AppState>) -> Router {
+    use axum::response::Redirect;
+    use axum::routing::get;
+    use axum_tracing_opentelemetry::middleware::{OtelAxumLayer, OtelInResponseLayer};
+    use tower_http::services::ServeDir;
+
+    // Static assets + 404: serve files from the public dir, falling back to the
+    // "Page not found." shell.
+    let serve_dir = ServeDir::new(public_dir).not_found_service(get(crate::not_found).with_state(state.clone()));
+
+    Router::new()
+        // --- Traced routes (declared BEFORE .layer()) ---
+        // Page routes.
+        .route("/", get(|| async { Redirect::permanent("/dpe/projects") }))
+        .route("/dpe", get(|| async { Redirect::permanent("/dpe/projects") }))
+        .route("/dpe/projects", get(projects_page_handler))
+        .route("/dpe/about", get(about_page_handler))
+        .route("/dpe/projects/{id}", get(project_page_handler))
+        // OAI-PMH (note: /dpe/oai, not /oai) — XML, must stay unbroken.
+        // Rate-limited per-IP; the limiter is scoped to this route only (see `oai_router`).
+        .merge(oai_router)
+        // Datastar SSE + JSON endpoints.
+        .route("/dpe/projects/{id}/tab/{tab}", get(fragments::tab_fragment_handler))
+        .route("/dpe/projects/search", get(fragments::search_fragment_handler))
+        .route("/dpe/api/v2/projects", get(fragments::projects_json_handler))
+        .route("/dpe/api/v2/projects/{id}", get(fragments::project_json_handler))
+        // Static assets + 404 fallback.
+        .fallback_service(serve_dir)
+        // --- OTel layers ---
+        // Axum layers wrap in reverse declaration order:
+        // - OtelInResponseLayer (declared first) runs INNER — injects traceparent into response headers
+        // - OtelAxumLayer (declared second) runs OUTER — creates the server span from the request
+        .layer(OtelInResponseLayer)
+        .layer(OtelAxumLayer::default())
+        .with_state(state)
+}
+
+/// Tests for the rate-limit *seam*: that the limiter is wired onto `/dpe/oai`
+/// only. The actual throttling algorithm is `tower_governor`'s and is not
+/// re-tested here. Fake layers (`AllowAll`/`DenyAll`) stand in for the real
+/// `GovernorLayer` so gating is deterministic and independent of timing.
+///
+/// Each fake is defined inside the submodule of the single test that uses it,
+/// so the source itself shows the fake cannot leak to another test. The shared
+/// harness (`test_state`, `status_of`, `NO_PUBLIC_DIR`) lives here at the top.
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::extract::Request;
+    use axum::http::StatusCode;
+    use tower::ServiceExt;
+
+    use crate::AppState;
+
+    fn test_state() -> AppState {
+        AppState {
+            fathom_site_id: None,
+            css_href: "/assets/app.css".to_string(),
+        }
+    }
+
+    // Static assets come from a nonexistent dir: these tests target redirect and
+    // OAI routes, never a real static file, so the fallback is never exercised.
+    const NO_PUBLIC_DIR: &str = "nonexistent-test-dir";
+
+    async fn status_of(app: axum::Router, uri: &str) -> StatusCode {
+        let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
+        app.oneshot(req).await.unwrap().status()
+    }
+
+    /// `DenyAll` — a fake limiter that rejects every request with 429 without
+    /// calling inner. Scoped to `deny_all::gates_oai_only`.
+    mod deny_all {
+        use std::convert::Infallible;
+        use std::task::{Context, Poll};
+
+        use axum::body::Body;
+        use axum::extract::Request;
+        use axum::http::StatusCode;
+        use axum::response::Response;
+        use tower::{Layer, Service};
+
+        use super::{status_of, test_state, NO_PUBLIC_DIR};
+        use crate::router::{build_router, oai_router_with};
+
+        #[derive(Clone)]
+        struct DenyAll;
+
+        #[derive(Clone)]
+        struct DenyAllService<S> {
+            // DenyAll short-circuits, so inner is never called — held only to satisfy Layer.
+            _inner: S,
+        }
+
+        impl<S> Layer<S> for DenyAll {
+            type Service = DenyAllService<S>;
+            fn layer(&self, inner: S) -> Self::Service {
+                DenyAllService { _inner: inner }
+            }
+        }
+
+        impl<S> Service<Request> for DenyAllService<S>
+        where
+            S: Service<Request, Response = Response, Error = Infallible>,
+        {
+            type Response = Response;
+            type Error = Infallible;
+            type Future = std::future::Ready<Result<Response, Infallible>>;
+
+            fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+                Poll::Ready(Ok(()))
+            }
+            fn call(&mut self, _req: Request) -> Self::Future {
+                let resp = Response::builder()
+                    .status(StatusCode::TOO_MANY_REQUESTS)
+                    .body(Body::empty())
+                    .unwrap();
+                std::future::ready(Ok(resp))
+            }
+        }
+
+        #[tokio::test]
+        async fn gates_oai_only() {
+            // The `/dpe` redirect is a pure handler (no data/cache access), so it is a
+            // stable "not rate-limited" control that avoids the set_data_dir global.
+            let app = build_router(test_state(), NO_PUBLIC_DIR.as_ref(), oai_router_with(DenyAll));
+            assert_eq!(status_of(app.clone(), "/dpe/oai").await, StatusCode::TOO_MANY_REQUESTS);
+            assert_eq!(status_of(app, "/dpe").await, StatusCode::PERMANENT_REDIRECT);
+        }
+    }
+
+    /// `AllowAll` — a fake limiter that lets every request through unchanged.
+    /// Scoped to `allow_all::passes_oai_through`.
+    mod allow_all {
+        use std::convert::Infallible;
+        use std::task::{Context, Poll};
+
+        use axum::extract::Request;
+        use axum::http::StatusCode;
+        use axum::response::Response;
+        use tower::{Layer, Service};
+
+        use super::{status_of, test_state, NO_PUBLIC_DIR};
+        use crate::router::{build_router, oai_router_with};
+
+        #[derive(Clone)]
+        struct AllowAll;
+
+        #[derive(Clone)]
+        struct AllowAllService<S> {
+            inner: S,
+        }
+
+        impl<S> Layer<S> for AllowAll {
+            type Service = AllowAllService<S>;
+            fn layer(&self, inner: S) -> Self::Service {
+                AllowAllService { inner }
+            }
+        }
+
+        impl<S> Service<Request> for AllowAllService<S>
+        where
+            S: Service<Request, Response = Response, Error = Infallible>,
+        {
+            type Response = Response;
+            type Error = Infallible;
+            type Future = S::Future;
+
+            fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+                self.inner.poll_ready(cx)
+            }
+            fn call(&mut self, req: Request) -> Self::Future {
+                self.inner.call(req)
+            }
+        }
+
+        #[tokio::test]
+        async fn passes_oai_through() {
+            // With a passthrough limiter, /dpe/oai must NOT be 429 — proving the layer
+            // gates rather than hard-blocks. (The handler answers the OAI request itself.)
+            let app = build_router(test_state(), NO_PUBLIC_DIR.as_ref(), oai_router_with(AllowAll));
+            assert_ne!(status_of(app, "/dpe/oai").await, StatusCode::TOO_MANY_REQUESTS);
+        }
+    }
+
+    #[tokio::test]
+    async fn real_oai_router_builds_and_wires() {
+        // The production oai_router must build from default config (guards the
+        // .expect()) and attach without a passthrough request tripping the limit.
+        use crate::router::{build_router, oai_router};
+
+        let config = crate::config::DpeConfig::default();
+        let app = build_router(test_state(), NO_PUBLIC_DIR.as_ref(), oai_router(&config));
+        assert_ne!(status_of(app, "/dpe/oai").await, StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    /// The rate-limit key extractor: keys on the rightmost (Traefik-appended)
+    /// `X-Forwarded-For` entry, never the client-forgeable leftmost one.
+    mod key_extractor {
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+        use axum::extract::ConnectInfo;
+        use axum::http::Request;
+        use tower_governor::key_extractor::KeyExtractor;
+
+        use crate::router::RightmostXffKeyExtractor;
+
+        fn extract(xff: Option<&str>, peer: Option<SocketAddr>) -> Result<IpAddr, ()> {
+            let mut b = Request::builder();
+            if let Some(v) = xff {
+                b = b.header("x-forwarded-for", v);
+            }
+            let mut req = b.body(()).unwrap();
+            if let Some(addr) = peer {
+                req.extensions_mut().insert(ConnectInfo(addr));
+            }
+            RightmostXffKeyExtractor.extract(&req).map_err(|_| ())
+        }
+
+        fn ip(a: u8, b: u8, c: u8, d: u8) -> IpAddr {
+            IpAddr::V4(Ipv4Addr::new(a, b, c, d))
+        }
+
+        #[test]
+        fn takes_rightmost_xff() {
+            assert_eq!(extract(Some("1.1.1.1, 2.2.2.2, 3.3.3.3"), None), Ok(ip(3, 3, 3, 3)));
+        }
+
+        #[test]
+        fn single_xff() {
+            assert_eq!(extract(Some("4.4.4.4"), None), Ok(ip(4, 4, 4, 4)));
+        }
+
+        #[test]
+        fn trims_whitespace() {
+            assert_eq!(extract(Some("1.1.1.1,  5.5.5.5 "), None), Ok(ip(5, 5, 5, 5)));
+        }
+
+        #[test]
+        fn ignores_client_forged_leftmost() {
+            // A client that prepends a fake IP cannot change the key: Traefik
+            // appends the real client last, and we read the last entry.
+            assert_eq!(extract(Some("9.9.9.9, 6.6.6.6"), None), Ok(ip(6, 6, 6, 6)));
+        }
+
+        #[test]
+        fn falls_back_to_peer_when_no_xff() {
+            let peer = SocketAddr::new(ip(7, 7, 7, 7), 40000);
+            assert_eq!(extract(None, Some(peer)), Ok(ip(7, 7, 7, 7)));
+        }
+
+        #[test]
+        fn falls_back_to_peer_when_rightmost_unparseable() {
+            let peer = SocketAddr::new(ip(8, 8, 8, 8), 40000);
+            assert_eq!(extract(Some("garbage"), Some(peer)), Ok(ip(8, 8, 8, 8)));
+        }
+
+        #[test]
+        fn errors_when_no_xff_and_no_peer() {
+            assert_eq!(extract(None, None), Err(()));
+        }
+    }
+}


### PR DESCRIPTION
Fixes DEV-6724

## Motivation
The OAI-PMH endpoint (`/dpe/oai`) had no rate limiting, so a single harvester could hammer it without bound. The issue asks us to mirror how Zenodo protects its OAI-PMH endpoint, with the note that Zenodo's own limit (30 req/min) may be stricter than we need.

## Summary
- `GET /dpe/oai` is now rate-limited per client IP (default: burst of 60, then ~60 req/min sustained — a relaxed take on Zenodo's 30/min).
- Over-limit requests get `429 Too Many Requests` with `Retry-After` and `X-RateLimit-*` headers.
- Limits are tunable per environment via `DPE_OAI_RATE_LIMIT_PER_SECOND` and `DPE_OAI_RATE_LIMIT_BURST`.

## Key Changes
### Rate limiting on the OAI route
- Reuses the existing `tower_governor` `GovernorLayer` + `SmartIpKeyExtractor` already used for `/telemetry/collect`. The limiter is scoped to `/dpe/oai` only — page routes and the JSON API are untouched.
- `.use_headers()` enables the `X-RateLimit-*` response headers, matching Zenodo's harvester feedback.

### Configuration
- New `DpeConfig` fields `oai_rate_limit_per_second` (default `1`) and `oai_rate_limit_burst` (default `60`), overridable via `DPE_OAI_RATE_LIMIT_*` env vars (same figment pattern as `DPE_OAI_BASE_URL`).

### Router extracted to its own module
- Router assembly moved from `main.rs` into `router.rs` so it is unit-testable in isolation from `serve()`'s I/O and global setup.

### Docs
- `operations.md`: the two new env vars + a reverse-proxy note (the ingress must set a trusted `X-Forwarded-For`, else the per-IP key is spoofable).
- `oai-pmh.md`: a "Rate limiting" section for harvesters.

## Challenges and Decisions

### Testing the rate limit without testing the library
**Problem:** The throttling algorithm is entirely `tower_governor`'s; re-testing the token bucket would just be testing an external crate (which our conventions forbid).
**Solution:** Test only the integration — that the limiter is wired onto the correct route. Only test the `AllowAll`, `DenyAll` and the standard integration. 

## Gotchas
- The per-IP key uses `X-Forwarded-For`/`X-Real-IP` first, peer address otherwise. **Behind the production ingress, the proxy must set a trusted `X-Forwarded-For`** — otherwise a client can spoof the header and bypass the limit. This is the same exposure the existing telemetry route already has; documented in `operations.md`.

## Test Plan
- [x] `just test`, clippy (`-D warnings`), `cargo machete`, `cargo +nightly fmt --check` all clean
- [x] Manual: hit `/dpe/oai` past the burst on a running instance and confirm `429` + `Retry-After` / `X-RateLimit-*` headers

```
% x() { curl 2>&1 -vs 'http://localhost:4000/dpe/oai?verb=ListRecords&metadataPrefix=oai_datacite' | tee >(wc -l) | grep '< HTTP'; }
% y() { x & x & x & x & x & x & x & x & x & x & x & x & x & x & x & x & x & x & x & x & x &; }
% y & y & y & y & y & y & y & y & y & y & y & y & y & y &
```
