### PR TITLE
feat(dpe-web): show project image credit on grid teaser cards

### DIFF
--- a/modules/dpe/web/src/pages/projects/components/card.rs
+++ b/modules/dpe/web/src/pages/projects/components/card.rs
@@ -40,6 +40,12 @@ pub fn project_card(project: &Project, keywords: &[String]) -> Markup {
                     (icon(OpenDocument, "w-12 h-12 text-gray-300"))
                 }
             }
+            @if let Some(credit) = &project.image_credit {
+                figcaption
+                    class="absolute bottom-0 left-0 max-w-[70%] truncate rounded-tr px-2 py-1 text-xs text-gray-700 bg-white/90 backdrop-blur-sm"
+                    title=(credit)
+                { (credit) }
+            }
             ({
                 project_card_indicators(
                     &project.status,
@@ -81,5 +87,26 @@ mod tests {
         let keywords = vec!["a".to_string(), "b".to_string(), "c".to_string(), "d".to_string()];
         let out = project_card(&p, &keywords).into_string();
         assert_eq!(out.matches("badge badge-secondary").count(), 3, "only first 3 keywords: {out}");
+    }
+
+    #[test]
+    fn renders_truncated_image_credit_when_present() {
+        let p = Project {
+            image_credit: Some("© Someone, Somewhere".to_string()),
+            ..sample_project()
+        };
+        let out = project_card(&p, &[]).into_string();
+        assert!(out.contains("© Someone, Somewhere"), "{out}");
+        // overlaid on the image bottom, single-line clip, full text on hover
+        assert!(out.contains("<figcaption"), "{out}");
+        assert!(out.contains("truncate"), "{out}");
+        assert!(out.contains(r#"title="© Someone, Somewhere""#), "{out}");
+    }
+
+    #[test]
+    fn omits_image_credit_when_absent() {
+        // sample_project() has image_credit: None → no caption on the card.
+        let out = project_card(&sample_project(), &[]).into_string();
+        assert!(!out.contains("truncate"), "{out}");
     }
 }


### PR DESCRIPTION
## Motivation
DEV-6860 added the `imageCredit` field and renders it under the cover image on the project **detail** page. The projects **grid** teaser cards didn't show it. This surfaces the same credit on the grid cards.

## Summary
- Shows `imageCredit` on each grid teaser card, when set.
- No layout shift: cards without a credit keep title/description/keywords at the same height.

## Key Changes
### Teaser card (dpe-web)
- `modules/dpe/web/src/pages/projects/components/card.rs`: an `absolute`-positioned `<figcaption>` overlaid on the bottom-left of the cover image — a white frosted chip (`bg-white/90` + `text-gray-700`, `rounded-tr`) mirroring the existing status pill in the bottom-right.
- Single-line `truncate` (capped at `max-w-[70%]` to clear the status icons), full text preserved in a `title` tooltip.

## Challenges and Decisions
### Alignment across cards
**Problem:** a first attempt placed the credit in the card body, which pushed the title down on cards that had a credit — titles/text/keywords no longer aligned across the grid.
**Solution:** overlay the caption on the image (`absolute`), so it occupies zero flow height and every card body starts at the same y regardless of whether a credit exists.
### Legibility
**Problem:** a translucent-dark bar was unreadable over dark cover images.
**Solution:** a solid-ish white chip with dark text reads on both dark and light images.

## Gotchas
- Overlay is padded/clamped (`max-w-[70%]`) to avoid the status/access pill at `bottom-0 right-0`.
- Purely presentational; renders only when `imageCredit` is set, so it's inert until projects carry a credit (data backfill is DEV-6870 / #311).

## Test Plan
- [x] `cargo test --tests` (full workspace) — passes, incl. new card tests (renders overlay figcaption when set; omitted when absent).
- [x] Verified locally on the grid: credit shows as a white chip on the image bottom-left; titles/descriptions/keywords stay aligned across cards with and without a credit; long credits truncate with a hover tooltip.

## Related
- DEV-6860 (the `imageCredit` field + detail-page caption), DEV-6870 / #311 (data backfill).

## Commit hygiene
- [x] Single commit, `feat(dpe-web): …`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
