### PR TITLE
feat: show project permalink as the bare ARK identifier

### DIFF
--- a/modules/dpe/server/src/snapshots/dpe_server__fragments__tests__project_sidebar_real_project.snap
+++ b/modules/dpe/server/src/snapshots/dpe_server__fragments__tests__project_sidebar_real_project.snap
@@ -1,8 +1,9 @@
 ---
 source: modules/dpe/server/src/fragments.rs
+assertion_line: 568
 expression: html
 ---
-<div class="card card-bordered overflow-visible dpe-small p-4 space-y-4 text-gray-700 lg:w-96"><div class="space-y-4"><h2 class="dpe-title">Cite this Project</h2><div><h3 class="dpe-subtitle">Permalink</h3><div class="card card-bordered w-full bg-gray-50 text-gray-700 text-sm"><div class="card-body"><div class="flex items-center justify-between gap-3"><a href="https://ark.dasch.swiss/ark:/72163/1/0803" class="text-primary break-all flex-1">https://ark.dasch.swiss/ark:/72163/1/0803</a><button class="btn btn-ghost px-1 py-0.5 text-xs tooltip tooltip-left flex-shrink-0 inline-flex items-center justify-center min-h-6 min-w-6" aria-label="Copy" data-tip="Copy" data-copy-text="https://ark.dasch.swiss/ark:/72163/1/0803" onclick="var status = this.nextElementSibling;
+<div class="card card-bordered overflow-visible dpe-small p-4 space-y-4 text-gray-700 lg:w-96"><div class="space-y-4"><h2 class="dpe-title">Cite this Project</h2><div><h3 class="dpe-subtitle">Permalink</h3><div class="card card-bordered w-full bg-gray-50 text-gray-700 text-sm"><div class="card-body"><div class="flex items-center justify-between gap-3"><a href="https://ark.dasch.swiss/ark:/72163/1/0803" class="text-primary hover:underline break-all flex-1">ark:/72163/1/0803</a><button class="btn btn-ghost px-1 py-0.5 text-xs tooltip tooltip-left flex-shrink-0 inline-flex items-center justify-center min-h-6 min-w-6" aria-label="Copy" data-tip="Copy" data-copy-text="https://ark.dasch.swiss/ark:/72163/1/0803" onclick="var status = this.nextElementSibling;
 try {
 navigator.clipboard.writeText(this.dataset.copyText);
 this.setAttribute('data-tip', 'Copied!');

--- a/modules/dpe/server/src/snapshots/dpe_server__fragments__tests__project_sidebar_with_entity_ids.snap
+++ b/modules/dpe/server/src/snapshots/dpe_server__fragments__tests__project_sidebar_with_entity_ids.snap
@@ -1,8 +1,9 @@
 ---
 source: modules/dpe/server/src/fragments.rs
+assertion_line: 629
 expression: html
 ---
-<div class="card card-bordered overflow-visible dpe-small p-4 space-y-4 text-gray-700 lg:w-96"><div class="space-y-4"><h2 class="dpe-title">Cite this Project</h2><div><h3 class="dpe-subtitle">Permalink</h3><div class="card card-bordered w-full bg-gray-50 text-gray-700 text-sm"><div class="card-body"><div class="flex items-center justify-between gap-3"><a href="https://ark.dasch.swiss/ark:/72163/1/0001" class="text-primary break-all flex-1">https://ark.dasch.swiss/ark:/72163/1/0001</a><button class="btn btn-ghost px-1 py-0.5 text-xs tooltip tooltip-left flex-shrink-0 inline-flex items-center justify-center min-h-6 min-w-6" aria-label="Copy" data-tip="Copy" data-copy-text="https://ark.dasch.swiss/ark:/72163/1/0001" onclick="var status = this.nextElementSibling;
+<div class="card card-bordered overflow-visible dpe-small p-4 space-y-4 text-gray-700 lg:w-96"><div class="space-y-4"><h2 class="dpe-title">Cite this Project</h2><div><h3 class="dpe-subtitle">Permalink</h3><div class="card card-bordered w-full bg-gray-50 text-gray-700 text-sm"><div class="card-body"><div class="flex items-center justify-between gap-3"><a href="https://ark.dasch.swiss/ark:/72163/1/0001" class="text-primary hover:underline break-all flex-1">ark:/72163/1/0001</a><button class="btn btn-ghost px-1 py-0.5 text-xs tooltip tooltip-left flex-shrink-0 inline-flex items-center justify-center min-h-6 min-w-6" aria-label="Copy" data-tip="Copy" data-copy-text="https://ark.dasch.swiss/ark:/72163/1/0001" onclick="var status = this.nextElementSibling;
 try {
 navigator.clipboard.writeText(this.dataset.copyText);
 this.setAttribute('data-tip', 'Copied!');

--- a/modules/dpe/web/src/pages/project/components/project_sidebar/permalink.rs
+++ b/modules/dpe/web/src/pages/project/components/project_sidebar/permalink.rs
@@ -4,10 +4,20 @@ use mosaic_tiles::copy_button::copy_button;
 use super::super::info_card::info_card;
 
 /// The project's permalink (PID) with a copy-to-clipboard button.
+///
+/// The ARK is shown as its bare identifier (`ark:/72163/1/0ABC`) — the way a
+/// DOI is displayed without the `doi.org/` host — so the permalink stays short
+/// and on one line. The link target and the copy button still use the full URL.
 pub fn permalink(permalink: &str) -> Markup {
+    let display = permalink
+        .find("ark:/")
+        .map(|i| &permalink[i..])
+        .or_else(|| permalink.strip_prefix("https://"))
+        .or_else(|| permalink.strip_prefix("http://"))
+        .unwrap_or(permalink);
     let card_inner = html! {
         div class="flex items-center justify-between gap-3" {
-            a href=(permalink) class="text-primary break-all flex-1" { (permalink) }
+            a href=(permalink) class="text-primary hover:underline break-all flex-1" { (display) }
             (copy_button(permalink))
         }
     };
@@ -25,10 +35,16 @@ mod tests {
     fn renders_link_and_copy_button() {
         let out = permalink("https://ark.dasch.swiss/ark:/72163/1/0ABC").into_string();
         assert!(out.contains("Permalink"), "{out}");
+        // The link target and copy text keep the full, resolvable URL.
         assert!(out.contains(r#"href="https://ark.dasch.swiss/ark:/72163/1/0ABC""#), "{out}");
         assert!(
             out.contains(r#"data-copy-text="https://ark.dasch.swiss/ark:/72163/1/0ABC""#),
             "copy button: {out}"
         );
+        // The visible link text is the bare ARK identifier (like a DOI, no host).
+        assert!(out.contains(r#">ark:/72163/1/0ABC<"#), "display bare ark id: {out}");
+        assert!(!out.contains(">ark.dasch.swiss"), "host stripped from display: {out}");
+        // Underlines on hover, like the other text links (contributors, persons).
+        assert!(out.contains("hover:underline"), "hover underline: {out}");
     }
 }


### PR DESCRIPTION
Fixes DEV-6756

## Motivation

On a project's **Cite this Project** card, the permalink (ARK URL) is shown in full, e.g. `https://ark.dasch.swiss/ark:/72163/1/083A`. It is long enough to wrap onto a second line, which looks broken.

## Summary

Display the permalink as its **bare ARK identifier** (`ark:/72163/1/083A`) — the way a DOI is shown without the `doi.org/` host — so it stays short and on one line. The link target (`href`) and the copy button still use the full, resolvable URL.

## Key Changes

- `project_sidebar/permalink.rs`: the **visible link text** is now the substring from `ark:/` onward (falls back to stripping the `https://`/`http://` scheme for any non-ARK PID); `href` and `data-copy-text` keep the full URL.
- The permalink now **underlines on hover** (`hover:underline`), matching the other text links (contributors, persons).
- Updated the unit test and re-accepted the two `project_sidebar` insta snapshots (visible text + link class only; `href`/copy unchanged).

## Challenges and Decisions

- The copy button intentionally still copies the full URL (the resolvable persistent identifier); only the display is shortened.

## Gotchas

- None. No data-model change; purely a display tweak in one component.

## Test Plan

- `just test` (full workspace) green.
- `cargo clippy --all-features -- -D warnings`, `maudfmt` no-op check, and `cargo +nightly fmt --check` all clean.
- Snapshot diff confirmed: the anchor text is now `ark:/72163/1/083A` while `href` and `data-copy-text` stay the full URL.
