### PR TITLE
feat: onboard project 8055 (VARMA) and link contributor profiles

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -23,6 +23,10 @@ Agent reference card for the **work phase**. All authoritative detail lives in `
 - Metric attributes must be bounded — validate against known sets, normalize dynamic values. High-cardinality data goes to structured logs only, never to metric attributes
 - Vendored JS files go in `modules/dpe/public/vendor/` — update `vendor/README.md` when adding or updating
 
+## Data Conventions
+
+- New project `temporalCoverage` values must resolve to structured dates for OAI-PMH — add each new free-text value to `modules/dpe/server/data/temporal-coverage-enrichment.json` (keyed by display text, with a W3CDTF range and `source: "llm"`). See `docs/src/dpe/oai-pmh.md` and the "Adding a Project Metadata File" section of `modules/dpe/CLAUDE.md`.
+
 ## Commit Conventions
 
 Follow [Conventional Commits](https://www.conventionalcommits.org/). Scopes match crate names.

--- a/modules/dpe/CLAUDE.md
+++ b/modules/dpe/CLAUDE.md
@@ -68,6 +68,14 @@ cd modules/dpe/web-e2e-tests && npx playwright test
 
 ## When Making Changes
 
+### Adding a Project Metadata File
+
+Project descriptive metadata lives as JSON under `modules/dpe/server/data/`.
+
+1. Add `<shortcode>_<slug>.json` under `projects/` (and any new `persons/person-NNN.json` / `organizations/organization-NNN.json`); pick new person/org ids by scanning existing internal `"id"` values, and reuse existing organizations rather than duplicating them.
+2. **Every `temporalCoverage` value must resolve to a structured date for OAI-PMH.** Free-text values (e.g. `{"en": "11th-15th centuries"}`) resolve against `modules/dpe/server/data/temporal-coverage-enrichment.json`, keyed by the display text. Add a row with a W3CDTF range and `"source": "llm"` (e.g. `"11th-15th centuries": {"date": "1001/1500", "original_name": "11th-15th centuries", "source": "llm"}`); if the value is not a time period, use `"date": null, "source": "unresolved"`. The `every_committed_temporal_coverage_resolves` test fails otherwise. See `docs/src/dpe/oai-pmh.md` → *Temporal coverage*.
+3. Run `just validate-data` (cross-references) and `just test`.
+
 ### Adding a New Component
 
 1. Add a `fn name(...) -> maud::Markup` in `web/src/components/`

--- a/modules/dpe/server/data/persons/person-414.json
+++ b/modules/dpe/server/data/persons/person-414.json
@@ -1,0 +1,23 @@
+{
+    "id": "person-414",
+    "givenNames": [
+        "Antonia"
+    ],
+    "familyNames": [
+        "Martínez Ruipérez"
+    ],
+    "jobTitles": [
+        "Post-doctoral researcher"
+    ],
+    "affiliations": [
+        "organization-092"
+    ],
+    "sameAs": [
+        {
+            "type": "URL",
+            "url": "https://kunstgeschichte.philhist.unibas.ch/en/persons/martinez-ruiperez-antonia/",
+            "text": "Universität Basel"
+        }
+    ],
+    "email": "antonia.martinezruiperez@unibas.ch"
+}

--- a/modules/dpe/server/data/persons/person-415.json
+++ b/modules/dpe/server/data/persons/person-415.json
@@ -1,0 +1,15 @@
+{
+    "id": "person-415",
+    "givenNames": [
+        "Jolanda"
+    ],
+    "familyNames": [
+        "Frische"
+    ],
+    "jobTitles": [
+        "Student"
+    ],
+    "affiliations": [
+        "organization-092"
+    ]
+}

--- a/modules/dpe/server/data/projects/8055_art-of-reason.json
+++ b/modules/dpe/server/data/projects/8055_art-of-reason.json
@@ -1,0 +1,105 @@
+{
+    "id": "8055",
+    "pid": "https://ark.dasch.swiss/ark:/72163/1/8055",
+    "name": "The Art of Reason in the Middle Ages. Visualizing reason and rational thought (11th-15th centuries)",
+    "shortcode": "8055",
+    "officialName": "The Art of Reason in the Middle Ages. Visualizing reason and rational thought (11th-15th centuries)",
+    "status": "Ongoing",
+    "shortDescription": "The Art of Reason explores how medieval visual culture shaped and represented ideas of reason, revealing images as active forces in medieval intellectual history.",
+    "description": {
+        "en": "The attribution of “irrationality” to the Middle Ages, combined with the complex and multifaceted nature of medieval conceptualizations of reason, has contributed to a fragmented understanding of the history of reason in the medieval period. Medieval images, far from being mere “reflections” of textual discussions of reason, emerge as powerful visual articulations of aspects of reason that were overlooked, marginalized, or only indirectly addressed in medieval texts. At the same time, they functioned as active instruments in shaping and stimulating the very processes of reasoning.\n\nThe Art of Reason aims to provide a comprehensive study of the idea of reason throughout the Middle Ages, examining how it was constructed and represented through medieval visual culture."
+    },
+    "startDate": "2023-09-01",
+    "endDate": "2027-08-31",
+    "howToCite": "Martínez Ruipérez, Antonia; Frische, Jolanda: Vernacular Allegories of Reason in Medieval Art [Database]. DaSCH. Persistent identifier.",
+    "accessRights": {
+        "accessRights": "Embargoed Access",
+        "embargoDate": "2029-08-31"
+    },
+    "legalInfo": [
+        {
+            "license": {
+                "licenseIdentifier": "CC BY-ND 4.0",
+                "licenseDate": "2026-07-21",
+                "licenseURI": "https://creativecommons.org/licenses/by-nd/4.0/"
+            },
+            "copyrightHolder": "Vernacular Allegories of Reason in Medieval Art",
+            "authorship": [
+                "CALCULATED"
+            ]
+        }
+    ],
+    "typeOfData": [
+        "Text",
+        "Image"
+    ],
+    "dataLanguage": [
+        "en"
+    ],
+    "keywords": [
+        {
+            "en": "Medieval art"
+        },
+        {
+            "en": "Reason"
+        },
+        {
+            "en": "Manuscripts Studies"
+        },
+        {
+            "en": "History of Thought"
+        }
+    ],
+    "disciplines": [
+        {
+            "en": "10404 Visual arts and Art history"
+        }
+    ],
+    "temporalCoverage": [
+        {
+            "en": "11th-15th centuries"
+        }
+    ],
+    "spatialCoverage": [
+        {
+            "type": "Geonames",
+            "url": "https://www.geonames.org/6255148/europe.html",
+            "text": "Europe"
+        }
+    ],
+    "attributions": [
+        {
+            "contributor": "person-414",
+            "contributorType": [
+                "Project Leader"
+            ]
+        },
+        {
+            "contributor": "person-415",
+            "contributorType": [
+                "Data Collector"
+            ]
+        }
+    ],
+    "abstract": {
+        "en": "In French allegorical literature of the 13th–15th centuries, Reason emerges as a significant figure in the development of the narrative. Works such as Le Roman de la Rose by Guillaume de Lorris and Jean de Meun, Le Pèlerinage de la vie humaine by Guillaume de Deguileville, and Christine de Pizan’s La Cité des Dames present, each in their own way, a particular conception of Reason. Very popular at the time, these extensively illustrated works offer a rich corpus of representations of Reason. The purpose of this database is to compile the dispersed images of Reason found in these allegorical works. Through the cataloguing of these images, this database also seeks to offer a more nuanced and comprehensive understanding of the representation of Reason within vernacular allegories of the late Middle Ages."
+    },
+    "contactPoint": [
+        "person-414"
+    ],
+    "funding": [
+        {
+            "funders": [
+                "organization-002"
+            ],
+            "number": "216489",
+            "name": "Ambizione",
+            "url": "https://data.snf.ch/grants/grant/216489"
+        }
+    ],
+    "alternativeNames": [
+        {
+            "en": "VARMA"
+        }
+    ]
+}

--- a/modules/dpe/server/data/projects/8055_art-of-reason.json
+++ b/modules/dpe/server/data/projects/8055_art-of-reason.json
@@ -23,7 +23,7 @@
                 "licenseDate": "2026-07-21",
                 "licenseURI": "https://creativecommons.org/licenses/by-nd/4.0/"
             },
-            "copyrightHolder": "Vernacular Allegories of Reason in Medieval Art",
+            "copyrightHolder": "The Art of Reason in the Middle Ages. Visualizing reason and rational thought (11th-15th centuries)",
             "authorship": [
                 "CALCULATED"
             ]

--- a/modules/dpe/server/data/temporal-coverage-enrichment.json
+++ b/modules/dpe/server/data/temporal-coverage-enrichment.json
@@ -4,6 +4,11 @@
     "original_name": "10th - 20th century",
     "source": "llm"
   },
+  "11th-15th centuries": {
+    "date": "1001/1500",
+    "original_name": "11th-15th centuries",
+    "source": "llm"
+  },
   "1269-1465": {
     "date": "1269/1465",
     "original_name": "1269-1465",

--- a/modules/dpe/web/src/pages/project/components/person.rs
+++ b/modules/dpe/web/src/pages/project/components/person.rs
@@ -5,10 +5,17 @@ use maud::{html, Markup};
 /// Shared name + roles + job-titles block for a resolved [`Person`].
 fn person_name_and_roles(person: &Person, roles: Option<&str>) -> Markup {
     let full_name = format!("{} {}", person.given_names.join(" "), person.family_names.join(" "));
-    let orcid_url = person.same_as.iter().find(|r| r.type_ == "ORCID").map(|r| r.url.as_str());
+    // Link the name to the person's ORCID when available, otherwise fall back to
+    // their first `sameAs` reference (e.g. an institutional profile page).
+    let link_url = person
+        .same_as
+        .iter()
+        .find(|r| r.type_ == "ORCID")
+        .or_else(|| person.same_as.first())
+        .map(|r| r.url.as_str());
     html! {
         div class="font-medium" {
-            @match orcid_url {
+            @match link_url {
                 Some(url) => a   href=(url)
                     target="_blank"
                     rel="noopener noreferrer"
@@ -121,5 +128,41 @@ mod tests {
     fn unknown_person_renders_not_found() {
         let out = person("person-missing", None, false).into_string();
         assert!(out.contains("Person not found"), "{out}");
+    }
+
+    #[test]
+    fn name_links_to_orcid_when_present() {
+        use dpe_core::models::AuthorityFileReference;
+        let mut p = sample_person();
+        p.same_as = vec![
+            AuthorityFileReference {
+                type_: "URL".to_string(),
+                url: "https://example.org/profile".to_string(),
+                text: None,
+            },
+            AuthorityFileReference {
+                type_: "ORCID".to_string(),
+                url: "https://orcid.org/0000-0002-1825-0097".to_string(),
+                text: None,
+            },
+        ];
+        let out = person_view(&p, &[], None, false).into_string();
+        assert!(out.contains(r#"href="https://orcid.org/0000-0002-1825-0097""#), "{out}");
+    }
+
+    #[test]
+    fn name_links_to_sameas_url_when_no_orcid() {
+        use dpe_core::models::AuthorityFileReference;
+        let mut p = sample_person();
+        p.same_as = vec![AuthorityFileReference {
+            type_: "URL".to_string(),
+            url: "https://kunstgeschichte.philhist.unibas.ch/en/persons/martinez-ruiperez-antonia/".to_string(),
+            text: None,
+        }];
+        let out = person_view(&p, &[], None, false).into_string();
+        assert!(
+            out.contains(r#"href="https://kunstgeschichte.philhist.unibas.ch/en/persons/martinez-ruiperez-antonia/""#),
+            "{out}"
+        );
     }
 }


### PR DESCRIPTION
Fixes DEV-6810

## Motivation

The researchers behind "The Art of Reason in the Middle Ages" (SNSF Ambizione 216489, PI Antonia Martínez Ruipérez, Universität Basel) supplied a completed metadata intake form for their dataset "Vernacular Allegories of Reason in Medieval Art" (VARMA, DaSCH shortcode 8055). The project needs its descriptive metadata registered in the DPE project registry. The intake form is written in the legacy dsp-meta vocabulary, so this transforms it to the flat JSON schema.

## Summary

Adds the VARMA project record plus its two contributors, reusing existing organizations. Also lets a contributor's name link to their institutional profile page when they have no ORCID — needed so the PI's University of Basel profile is reachable.

## Key Changes

- `modules/dpe/server/data/projects/8055_art-of-reason.json` — new project (Ongoing; Embargoed Access, embargo date 2029-08-31; CC BY-ND 4.0; SNSF Ambizione 216489; disciplines 10404 Visual arts and Art history).
- `modules/dpe/server/data/persons/person-414.json` — Antonia Martínez Ruipérez (Project Leader, contact point).
- `modules/dpe/server/data/persons/person-415.json` — Jolanda Frische (Data Collector).
- Reused `organization-092` (Universität Basel, Kunsthistorisches Seminar) and `organization-002` (SNSF) — no duplicates created.
- `modules/dpe/web/src/pages/project/components/person.rs` — a contributor's name now links to their ORCID when present, otherwise to their first `sameAs` reference (e.g. an institutional profile). Adds two tests.

## Challenges and Decisions

- **`licenseDate`** — the intake form gives no publication date (project is embargoed/ongoing), but the field is required; set to the entry date `2026-07-21`. :warning: To be confirmed with the researcher.
- **License version** — intake says "CC BY-ND" with no version → CC BY-ND 4.0.
- **Access rights** — "Open Access with a 2-year embargo after project completion" → `Embargoed Access`, `embargoDate` 2029-08-31 (project ends 2027-08-31 + 2y).
- **Person 2 (Jolanda Frische)** — intake supplies only name / role / affiliation / job title; no email or ORCID.
- **IDs** — next free person IDs (414, 415) picked by scanning internal `"id"` values against `origin/main`; the Basel org was reused rather than duplicated.

## Gotchas

- The teaser image (Paris, Bibliothèque Mazarine, ms 729, fol. 230) is handled separately in DEV-6811, not here.
- Backend provisioning of 8055 in dsp-api is an ops task, out of scope.

## Test Plan

- `just validate-data` → 0 errors (84 projects, 415 persons, 142 organizations); all cross-references resolve.
- `cargo test -p dpe-web -p dpe-server` → all pass, including two new person-link tests; no snapshot regressions.
- Verified locally on the project page: correct metadata; no "Discover Project Data" button; "Also known as: VARMA"; PI name links to the unibas profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
