### PR TITLE
fix(ci): fetch full history when amending the release PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -48,6 +48,11 @@ jobs:
         if: steps.find-pr.outputs.branch
         with:
           ref: ${{ steps.find-pr.outputs.branch }}
+          # Full history: the next step amends release-please's commit. A shallow
+          # checkout (default depth 1) has no parent to amend onto, so the amend
+          # becomes a parentless root commit, the force-push makes the branch
+          # disjoint from main, and GitHub auto-closes the release PR.
+          fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
 
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Fixes DEV-6863 — https://linear.app/dasch/issue/DEV-6863

## Motivation

Every Release Please PR has been opening and then auto-closing within ~20 seconds, so **no release has been cut since v0.8.0 (6 July)**. DEV keeps deploying on each merge to `main`, but tagged releases — and any production image pinned off a release — are frozen at v0.8.0.

## Summary

The `Update Cargo.lock on release PR` step amends release-please's commit, but its `actions/checkout` used the default **shallow clone (depth 1)**. With no parent available to amend onto, `git commit --amend` produced a **parentless root commit** (`843bca3` — 1108 files / 1.3M insertions); the `git push --force-with-lease` then left the branch with **no common ancestor with `main`**, and GitHub auto-closes a PR whose head is disjoint from its base.

## Key Changes

- Add `fetch-depth: 0` to the `actions/checkout@v4` step in `.github/workflows/release-please.yml` so `--amend` preserves the real parent and the release branch stays connected to `main`.

## Challenges and Decisions

- Considered dropping the amend and adding `Cargo.lock` as a second commit, but that breaks the one-commit-per-PR rule the amend was introduced to satisfy (`fix(ci): amend Cargo.lock into release commit…`). Full history is the minimal fix that keeps the single-commit release.

## Gotchas

- This **cannot be verified on this PR's own CI** — the bug only manifests when `release-please.yml` runs on push to `main`. It takes effect on the next merge to `main` after this lands.

## Test Plan

- After merge, confirm the next push to `main` leaves the `chore(main): release …` PR **open** (not self-closed within seconds), with a diff of ~3 files (CHANGELOG, manifest, Cargo.toml/lock) instead of the whole tree.
- Confirm `git merge-base main release-please--branches--main` returns a real common ancestor.
