### PR TITLE
feat(dpe-data): backfill imageCredit for 16 projects from dsp-app

### DIFF
--- a/modules/dpe/server/data/projects/0108_campane-ticino.json
+++ b/modules/dpe/server/data/projects/0108_campane-ticino.json
@@ -1,5 +1,6 @@
 {
     "id": "0108",
+    "imageCredit": "Campanile di Aurigeno. © Romeo Dell'Era / Belltower of Aurigeno. © Romeo Dell'Era",
     "pid": "https://ark.dasch.swiss/ark:/72163/1/0108",
     "name": "Le campane del Canton Ticino. Studio di un patrimonio materiale e immateriale",
     "shortcode": "0108",

--- a/modules/dpe/server/data/projects/0117_prom_know.json
+++ b/modules/dpe/server/data/projects/0117_prom_know.json
@@ -1,5 +1,6 @@
 {
     "id": "0117",
+    "imageCredit": "René Sigrist, 2023, Collaborations les plus significatives entre chimistes de la période 1810-1860, CC BY-SA 4.0.",
     "pid": "https://ark.dasch.swiss/ark:/72163/1/0117",
     "name": "Promoting Knowledge. The Origins of the Science System and the Making of Professional Structures in European States, 1700-1870",
     "shortcode": "0117",

--- a/modules/dpe/server/data/projects/0119_prethero.json
+++ b/modules/dpe/server/data/projects/0119_prethero.json
@@ -1,5 +1,6 @@
 {
     "id": "0119",
+    "imageCredit": "Jehan qui de tout se mesle [page de titre, détail], s.l. s.n., début XVIe s. @ Archives de l'État de Fribourg; AEF, Littérature 2.1.",
     "pid": "https://ark.dasch.swiss/ark:/72163/1/0119",
     "name": "Premiers théâtres romands",
     "shortcode": "0119",

--- a/modules/dpe/server/data/projects/0120_posepi.json
+++ b/modules/dpe/server/data/projects/0120_posepi.json
@@ -1,5 +1,6 @@
 {
     "id": "0120",
+    "imageCredit": "https://creativecommons.org/licenses/by-sa/4.0/ - CC BY-SA 4.0.",
     "pid": "https://ark.dasch.swiss/ark:/72163/1/0120",
     "name": "Prendre une position épistémique dans l’interaction. Les marqueurs du savoir, du non-savoir et du doute en français",
     "shortcode": "0120",

--- a/modules/dpe/server/data/projects/0121_societesavoie.json
+++ b/modules/dpe/server/data/projects/0121_societesavoie.json
@@ -1,5 +1,6 @@
 {
     "id": "0121",
+    "imageCredit": "Préambule d'un compte de la trésorerie générale de Savoie, Archivio di Stato di Tornino, Sezioni riunite, Camera bei Conti di Savoia, Inventario 16, n° 87 (1441), fol. 1r. @ Eva Pibiri, 2023.",
     "pid": "https://ark.dasch.swiss/ark:/72163/1/0121",
     "name": "Société de cour, élites et finances : de l’Hôtel des princes de Savoie à l’État moderne",
     "shortcode": "0121",

--- a/modules/dpe/server/data/projects/0810_dasch.json
+++ b/modules/dpe/server/data/projects/0810_dasch.json
@@ -1,5 +1,6 @@
 {
     "id": "0810",
+    "imageCredit": "© DaSCH. Design: Rebecca Sigloch (2022), CC BY 4.0",
     "pid": "https://ark.dasch.swiss/ark:/72163/1/0810",
     "name": "DaSCH – Swiss National Data and Service Center for the Humanities",
     "shortcode": "0810",

--- a/modules/dpe/server/data/projects/0813_bruno-manser.json
+++ b/modules/dpe/server/data/projects/0813_bruno-manser.json
@@ -1,5 +1,6 @@
 {
     "id": "0813",
+    "imageCredit": "Foto: Alberto Venzago.",
     "pid": "https://ark.dasch.swiss/ark:/72163/1/0813",
     "name": "Annotating Media of Bruno Manser",
     "shortcode": "0813",

--- a/modules/dpe/server/data/projects/082A_lenzburg.json
+++ b/modules/dpe/server/data/projects/082A_lenzburg.json
@@ -1,5 +1,6 @@
 {
     "id": "082A",
+    "imageCredit": "Foto: Archiv Verein Folk Festivals Lenzburg",
     "pid": "https://ark.dasch.swiss/ark:/72163/1/082A",
     "name": "Tonbandsammlung Folkfestival auf der Lenzburg",
     "shortcode": "082A",

--- a/modules/dpe/server/data/projects/0846_aura-effizienz.json
+++ b/modules/dpe/server/data/projects/0846_aura-effizienz.json
@@ -1,5 +1,6 @@
 {
     "id": "0846",
+    "imageCredit": "The Wheel of Motion (1920-1928). Source: Frank Bunker Gilbreth, Lilliane Moller Gilbreth: DieMagie des Bewegungsstudiums, hg. von Bernd Stiegler. München: Wilhelm Fink 2012, S. 185f.",
     "pid": "https://ark.dasch.swiss/ark:/72163/1/0846",
     "name": "Aura und Effizienz. Leistungsorientierte Materialisierung und Spiritualisierung in der Literatur der 1920-30er-Jahre: Emmy Hennings, Marieluise Fleisser, Friedrich Glauser und Bruno Goetz",
     "shortcode": "0846",

--- a/modules/dpe/server/data/projects/0847_locusludi.json
+++ b/modules/dpe/server/data/projects/0847_locusludi.json
@@ -1,5 +1,6 @@
 {
     "id": "0847",
+    "imageCredit": "Tombe du Plongeur, fresque décorative du mur nord, Paestum, 480-470 av. J.-C., Paestum, Museo Archeologico Nazionale. Wikimedia Commons, photo by Velvet. CC BY-SA 3.0.",
     "pid": "https://ark.dasch.swiss/ark:/72163/1/0847",
     "name": "Locus Ludi database: The Kottabos in the Greek World",
     "shortcode": "0847",

--- a/modules/dpe/server/data/projects/0854_daschland.json
+++ b/modules/dpe/server/data/projects/0854_daschland.json
@@ -1,5 +1,6 @@
 {
     "id": "0854",
+    "imageCredit": "Authorship: AI-Generated.",
     "pid": "https://ark.dasch.swiss/ark:/72163/1/0854",
     "name": "Alice in DaSCHland",
     "shortcode": "0854",

--- a/modules/dpe/server/data/projects/0857_symblight.json
+++ b/modules/dpe/server/data/projects/0857_symblight.json
@@ -1,5 +1,6 @@
 {
     "id": "0857",
+    "imageCredit": "Authorship: Eva Spinazzè; Licence: CC BY NC 4.0",
     "pid": "https://ark.dasch.swiss/ark:/72163/1/0857",
     "name": "Symbolism of light in Early Christian sacred buildings in the Swiss Alpine valleys",
     "shortcode": "0857",

--- a/modules/dpe/server/data/projects/085C_wiborada.json
+++ b/modules/dpe/server/data/projects/085C_wiborada.json
@@ -1,5 +1,6 @@
 {
     "id": "085C",
+    "imageCredit": "Edition und Übersetzung der beiden von den St. Galler Mönchen Ekkehart I. und Herimannus verfassten Viten Wiboradas von St. Gallen († 926) durch Walter Berschin.",
     "pid": "https://ark.dasch.swiss/ark:/72163/1/085C",
     "name": "Vitae Sanctae Wiboradae — Lebensbeschreibungen der heiligen Wiborada von St. Gallen, herausgegeben, übersetzt und mit einer Einleitung und Anmerkungen versehen von Walter Berschin",
     "shortcode": "085C",

--- a/modules/dpe/server/data/projects/0860_texturessacredscript.json
+++ b/modules/dpe/server/data/projects/0860_texturessacredscript.json
@@ -1,5 +1,6 @@
 {
     "id": "0860",
+    "imageCredit": "Staatsbibliothek Bamberg, Msc.Bibl.95, fol. 9r, Detail. Public Domain Mark 1.0 Universal Deed (https://creativecommons.org/publicdomain/mark/1.0/)",
     "pid": "https://ark.dasch.swiss/ark:/72163/1/0860",
     "name": "Textures of Sacred Scripture",
     "shortcode": "0860",

--- a/modules/dpe/server/data/projects/0862_gotthelf.json
+++ b/modules/dpe/server/data/projects/0862_gotthelf.json
@@ -1,5 +1,6 @@
 {
     "id": "0862",
+    "imageCredit": "Author: Christian von Zimmermann.",
     "pid": "https://ark.dasch.swiss/ark:/72163/1/0862",
     "name": "(digitale) Historisch-Kritische Gesamtausgabe der Werke und Briefe von Jeremias Gotthelf, HKG und dHKG",
     "shortcode": "0862",

--- a/modules/dpe/server/data/projects/0868_solec.json
+++ b/modules/dpe/server/data/projects/0868_solec.json
@@ -1,5 +1,6 @@
 {
     "id": "0868",
+    "imageCredit": "CC BY / \"When did the Sun darken in antiquity? Discover calculated solar eclipses and their traces in ancient historical sources.\"",
     "pid": "https://ark.dasch.swiss/ark:/72163/1/0868",
     "name": "Canon of solar eclipses from 2501 BCE to 1000 CE",
     "shortcode": "0868",


### PR DESCRIPTION
Fixes DEV-6870

## Motivation
DEV-6860 gave the DPE an optional `imageCredit` field (rendered as a caption under the cover image), but shipped it empty. Credit text for many projects already existed in dsp-app's `LicenseCaptionsMapping` and was invisible in the DPE. This backfills it so those credits render in the DPE too.

## Summary
- Adds `imageCredit` to the 16 project JSONs that have a credit in dsp-app.
- Purely additive data change — one line per file, no code touched.

## Key Changes
### DPE project data (dpe-data)
- `"imageCredit": "…"` added to 16 files under `modules/dpe/server/data/projects/`, sourced verbatim from dsp-app `libs/vre/pages/project/project/src/lib/description/license-captions-mapping.ts`.
- Only bare label prefixes (`Subtitle:`, `Subtitle image:`, `Licence Image:`) were stripped; all other researcher-authored text (including licence lines and diacritics) is kept verbatim. Multi-part captions joined with ` / `.

## Challenges and Decisions
### The dsp-app map is not pure "credits"
**Problem:** entries mix photographer credits, subtitles, authorship notes and bare licence URLs.
**Decision:** migrate all 16 verbatim (per product owner) rather than editorialise, keeping faithful parity with what dsp-app shows. `0120` (a bare CC-licence URL), `0854` ("Authorship: AI-Generated") and `085C` (a work description) are included as-is despite not being classic photo credits.
### Left `howToCite` untouched
Some projects historically carried credit-like text in `howToCite`; per the DEV-6860 decision that field is not modified here.

## Gotchas
- The cover image itself is still resolved by filename convention (`/assets/images/<shortcode>.webp`); `imageCredit` only annotates it. It renders only when set, so untouched projects are unaffected.
- `085C`'s dsp-app map key is lowercase (`085c`) and never renders there — that's DEV-6862. The DPE keys credits by project file, so no case trap here.
- Kept a source typo verbatim (`DieMagie`, 0846) rather than silently correcting researcher text.

## Test Plan
- [x] `just validate-data` — all project/person/org cross-references valid.
- [x] `cargo test --tests` (full workspace) — passes.
- [x] Ran the DPE locally and confirmed the caption renders verbatim under the hero for sampled projects (0813, 0868, 0854); Maud HTML-escapes embedded quotes correctly.

## Commit hygiene
- [x] Single commit, `feat(dpe-data): …`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
