### PR TITLE
fix: restore default blue link colour

### DIFF
--- a/modules/mosaic/tiles/src/components/theme_provider/tokens.css
+++ b/modules/mosaic/tiles/src/components/theme_provider/tokens.css
@@ -19,6 +19,11 @@
     --color-primary-800: oklch(0.33 0.0595 244.6);
     --color-primary-900: oklch(0.27 0.0466 244.6);
     --color-primary-950: oklch(0.2 0.0325 244.6);
+    /* Default primary = the 600 stop (DaSCH Blue #336790). Re-enables the bare
+       `text-primary` / `bg-primary` / `border-primary` utilities used by DPE text
+       links; without it those classes resolve to nothing (see modules/dpe/CLAUDE.md).
+       Uses the same var() aliasing as the info → secondary tokens below. */
+    --color-primary: var(--color-primary-600);
 
     /* Secondary: DaSCH Blue Light (#74A2CF) */
     --color-secondary-50: oklch(0.97 0.0143 248.6);


### PR DESCRIPTION
Fixes DEV-6852

## Motivation

Text links in the DPE (person names, emails, the project permalink/ARK, contributor org, funding "More info", DMP, "Clear all", the About back-link) regressed from **DaSCH blue** to near-black, only reacting on hover.

Root cause: the Leptos→Maud migration (`b89eaf4f`, DEV-6642) removed DaisyUI and its `daisy-ui-theme.css`, which held the **only** definition of the bare `--color-primary` token (= DaSCH Blue `#336790`, identical to today's `primary-600`). The replacement `tokens.css` defines only the numbered stops (`--color-primary-50 … 950`). In Tailwind v4 the utility `text-primary` (no stop) compiles to `color: var(--color-primary)` — now undefined — so the rule emits nothing and every `<a class="text-primary …">` falls back to Preflight's `a { color: inherit }`. The markup never changed; only the token backing it disappeared. This is exactly the "class resolves to nothing" footgun called out in `modules/dpe/CLAUDE.md`. The commit stated "no visual regression intended," so this was accidental.

Mosaic's `.link` / `.breadcrumb-link` use the stop form (`text-primary-600`) and were unaffected — which is why breadcrumbs stayed blue while body links did not.

## Summary

Re-add the bare `--color-primary` token as an alias of the 600 stop in the single design-system token source. One line, no markup changes — every `text-primary` link resolves to DaSCH blue again.

## Key Changes

- `modules/mosaic/tiles/src/components/theme_provider/tokens.css`: add `--color-primary: var(--color-primary-600);` inside the `@theme static` block, right after the primary scale. Mirrors the existing `info → secondary` var() aliasing in the same file.

## Challenges and Decisions

- **Token alias vs. per-site edits.** Considered changing the ~9 anchors to `text-primary-600`, or routing them through the Mosaic `link()` primitive. Chose the token alias: it's the minimal revert of an accidental regression, fixes every site at once, keeps each link's existing hover behaviour, and removes the footgun for future `text-primary` / `bg-primary` / `border-primary` usage. Component consolidation onto the Mosaic `link` primitive remains a natural follow-up for the design-system work.
- **Shared token file.** This file is `@import`ed by both DPE and the Mosaic playground, so the fix is global by construction; the only effect on the playground is that bare `primary` utilities become available (harmless).

## Gotchas

- The built `public/assets/app.css` is gitignored, so the tracked diff is only the token file. Rebuild with `just css` (or it happens automatically under `just dev`).
- The same latent footgun exists for other bare semantic tokens (`text-secondary`, `text-success`, …), but nothing uses them bare today — out of scope here.

## Test Plan

- `just css` then `grep -E '\.text-primary\{' modules/dpe/public/assets/app.css` → now returns `.text-primary{color:var(--color-primary)}` (absent before the fix).
- `just check` passes (CSS-only change; no Rust delta).
- Manual: on `/dpe/projects/0854` (Alice in DaSCHland) the person name + email (Contributors tab) and the "Cite this Project → Permalink" ARK all render DaSCH blue at rest, underlining on hover; non-link text stays dark. Verified in-browser.
