### PR TITLE
fix(ci): cap advisory diff size and pass it to jq argv-safely

### DIFF
--- a/.github/scripts/commit-advisory.sh
+++ b/.github/scripts/commit-advisory.sh
@@ -4,11 +4,17 @@
 # PR comment and always exits 0, so an Anthropic API outage just means "no advice
 # this run".
 #
-# It reads the branch's full diffs plus the canonical git-conventions doc as its
+# It reads the branch's diffs plus the canonical git-conventions doc as its
 # rubric and judges atomicity: should any of these commits be squashed, split, or
 # reworded so the history reads well on main? Placeholder and malformed messages
 # are NOT its job — the type allowlist and mandatory scope in .commitlintrc.yml
 # catch those deterministically in the gate.
+#
+# Diffs are size-capped so a data-heavy PR (e.g. record-dump updates) can't blow
+# up the payload: any single file whose patch exceeds MAX_FILE_PATCH_BYTES
+# collapses to its header plus a change-count marker (the hunks of a generated
+# dump carry no atomicity signal anyway), and the whole diff is truncated at
+# MAX_TOTAL_DIFF_BYTES as a backstop. Normal source hunks are kept in full.
 #
 # Structured outputs (output_config.format) force a JSON verdict, so comment
 # rendering never depends on free-form parsing.
@@ -18,6 +24,8 @@
 #   BASE_REF            base to diff against            (default: origin/main)
 #   MODEL               (default: claude-sonnet-5)
 #   RUBRIC_FILE         git-conventions doc              (default: docs/src/git-conventions.md)
+#   MAX_FILE_PATCH_BYTES  per-file patch cap             (default: 32768)
+#   MAX_TOTAL_DIFF_BYTES  overall diff cap               (default: 262144)
 #   PR_NUMBER, GH_TOKEN used to post the comment (CI); if unset, prints instead
 #
 # Safe to `source` for unit testing: functions only; main runs when executed.
@@ -30,6 +38,8 @@
 : "${BASE_REF:=origin/main}"
 : "${MODEL:=claude-sonnet-5}"
 : "${RUBRIC_FILE:=docs/src/git-conventions.md}"
+: "${MAX_FILE_PATCH_BYTES:=32768}"
+: "${MAX_TOTAL_DIFF_BYTES:=262144}"
 : "${ANTHROPIC_API_KEY:=}"
 : "${PR_NUMBER:=}"
 
@@ -44,9 +54,58 @@ compute_range() {
   printf '%s..HEAD' "$base"
 }
 
-# build_diffs <range> — full patches.
+# cap_patches — stdin: `git log -p` output; stdout: same, but every single-file
+# patch larger than MAX_FILE_PATCH_BYTES collapsed to its header lines plus a
+# `[patch omitted: +A/-B lines, ~K KB]` marker. Keeps the file paths and change
+# magnitude (enough to judge a message against) while dropping the hunk bulk of
+# generated/data files. Normal source patches pass through untouched.
+cap_patches() {
+  awk -v cap="${MAX_FILE_PATCH_BYTES:-32768}" '
+    function flush(   i, size, add, del, line) {
+      if (n == 0) return
+      size = 0
+      for (i = 1; i <= n; i++) size += length(buf[i]) + 1
+      if (size <= cap) {
+        for (i = 1; i <= n; i++) print buf[i]
+      } else {
+        add = 0; del = 0
+        for (i = 1; i <= n; i++) {
+          line = buf[i]
+          if (line ~ /^\+/ && line !~ /^\+\+\+/) add++
+          else if (line ~ /^-/ && line !~ /^---/) del++
+        }
+        for (i = 1; i <= n; i++) {        # header lines, up to the first hunk
+          if (buf[i] ~ /^@@/) break
+          print buf[i]
+        }
+        printf "    [patch omitted: +%d/-%d lines, ~%d KB — exceeds per-file cap]\n", \
+          add, del, int(size / 1024)
+      }
+      n = 0
+    }
+    /^diff --git / { flush(); in_file = 1; buf[++n] = $0; next }
+    /^commit /     { flush(); in_file = 0; print; next }
+                   { if (in_file) buf[++n] = $0; else print }
+    END            { flush() }
+  '
+}
+
+# cap_total — stdin: diff text; stdout: same, truncated at MAX_TOTAL_DIFF_BYTES
+# with an explicit marker. Final backstop against a pathological many-file PR.
+cap_total() {
+  local max="${MAX_TOTAL_DIFF_BYTES:-262144}" input
+  input="$(cat)"
+  if [ "${#input}" -le "$max" ]; then
+    printf '%s' "$input"
+  else
+    printf '%s\n\n[diff truncated: exceeded overall cap of %d KB — remainder omitted]\n' \
+      "${input:0:max}" "$((max / 1024))"
+  fi
+}
+
+# build_diffs <range> — patches, per-file- and total-capped (see cap_* above).
 build_diffs() {
-  git log -p "$1"
+  git log -p "$1" | cap_patches | cap_total
 }
 
 # extract_text <response-json> — the first text block (the structured-output JSON).
@@ -72,19 +131,38 @@ format_comment() {
   echo "_Clean up with \`git rebase -i $BASE_REF\` if you agree._"
 }
 
-# --- API + posting (exercised in CI, not unit-tested) ---------------------
-
-# call_api <model> <max_tokens> <system> <user> <output_config-json> — echoes raw response.
-call_api() {
-  local model="$1" max_tokens="$2" system="$3" user="$4" output_config="$5" body
-  body="$(jq -n \
+# build_request_body <model> <max_tokens> <system> <user> <output_config-json>
+# Echoes the JSON request body. <user> is passed to jq via --rawfile (a temp
+# file), not --arg, so an arbitrarily large branch diff never hits the argv size
+# limit (a single --arg over ~128 KB fails with "Argument list too long").
+# Deterministic and unit-tested; the network call lives in call_api.
+build_request_body() {
+  local model="$1" max_tokens="$2" system="$3" user="$4" output_config="$5" userfile rc
+  userfile="$(mktemp)"
+  printf '%s' "$user" >"$userfile"
+  jq -n \
     --arg model "$model" \
     --argjson max_tokens "$max_tokens" \
     --arg system "$system" \
-    --arg user "$user" \
+    --rawfile user "$userfile" \
     --argjson output_config "$output_config" \
     '{model: $model, max_tokens: $max_tokens, system: $system,
-      messages: [{role: "user", content: $user}], output_config: $output_config}')"
+      messages: [{role: "user", content: $user}], output_config: $output_config}'
+  rc=$?
+  rm -f "$userfile"
+  return "$rc"
+}
+
+# --- API + posting (exercised in CI, not unit-tested) ---------------------
+
+# call_api <model> <max_tokens> <system> <user> <output_config-json> — echoes raw
+# response, or returns 1 (with a message) if the request body can't be built.
+call_api() {
+  local model="$1" max_tokens="$2" system="$3" user="$4" output_config="$5" body
+  if ! body="$(build_request_body "$model" "$max_tokens" "$system" "$user" "$output_config")"; then
+    echo "advisory: failed to build request payload — skipping, not blocking" >&2
+    return 1
+  fi
   curl -sS --max-time 120 "$API_URL" \
     -H "x-api-key: $ANTHROPIC_API_KEY" \
     -H "anthropic-version: $ANTHROPIC_VERSION" \
@@ -122,12 +200,14 @@ run_advisory() {
 $rubric
 </git_conventions>
 $INJECTION_GUARD"
-  resp="$(call_api "$MODEL" 8000 "$system" "<commit_data>
+  if ! resp="$(call_api "$MODEL" 8000 "$system" "<commit_data>
 $diffs
-</commit_data>" "$output_config")"
+</commit_data>" "$output_config")"; then
+    return 0   # payload build failed; call_api already explained why
+  fi
   text="$(extract_text "$resp")"
   if [ -z "$text" ]; then
-    echo "advisory: no usable response (API error/outage?) — skipping, not blocking" >&2
+    echo "advisory: no usable response from the API (error or outage) — skipping, not blocking" >&2
     return 0
   fi
   issues="$(jq -c '.issues // []' <<<"$text" 2>/dev/null || echo '[]')"

--- a/.github/scripts/commit-advisory.test.sh
+++ b/.github/scripts/commit-advisory.test.sh
@@ -36,6 +36,16 @@ assert_eq() {
   fi
 }
 
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL: $desc (expected NOT to contain '$needle')"
+  fi
+}
+
 make_repo() {
   local dir; dir="$(mktemp -d)"
   (
@@ -66,6 +76,58 @@ diffs_out="$(test_range_and_diffs)"
 assert_contains "diffs: includes the subject"   "feat(dpe-web): add a" "$diffs_out"
 assert_contains "diffs: includes patch body"    "+line one"           "$diffs_out"
 assert_contains "diffs: names the changed file" "a.txt"               "$diffs_out"
+
+# --- build_diffs: per-file cap --------------------------------------------
+# A small file keeps its full hunk; a file whose patch exceeds the cap collapses
+# to header + marker, and its bulk never reaches the payload.
+
+test_per_file_cap() {
+  local repo out; repo="$(make_repo)"
+  out="$(
+    cd "$repo" || exit 1
+    git checkout -q -b feature
+    printf 'small change\n' >small.txt
+    yes 'a big generated line of dump content xxxxxxxxxxxxxxxx' | head -n 2000 >big.txt
+    git add small.txt big.txt
+    git commit -q -m "feat(dpe-web): add small and big"
+    MAX_FILE_PATCH_BYTES=1024 build_diffs "$(compute_range base)"
+  )"
+  rm -rf "$repo"
+  printf '%s' "$out"
+}
+cap_out="$(test_per_file_cap)"
+assert_contains     "cap: keeps small file's hunk"     "+small change"           "$cap_out"
+assert_contains     "cap: still names the big file"    "big.txt"                 "$cap_out"
+assert_contains     "cap: marker with change counts"   "[patch omitted: +2000/-0 lines" "$cap_out"
+assert_not_contains "cap: big file hunk not inlined"   "+a big generated line"   "$cap_out"
+
+# --- build_diffs: total cap -----------------------------------------------
+
+test_total_cap() {
+  local repo out; repo="$(make_repo)"
+  out="$(
+    cd "$repo" || exit 1
+    git checkout -q -b feature
+    printf 'a\nb\nc\n' >f.txt && git add f.txt && git commit -q -m "feat(dpe-web): add f"
+    MAX_TOTAL_DIFF_BYTES=40 build_diffs "$(compute_range base)"
+  )"
+  rm -rf "$repo"
+  printf '%s' "$out"
+}
+total_out="$(test_total_cap)"
+assert_contains "total cap: appends truncation marker" "[diff truncated" "$total_out"
+
+# --- build_request_body: argv-safe for large diffs ------------------------
+# A user string well past the ~128 KB single-argument limit must still build a
+# valid request body (regression for the jq "Argument list too long" failure).
+
+big_user="$(yes 'line of diff content to make the payload large' | head -n 5000)"
+body_out="$(build_request_body "claude-sonnet-5" 8000 "sys" "$big_user" '{"effort":"medium"}')"
+assert_contains "request body: builds with oversized user" '"role": "user"'            "$body_out"
+assert_contains "request body: carries the model"          '"model": "claude-sonnet-5"' "$body_out"
+assert_eq "request body: user content preserved intact" \
+  "$(printf '%s' "$big_user" | wc -c | tr -d ' ')" \
+  "$(jq -rj '.messages[0].content' <<<"$body_out" | wc -c | tr -d ' ')"
 
 # --- extract_text ---------------------------------------------------------
 


### PR DESCRIPTION
## Motivation
The commit-hygiene advisory silently stopped running on data-heavy PRs. On PR #314 (`chore/update-records`) the step
logged `jq: Argument list too long` and skipped. It was never visible as a failure because the advisory is fail-open
(the job stays green), but it means the advisor never gets to comment on exactly the PRs whose history most benefits
from a second look.

## Summary
- Advisory now runs on large-diff PRs instead of silently skipping.
- No user-facing behaviour change on normal PRs; still fully non-blocking.

## Key Changes
### Pass the diff to jq argv-safely
`build_request_body` (extracted from `call_api`) now feeds the diff to `jq` via `--rawfile` from a temp file instead of
`--arg`. A single `--arg` over ~128 KB hits the Linux `MAX_ARG_STRLEN` limit and fails with "Argument list too long";
`--rawfile` keeps the value out of argv entirely. It's a deterministic, unit-tested helper now.

### Cap the diff sent to the model
`build_diffs` still runs `git log -p`, then pipes through two new helpers:
- `cap_patches` collapses any single-file patch over `MAX_FILE_PATCH_BYTES` (default 32 KB) to its header plus a
  `[patch omitted: +A/-B lines, ~K KB]` marker — a record dump keeps its name and change magnitude but drops the noise
  hunks, while normal source patches pass through in full.
- `cap_total` truncates the whole diff at `MAX_TOTAL_DIFF_BYTES` (default 256 KB) as a backstop, with an explicit marker.

### Honest failure messages
A payload-build failure now logs "failed to build request payload" and is distinct from "no usable response from the
API" — the previous single message blamed the API for what was actually a client-side overflow.

## Challenges and Decisions
### Why cap per-file rather than switch to `git log --stat`
**Problem:** the full diff is both too big and mostly noise for a dump PR, but `--stat` alone would blind the advisor to
split and subtle-reword judgments that genuinely need the hunks.
**Solution:** keep full hunks for normal files, collapse only the oversized ones. The size threshold acts as the
"is this worth reading" proxy, so real source changes stay fully visible while generated bulk is dropped.

### Why not let the model fetch hunks on demand (tool use)
Considered, but that turns a one-shot fail-open curl into a multi-turn tool-use loop — exactly the "harden more bash"
the script's own tripwire warns against. If we ever want that, it's the signal to graduate the advisor to the Rust
binary the tripwire points at. The per-file cap gets ~all of the benefit deterministically.

## Gotchas
- The `MAX_ARG_STRLEN` 128 KB per-argument limit is Linux-only; macOS has no per-arg cap, so this failure never
  reproduces locally on a Mac — only on the CI runner. Don't rely on local runs to catch argv-size regressions.
- The awk in `cap_patches` keys off `^diff --git ` / `^commit ` at column 0; git indents commit-message lines and
  prefixes hunk lines, so those markers never collide with content.

## Test Plan
- [x] `bash .github/scripts/commit-advisory.test.sh` → 22 passed, 0 failed (new tests: per-file cap, total cap, argv regression)
- [x] `shellcheck --severity=warning` on both files → clean
- [x] Manual: `build_diffs` on a repo with a small + a 2000-line file collapses only the big one, keeps the small hunk

## Commit hygiene
- [x] I have reviewed and cleaned up the branch history (squashed working commits, clear messages) so it reads well on `main`
- [ ] allow-many-commits
