### PR TITLE
feat(dpe-web): add optional imageCredit field + cover-image caption

### DIFF
--- a/docs/src/dpe/metadata-model.md
+++ b/docs/src/dpe/metadata-model.md
@@ -183,6 +183,7 @@ cardinality between the archival and in-progress stages.
 | `documentationMaterial` | url[]                                  | 0-n   | 0-n       |
 | `provenance`            | string                                 | 0-1   | 0-1       |
 | `additionalMaterial`    | url[]                                  | 0-n   | 0-n       |
+| `imageCredit`           | string                                 | 0-1   | 0-1       |
 
 - `id`: A unique internal identifier; not exposed to the user and not persistent.
 - `pid`: A unique persistent identifier (currently an ARK URL).
@@ -233,6 +234,10 @@ cardinality between the archival and in-progress stages.
 - `documentationMaterial`: URLs pointing to documentation material.
 - `provenance`: The history of the project, if applicable.
 - `additionalMaterial`: Additional URLs related to the project.
+- `imageCredit`: An optional credit line for the project's cover image (e.g.
+  "© Fabrice Ducrest, Unil"), stored verbatim and rendered as a caption beneath
+  the image. Distinct from `legalInfo`, which describes the dataset's rights —
+  not the teaser image.
 
 > [!NOTE]
 > All records of a project are referenced in its `records` array, regardless of
@@ -253,6 +258,9 @@ cardinality between the archival and in-progress stages.
 > - Many fields are optional in the code regardless of the archival cardinality
 >   above (e.g. `dataManagementPlan`, `dataPublicationYear`, `typeOfData`,
 >   `dataLanguage`, `records`, `publications`, `provenance`, `additionalMaterial`).
+> - `imageCredit` is implemented as an optional string. Note the cover image
+>   itself is **not** modelled: it is resolved by filename convention
+>   (`/assets/images/<shortcode>.webp`); `imageCredit` only records its credit.
 
 ### Collection
 

--- a/modules/dpe/api-oai/src/handlers/test_utils.rs
+++ b/modules/dpe/api-oai/src/handlers/test_utils.rs
@@ -219,6 +219,7 @@ pub fn incunabula_project() -> Project {
         documentation_material: None,
         provenance: None,
         additional_material: None,
+        image_credit: None,
     }
 }
 

--- a/modules/dpe/core/src/project.rs
+++ b/modules/dpe/core/src/project.rs
@@ -90,6 +90,9 @@ pub struct ProjectRaw {
     #[serde(default)]
     pub provenance: Option<String>,
     pub additional_material: Option<Vec<String>>,
+    /// Optional credit line for the project's cover image (e.g. a photographer
+    /// copyright). Stored verbatim; distinct from `legal_info` (dataset rights).
+    pub image_credit: Option<String>,
 }
 
 pub const ACCESS_RIGHTS_VALUES: &[&str] = &[
@@ -173,6 +176,9 @@ pub struct Project {
     pub documentation_material: Option<Vec<String>>,
     pub provenance: Option<String>,
     pub additional_material: Option<Vec<String>>,
+    /// Optional credit line for the project's cover image (e.g. a photographer
+    /// copyright). Stored verbatim; distinct from `legal_info` (dataset rights).
+    pub image_credit: Option<String>,
 }
 
 impl From<ProjectRaw> for Project {
@@ -218,6 +224,7 @@ impl From<ProjectRaw> for Project {
             documentation_material: raw.documentation_material,
             provenance: raw.provenance,
             additional_material: raw.additional_material,
+            image_credit: raw.image_credit,
         }
     }
 }
@@ -260,6 +267,7 @@ impl From<&Project> for ProjectRaw {
             documentation_material: p.documentation_material.clone(),
             provenance: p.provenance.clone(),
             additional_material: p.additional_material.clone(),
+            image_credit: p.image_credit.clone(),
         }
     }
 }
@@ -396,6 +404,27 @@ mod tests {
         let (primary, secondary) = parse_url_value(None);
         assert!(primary.is_none());
         assert!(secondary.is_none());
+    }
+
+    /// A file without `imageCredit` (all committed files predate the field) must
+    /// deserialize to `None` — the field is purely additive.
+    #[test]
+    fn image_credit_defaults_to_none_for_existing_file() {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../server/data/projects/0102_tanner.json");
+        let json = std::fs::read_to_string(path).expect("sample project file should be readable");
+        let project = serde_json::from_str::<ProjectRaw>(&json).map(Project::from).expect("parses");
+        assert!(project.image_credit.is_none());
+    }
+
+    /// When present, `imageCredit` round-trips verbatim through `ProjectRaw` → `Project`.
+    #[test]
+    fn image_credit_is_parsed_when_present() {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../server/data/projects/0102_tanner.json");
+        let json = std::fs::read_to_string(path).expect("sample project file should be readable");
+        let mut value: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        value["imageCredit"] = json!("© Someone, Somewhere");
+        let project = Project::from(serde_json::from_value::<ProjectRaw>(value).expect("parses"));
+        assert_eq!(project.image_credit.as_deref(), Some("© Someone, Somewhere"));
     }
 
     /// Classify an authority-file URL as a place gazetteer, a period gazetteer,

--- a/modules/dpe/server/src/fragments.rs
+++ b/modules/dpe/server/src/fragments.rs
@@ -311,6 +311,7 @@ mod tests {
             documentation_material: None,
             provenance: None,
             additional_material: None,
+            image_credit: None,
         }
     }
 
@@ -624,6 +625,7 @@ mod tests {
             documentation_material: None,
             provenance: None,
             additional_material: None,
+            image_credit: None,
         };
         let html = render_project_sidebar(&project);
         insta::assert_snapshot!("project_sidebar_with_entity_ids", html);

--- a/modules/dpe/web/src/domain/projects.rs
+++ b/modules/dpe/web/src/domain/projects.rs
@@ -254,6 +254,7 @@ mod tests {
             documentation_material: None,
             provenance: None,
             additional_material: None,
+            image_credit: None,
         }
     }
 

--- a/modules/dpe/web/src/pages/project/components/project_header.rs
+++ b/modules/dpe/web/src/pages/project/components/project_header.rs
@@ -82,6 +82,9 @@ pub fn project_header(proj: &Project) -> Markup {
                     style="height: 320px"
                 { (icon(OpenDocument, "w-12 h-12 text-gray-300")) }
             }
+            @if let Some(credit) = &proj.image_credit {
+                figcaption class="px-3 py-1 text-right text-xs text-gray-500" { (credit) }
+            }
         }
         (card_body(body_inner))
     };
@@ -102,5 +105,24 @@ mod tests {
         // sample_project has a primary url → "Discover Project Data" button.
         assert!(out.contains(r#"href="https://example.org/project""#), "{out}");
         assert!(out.contains("Discover Project Data"), "{out}");
+    }
+
+    #[test]
+    fn renders_image_credit_as_figcaption_when_present() {
+        let proj = Project {
+            image_credit: Some("© Fabrice Ducrest, Unil".to_string()),
+            ..sample_project()
+        };
+        let out = project_header(&proj).into_string();
+        assert!(out.contains("<figcaption"), "{out}");
+        // Verbatim credit — "©" is preserved by Maud's auto-escaping splice.
+        assert!(out.contains("© Fabrice Ducrest, Unil"), "{out}");
+    }
+
+    #[test]
+    fn omits_figcaption_when_no_image_credit() {
+        // sample_project() has image_credit: None.
+        let out = project_header(&sample_project()).into_string();
+        assert!(!out.contains("<figcaption"), "{out}");
     }
 }

--- a/modules/dpe/web/src/test_support.rs
+++ b/modules/dpe/web/src/test_support.rs
@@ -89,6 +89,7 @@ pub(crate) fn sample_project() -> Project {
         documentation_material: None,
         provenance: None,
         additional_material: None,
+        image_credit: None,
     }
 }
 


### PR DESCRIPTION
Fixes DEV-6860

## Motivation
Project cover images in the DPE are associated by filename convention only (`/assets/images/<shortcode>.webp`) and rendered with just `src` + `alt`, so a project's cover-image credit — e.g. **"© Fabrice Ducrest, Unil"** on project 0113 (surfaced by #305) — had nowhere to live. Credits had leaked into `howToCite`, conflating dataset citation with an asset credit. `legalInfo` is the wrong home: it is *calculated dataset rights* and would misattribute the dataset copyright to the photographer.

## Summary
- New optional `imageCredit` field on the project metadata model.
- Rendered as a `<figcaption>` beneath the cover image on the project detail page.
- Documented in the metadata model; no data migration (purely additive).

## Key Changes
### Metadata model (dpe-core)
- `image_credit: Option<String>` on `ProjectRaw` and `Project`, threaded through both `From` conversions. `Option` + `rename_all = camelCase` means missing → `None`, so all 84 existing files stay valid.

### Rendering (dpe-web)
- `<figcaption>` added inside the existing `<figure>` in `project_header.rs`, shown only when set (small, right-aligned, muted). The grid card is intentionally left unchanged.

### Docs
- `imageCredit` added to the Project table, field descriptions, and the "As implemented" callout in `docs/src/dpe/metadata-model.md`.

## Challenges and Decisions
### Where does an image credit belong?
**Problem:** `legalInfo` looks like the obvious home, but it is calculated from records and describes the *dataset's* rights, not a teaser-image credit.
**Solution:** a dedicated optional string, stored verbatim, rendered as a semantic `<figure>`/`<figcaption>` caption. It touches neither `legalInfo` nor `howToCite`.

### Backfill deliberately excluded
`howToCite` is left untouched on every project. `0816_vitrocentre` (image credit mixed into its citation) and `085E_hamidi` (reads like a legitimate dataset citation) are left as-is to avoid editing researcher-authored strings; any migration can be a separate ticket.

## Gotchas
- The cover image itself is still **not** modelled — it is resolved by filename convention. `imageCredit` only records the credit for that conventional image.
- The field ships as **infrastructure**: it renders only once a project sets `imageCredit`. Project 0113 (which surfaced this) is not yet in the DPE data, so nothing renders until its metadata lands (DEV-6859). The dsp-app counterpart is DEV-6861.
- Adding a field to `Project` surfaces every struct-literal construction site at compile time — five test fixtures needed the new field.

## Test Plan
- [x] `cargo test --tests` + the dev-feature suite pass, incl. new tests: `<figcaption>` renders verbatim when set, is omitted when `None`, and `imageCredit` defaults to `None` for existing files / round-trips when present.
- [x] `cargo clippy --all-features -- -D warnings` — clean.
- [x] `maudfmt` + `cargo +nightly fmt` applied; no drift outside the changed files.
- [x] `validate-data` — all 84 projects still valid.
- [x] Ran the DPE locally, set a temporary `imageCredit` on a project, verified the caption renders beneath the hero image, then reverted.

## Commit hygiene
- [x] Single commit, `type(scope): subject`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
