### PR TITLE
feat(dpe-data): add imageCredit for 0113 (Women Martyrs in Action)

### DIFF
--- a/modules/dpe/server/data/projects/0113_womartyr-act.json
+++ b/modules/dpe/server/data/projects/0113_womartyr-act.json
@@ -1,5 +1,6 @@
 {
     "id": "0113",
+    "imageCredit": "© Fabrice Ducrest, Unil",
     "pid": "https://ark.dasch.swiss/ark:/72163/1/0113",
     "name": "Women Martyrs in Action: Recreating and Performing Medieval Heroines Today",
     "shortcode": "0113",


### PR DESCRIPTION
Fixes DEV-6881

## Motivation

Project 0113 "Women Martyrs in Action" was onboarded to the DPE (PR #305, DEV-6859) with a cover image (`0113.webp`) but no `imageCredit`. The DPE `imageCredit` field (DEV-6860) and the 16-project backfill (DEV-6870, PR #311) landed around the same time, and 0113 was not among the 16 — its credit was being added to dsp-app in parallel via DEV-6861, so it never entered the backfill's `LicenseCaptionsMapping` snapshot.

As a result, 0113's cover image currently renders with no credit caption in the DPE, unlike every other project that has a known credit. This is a timing gap, not a deliberate omission.

## Summary

Add the known credit for 0113 so its cover image renders a caption like the other 16 credited projects.

## Key Changes

- `modules/dpe/server/data/projects/0113_womartyr-act.json`: add `"imageCredit": "© Fabrice Ducrest, Unil"`.

## Challenges and Decisions

- Credit migrated **verbatim** (including casing "Unil") from the asset-side credit recorded in dsp-app via DEV-6861 / dsp-app PR #3287 — not normalized.
- Placed the field directly after `id`, matching the placement used by the DEV-6870 backfill across all 16 files.
- `howToCite` left untouched, per the DEV-6860 decision.

## Gotchas

- None. Single data-file addition; no code or rendering changes.

## Test Plan

- `just validate-data` — passes (85 projects, all data files valid).
- `just test` — all suites pass; no snapshot changes generated.
