### PR TITLE
feat(dpe-api-dataverse): add Dataverse-compatible file metadata API (…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ All authoritative documentation lives in `docs/src/`. Key pages:
 | Operations (Docker, env vars) | `docs/src/dpe/operations.md` |
 | JSON API | `docs/src/dpe/json-api.md` |
 | OAI-PMH Endpoint Usage | `docs/src/dpe/oai-pmh.md` |
+| Dataverse-Compatible API | `docs/src/dpe/dataverse-api.md` |
 | Workflows | `docs/src/workflows.md` |
 | Git Conventions (branch, commits, PRs) | `docs/src/git-conventions.md` |
 | Tech Stack | `docs/src/fundamentals/tech_stack.md` |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,6 +580,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dpe-api-dataverse"
+version = "0.8.2"
+dependencies = [
+ "axum",
+ "dpe-core",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "dpe-api-oai"
 version = "0.8.2"
 dependencies = [
@@ -612,6 +624,7 @@ dependencies = [
  "axum-tracing-opentelemetry",
  "clap",
  "datastar",
+ "dpe-api-dataverse",
  "dpe-api-oai",
  "dpe-core",
  "dpe-telemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "modules/mosaic/playground",
   "modules/mosaic/tiles",
   "modules/dpe/core",
+  "modules/dpe/api-dataverse",
   "modules/dpe/api-oai",
   "modules/dpe/web",
   "modules/dpe/server",

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -26,6 +26,7 @@
 - [Operations](./dpe/operations.md)
 - [JSON API](./dpe/json-api.md)
 - [OAI-PMH Endpoint](./dpe/oai-pmh.md)
+- [Dataverse-Compatible API](./dpe/dataverse-api.md)
 
 ## Mosaic
 

--- a/docs/src/dpe/dataverse-api.md
+++ b/docs/src/dpe/dataverse-api.md
@@ -1,0 +1,176 @@
+# Dataverse-Compatible API
+
+DPE serves a minimal subset of the [Dataverse Native API](https://guides.dataverse.org/en/latest/api/native-api.html) so that EOSC Data Commons can harvest DaSCH datasets with file-level download information.
+
+Their pipeline works in two steps: it harvests our [OAI-PMH](./oai-pmh.md) feed with the `oai_datacite` prefix, and then, for each record, asks a Dataverse API for that record's files. Rather than deploy Dataverse, DPE reimplements the two endpoints that pipeline actually calls.
+
+> **Three fields are placeholders.** The MIME type, creation date, download URL, and file id all come from real record data. But `filename`, `filesize`, and `checksum` have no source in DPE or dsp-api yet, and are served as obvious fakes — every `filesize` is `1` and every checksum is the MD5 of the empty string. A client that verifies a checksum against the downloaded bytes **will** find a mismatch. A forthcoming dsp-api file endpoint will supply the real values. See [Placeholders](#placeholders).
+
+## Endpoints
+
+Both endpoints are unauthenticated — they serve published, public metadata — and both live at the **host root**, not under `/dpe` like the rest of the application. The URL shapes are fixed by the Dataverse contract: the versions endpoint is the URL EOSC Data Commons seeds on their side, and the client builds the download URL itself from the `dataFile.id` we emit.
+
+Both are rate-limited per IP, like the OAI endpoint (see [Operations](./operations.md#environment-variables)).
+
+### `GET /api/datasets/:persistentId/versions/:latest-published`
+
+Returns the file list for one record.
+
+`:persistentId` and `:latest-published` are **literal path segments**, not path parameters — that is genuinely how the Dataverse API spells this route. The dataset is selected by the `persistentId` *query* parameter instead.
+
+| Query parameter | Required | Description |
+|---|---|---|
+| `persistentId` | Yes | The full OAI header identifier, exactly as emitted by our OAI-PMH feed (e.g. `oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh`). The crawler passes it back verbatim, colons and all. |
+| `exporter` | No | Sent by the crawler as `dataverse_json`. Accepted and ignored: this endpoint only speaks that one format. |
+
+Example:
+
+```bash
+curl 'http://localhost:4000/api/datasets/:persistentId/versions/:latest-published?exporter=dataverse_json&persistentId=oai:dasch.swiss:ark:/72163/1/0803/_qXHiyf6WsOfLFEXr7Zdng7'
+```
+
+```json
+{
+  "status": "OK",
+  "data": {
+    "files": [
+      {
+        "restricted": false,
+        "version": 1,
+        "dataFile": {
+          "id": 8294929545880278,
+          "filename": "2vbIabBOEvq-EU9jwmgEe9j.jp2",
+          "contentType": "image/jp2",
+          "filesize": 1,
+          "creationDate": "2011-04-14T07:15:28Z",
+          "checksum": { "type": "MD5", "value": "d41d8cd98f00b204e9800998ecf8427e" }
+        }
+      }
+    ]
+  }
+}
+```
+
+That is a verbatim response from the committed data. Note the `filesize` of `1` and the empty-string MD5 — the placeholders described [below](#placeholders).
+
+A record with no file returns the same envelope with an empty array:
+
+```json
+{ "status": "OK", "data": { "files": [] } }
+```
+
+Field notes:
+
+| Field | Type | Notes |
+|---|---|---|
+| Field | Type | Source | Notes |
+|---|---|---|---|
+| `restricted` | bool | constant | Required. Always `false` — all DaSCH data is currently openly accessible. |
+| `version` | u64 | constant | Required. Always `1` — DPE has no per-file version concept. |
+| `dataFile.id` | u64 | derived | Required. Derived from the record IRI; see [File ids](#file-ids). |
+| `dataFile.contentType` | string | record `file.mimeType` | Required, must parse as a MIME type. May carry parameters (`text/csv; charset=UTF-8`). |
+| `dataFile.creationDate` | string | record `dateCreated` | Required, ISO 8601. |
+| `dataFile.filename` | string | **placeholder** | Required. Synthesised from the asset id plus a MIME-guessed extension — *not* the original filename. |
+| `dataFile.filesize` | u64 | **placeholder** | Required, in bytes. Always `1`. |
+| `dataFile.checksum.type` | string | **placeholder** | Required. Always `MD5`. |
+| `dataFile.checksum.value` | string | **placeholder** | Required, hex. Always the MD5 of the empty string, so it is recognisable as fake. |
+| `dataFile.lastUpdateTime` | string | — | Optional. Never emitted: records carry no per-file modification date. |
+| `directoryLabel` | string | — | Optional. Never emitted: DPE has no directory concept, and Harvard omits it too. |
+
+Absent optionals are **omitted, not `null`**. That is contractual, not cosmetic: the consuming parser expects a string there, and `null` is a different shape than a missing key.
+
+Responses:
+
+| Status | When |
+|---|---|
+| `200` | The identifier resolves. `data.files` is empty when the record exists but has no file — the majority case, see below. |
+| `400` | `persistentId` is missing or blank. |
+| `404` | The identifier matches no known project or record. |
+
+The distinction between a `200` with an empty list and a `404` is deliberate, and it matters at scale: **roughly 77% of records (39,216 of 50,994) are metadata-only** and have no file at all. Answering those with `404` would make a normal harvest look like a broken endpoint, so a known-but-fileless record gets an empty array and only a genuinely unknown identifier gets `404`.
+
+### `GET /api/access/datafile/{id}`
+
+Returns the bytes of one file, selected by the numeric `dataFile.id`. The client constructs this URL itself, so its shape is not ours to choose.
+
+```bash
+curl -L 'http://localhost:4000/api/access/datafile/8294929545880278'
+# 307 → https://ingest.dasch.swiss/projects/0803/assets/2vbIabBOEvq-EU9jwmgEe9j/original
+```
+
+| Status | When |
+|---|---|
+| `307` | Redirect to the storage URL (dsp-ingest). Clients follow redirects here; production Dataverse does the same thing, answering with a `303` to presigned object storage. |
+| `403` | The file is `restricted`. Currently unreachable — all DaSCH data is open — but kept so the branch is correct once a real restriction signal exists. |
+| `404` | No file has that id, or the segment is not numeric. |
+
+`Content-Disposition` is deliberately not set on the redirect — it belongs on the final hop, which dsp-ingest serves.
+
+Errors from both endpoints use Dataverse's own envelope, so a client written against the real API can read them:
+
+```json
+{ "status": "ERROR", "message": "file not found: 999999" }
+```
+
+## Data source
+
+There is no separate data file and no database. Everything is derived from the records already committed under `modules/dpe/server/data/records/`, so the endpoint stays in step with the record dumps automatically and nothing has to be maintained by hand.
+
+A record's `file` object supplies the MIME type and the storage URL:
+
+```json
+{
+  "id": "http://rdfh.ch/0803/_qXHiyf6WsOfLFEXr7Zdng",
+  "pid": "https://ark.dasch.swiss/ark:/72163/1/0803/_qXHiyf6WsOfLFEXr7Zdng7",
+  "dateCreated": "2011-04-14T07:15:28Z",
+  "file": {
+    "mimeType": "image/jp2",
+    "url": "https://ingest.dasch.swiss/projects/0803/assets/2vbIabBOEvq-EU9jwmgEe9j/original"
+  }
+}
+```
+
+`DataverseFile::from_record` maps that to the wire shape; records without a `file` key produce no files at all. Of the 50,994 committed records, 11,778 carry a file.
+
+### File ids
+
+The Dataverse format has **no download-URL field.** Clients derive the URL from `dataFile.id` by string concatenation — `{scheme}://{host}/api/access/datafile/{id}` — and cache the result. (Confirmed against a live Harvard response in `notes/examples/harvard-dataverse-payload.json`, whose only storage-facing field is an internal `storageIdentifier`.) So the id *is* the download address, and it must keep resolving to the same file.
+
+Ids are therefore derived, not assigned: `file_id_for_iri` hashes the record IRI with FNV-1a and masks to 53 bits. That is deterministic and stateless, needs no lookup table, and survives regeneration of the record dumps — which matters, because those dumps are machine-generated and would destroy any hand-written ids.
+
+Two constraints shape the choice:
+
+- **53 bits, not 64.** Many JSON consumers parse numbers as IEEE-754 doubles and lose integer precision above 2⁵³, which would silently round an id and break the derived URL.
+- **Collisions are detected, not silent.** Two records hashing to the same id would make one file's download URL serve the other's bytes. The id index rejects duplicates and logs an error, and `committed_records_have_no_id_collisions` asserts the property over the real data, so a colliding dump fails the build. There are currently zero collisions across all 50,994 records.
+
+The record IRI is hashed rather than the ARK because the IRI is what dsp-api uses internally, so it lines up with whatever the forthcoming file endpoint returns.
+
+### Placeholders
+
+Three required fields have no source in DPE or dsp-api today and are filled with obvious fakes, grouped in `dpe_core::FilePlaceholders`:
+
+| Field | Placeholder | Why it is not real |
+|---|---|---|
+| `filename` | asset id + MIME-guessed extension | dsp-api has the original filename (`FileValueV2.originalFilename`) but discards it on export, keeping only the opaque asset id. |
+| `filesize` | `1` | Not present in dsp-api at all; must come from dsp-ingest. |
+| `checksum` | MD5 of the empty string | No hashing anywhere in the pipeline. |
+
+The checksum placeholder is the MD5 of the empty string (`d41d8cd9…`) rather than random hex specifically so that anyone inspecting a response can recognise it as fake.
+
+When the dsp-api file endpoint lands it populates `FilePlaceholders`, and the wire types, handlers, and routes do not change. Moving to SHA-256 at that point is a data change too: the serializer emits whatever `checksum_type` says.
+
+`restricted` is *not* a placeholder — it is a constant `false`, because every DaSCH record is `Full Open Access` and dsp-api hardcodes that on export. If DaSCH ever holds restricted assets this must become a real per-file value; a per-record access-rights string cannot express per-file restriction.
+
+## Implementation
+
+| Piece | Location |
+|---|---|
+| Endpoint handlers, DTOs, errors | `modules/dpe/api-dataverse/` |
+| File model, id derivation, placeholders | `modules/dpe/core/src/dataverse_file.rs` |
+| Record-backed lookup and id index | `modules/dpe/core/src/dataverse_file_cache.rs` |
+| Route wiring and rate limiting | `modules/dpe/server/src/router.rs` |
+
+Two implementation details are worth knowing before editing the routes:
+
+- **The literal colons are intentional.** Axum 0.8 spells path parameters `{name}` and panics on any segment starting with `:` to catch un-migrated 0.7-style routes, so registering these literal segments requires `without_v07_checks()`. On merge, Axum keeps that check unless *both* routers disabled it — so every router in the merge chain (`build_router`, `oai_router_with`, `dataverse_router_with`) opts out. Removing it from any one of them makes the application panic at startup.
+- **`files_for` returns a three-way answer.** `None` means no such record (`404`), `Some(vec![])` means a record with no file (`200`, empty array), and a non-empty vec is the normal case. Collapsing the first two would break the majority of harvest requests.

--- a/docs/src/dpe/operations.md
+++ b/docs/src/dpe/operations.md
@@ -64,6 +64,8 @@ dpe-server healthcheck --url http://localhost:9090/healthz # custom URL
 | `DPE_OAI_RATE_LIMIT_PER_SECOND` | No | `1` | Per-IP rate limit on `/dpe/oai`: seconds per request once the burst is spent. `1` ≈ 60 requests/minute sustained. See [OAI-PMH](./oai-pmh.md). |
 | `DPE_OAI_RATE_LIMIT_BURST` | No | `60` | Per-IP burst allowance on `/dpe/oai`: back-to-back requests before the sustained rate applies. |
 | `DPE_OAI_PAGE_SIZE` | No | `100` | Items per page in `ListRecords` / `ListIdentifiers` responses before a resumption token is emitted. Non-positive or non-numeric values fall back to the default. See [OAI-PMH](./oai-pmh.md). |
+| `DPE_DATAVERSE_RATE_LIMIT_PER_SECOND` | No | `1` | Per-IP rate limit on the Dataverse-compat routes: seconds per request once the burst is spent. `1` ≈ 60 requests/minute sustained. See [Dataverse API](./dataverse-api.md). |
+| `DPE_DATAVERSE_RATE_LIMIT_BURST` | No | `60` | Per-IP burst allowance on the Dataverse-compat routes: back-to-back requests before the sustained rate applies. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | No | *(none)* | OTLP gRPC endpoint (e.g., `http://alloy:4317`). When unset, OTel falls back to no-op export. |
 | `OTEL_SERVICE_NAME` | No | *(none)* | Service name for OTel resource attributes (e.g., `dpe`) |
 | `OTEL_RESOURCE_ATTRIBUTES` | No | *(none)* | Comma-separated OTel resource attributes (e.g., `service.namespace=dpe,service.version=0.2.1,deployment.environment=prod`) |
@@ -72,7 +74,7 @@ dpe-server healthcheck --url http://localhost:9090/healthz # custom URL
 | `DPE_PUBLIC_DIR` | No | `modules/dpe/public` | Directory served as static assets by `ServeDir` (favicon, logo, vendored JS, project images, and the compiled `app.<hash>.css`). |
 | `DPE_ENV` | No | `DEV` | Deployment environment (`DEV` or `PROD`). Controls OTLP log export (see [Logging](#logging)). The Docker image sets `PROD`. |
 
-> **Rate limiting and reverse proxies.** The OAI (`/dpe/oai`) and telemetry (`/telemetry/collect`) rate limits key on the client IP, taken from the **rightmost** `X-Forwarded-For` entry (the address Traefik itself appends), falling back to the connection peer address. Reading the rightmost entry — not the leftmost — is deliberate: Traefik appends the real client after any `X-Forwarded-For` value the client supplied, so the rightmost entry is proxy-authored and cannot be spoofed, while the leftmost stays attacker-controlled. This holds only while Traefik is the sole hop in front of DPE; a second proxy that appends to `X-Forwarded-For` would shift the trusted entry and require counting hops from the right.
+> **Rate limiting and reverse proxies.** The OAI (`/dpe/oai`), Dataverse-compat (`/api/datasets/…`, `/api/access/datafile/…`) and telemetry (`/telemetry/collect`) rate limits key on the client IP, taken from the **rightmost** `X-Forwarded-For` entry (the address Traefik itself appends), falling back to the connection peer address. Reading the rightmost entry — not the leftmost — is deliberate: Traefik appends the real client after any `X-Forwarded-For` value the client supplied, so the rightmost entry is proxy-authored and cannot be spoofed, while the leftmost stays attacker-controlled. This holds only while Traefik is the sole hop in front of DPE; a second proxy that appends to `X-Forwarded-For` would shift the trusted entry and require counting hops from the right.
 
 ## Health Check
 

--- a/docs/src/dpe/project_structure.md
+++ b/docs/src/dpe/project_structure.md
@@ -6,6 +6,7 @@
 modules/dpe/
 ├── core/             dpe-core          Pure domain (serde only)
 ├── telemetry/        dpe-telemetry     Telemetry types and validation (serde only)
+├── api-dataverse/    dpe-api-dataverse Dataverse-compatible file metadata API
 ├── api-oai/          dpe-api-oai       OAI-PMH 2.0 endpoint
 ├── web/              dpe-web           Maud view library (pages + components)
 ├── server/           dpe-server        Axum binary (composition root)
@@ -20,6 +21,7 @@ modules/dpe/
 dpe-core              ← pure domain, no framework deps
   ↑
   ├── dpe-api-oai     ← OAI-PMH endpoint
+  ├── dpe-api-dataverse ← Dataverse-compatible file metadata API
   ├── dpe-web         ← Maud pages + components
   └── dpe-server      ← composition root, Datastar fragment handlers
        ↑
@@ -45,6 +47,12 @@ Dependencies: `serde`, `serde_json` only.
 OAI-PMH 2.0 Data Provider. Implements the six required verbs (Identify, ListMetadataFormats, ListSets, ListIdentifiers, ListRecords, GetRecord). Usage is documented in [OAI-PMH Endpoint](./oai-pmh.md).
 
 Depends on `dpe-core` for domain types — no web framework dependency.
+
+### `dpe-api-dataverse` (api-dataverse/)
+
+A minimal subset of the Dataverse Native API — two endpoints — so EOSC Data Commons can harvest DaSCH datasets with file-level download information. Usage and the placeholder-data caveat are documented in [Dataverse-Compatible API](./dataverse-api.md).
+
+Depends on `dpe-core` for the file model and repository traits, and on `axum` because this protocol signals errors through HTTP status codes.
 
 ### `dpe-web` (web/)
 

--- a/docs/src/repo_structure.md
+++ b/docs/src/repo_structure.md
@@ -8,6 +8,7 @@ This repository is a Rust workspace structured as a monorepo. All Rust crates ar
 modules/
 ├── dpe/                       # Discovery and Presentation Environment
 │   ├── core/                  # Pure domain types, repositories, data loading (crate: dpe-core)
+│   ├── api-dataverse/         # Dataverse-compatible file metadata API (crate: dpe-api-dataverse)
 │   ├── api-oai/               # OAI-PMH 2.0 API (crate: dpe-api-oai)
 │   ├── web/                   # Web layer: Maud pages and components (crate: dpe-web)
 │   ├── server/                # Server binary: route composition, Datastar fragments (crate: dpe-server)
@@ -29,6 +30,7 @@ modules/
 | Crate | Folder | Role |
 |-------|--------|------|
 | `dpe-core` | `dpe/core` | Pure domain types and data access (zero framework deps) |
+| `dpe-api-dataverse` | `dpe/api-dataverse` | Dataverse-compatible file metadata API |
 | `dpe-api-oai` | `dpe/api-oai` | OAI-PMH 2.0 API (depends on `dpe-core` only) |
 | `dpe-web` | `dpe/web` | Maud pages and components (`fn -> Markup`) |
 | `dpe-server` | `dpe/server` | Server binary — composes all routes |
@@ -41,8 +43,8 @@ modules/
 Each API is a separate crate under `modules/dpe/`:
 
 - **Naming**: `dpe-api-{name}` (e.g., `dpe-api-oai`)
-- **Dependencies**: `dpe-core` for domain types; never depends on other API crates or `dpe-web`
-- **Entry point**: Exports a handler function (e.g., `pub async fn oai_handler(...)`)
-- **Composition**: `dpe-server` wires the handler into the Axum router
+- **Dependencies**: `dpe-core` for domain types; never depends on other API crates or `dpe-web`. An API crate may depend on `axum` where the protocol needs it (`dpe-api-dataverse` maps errors to HTTP status codes); `dpe-api-oai` does not, because OAI-PMH carries its errors in the body of a `200`.
+- **Entry point**: Exports handler functions (e.g., `pub async fn oai_handler(...)`)
+- **Composition**: `dpe-server` wires the handlers into the Axum router
 
 For detailed crate responsibilities and the dependency graph, see [DPE Project Structure](./dpe/project_structure.md).

--- a/modules/dpe/api-dataverse/Cargo.toml
+++ b/modules/dpe/api-dataverse/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "dpe-api-dataverse"
+version.workspace = true
+edition = "2021"
+publish = false
+
+[dependencies]
+dpe-core = { path = "../core" }
+axum.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing = { workspace = true }

--- a/modules/dpe/api-dataverse/src/dto.rs
+++ b/modules/dpe/api-dataverse/src/dto.rs
@@ -1,0 +1,116 @@
+//! Wire types for the Dataverse `versions` response.
+//!
+//! These mirror the Dataverse Native API shape, because the consuming parser
+//! (`datahugger-ng`'s Dataverse backend) hard-fails a record when a field is
+//! missing or malformed. `notes/dataverse-api-handoff.md` §3.1 is the
+//! authoritative field list — the parser is the client, not the specification, so
+//! a field it happens to tolerate may still be required by the format.
+//!
+//! Note what the format does *not* have: a download URL. Clients derive it from
+//! `dataFile.id` by string concatenation (`/api/access/datafile/{id}`), which is
+//! why that id must keep resolving to the same file. Verified against a live
+//! Harvard response — see `notes/examples/harvard-dataverse-payload.json`, where
+//! the only storage-facing field is an internal `storageIdentifier`.
+
+use dpe_core::DataverseFile;
+use serde::Serialize;
+
+/// The response envelope: `{"status": "OK", "data": {"files": [...]}}`.
+#[derive(Debug, Serialize)]
+pub struct VersionsResponse {
+    pub status: &'static str,
+    pub data: VersionsData,
+}
+
+impl VersionsResponse {
+    /// Wraps the given files in the `status: OK` envelope.
+    pub fn ok(files: Vec<DataverseFile>) -> Self {
+        Self {
+            status: "OK",
+            data: VersionsData { files: files.into_iter().map(FileEntry::from).collect() },
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct VersionsData {
+    pub files: Vec<FileEntry>,
+}
+
+/// One entry in `data.files`. The per-file metadata sits in the nested `dataFile`;
+/// `restricted` and `version` are siblings of it, not members — that nesting is
+/// part of the contract.
+///
+/// `directoryLabel` is not emitted at all: it is optional in the contract, DPE has
+/// no directory concept at any layer, and the live Harvard response omits it on
+/// every file.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileEntry {
+    /// Always `false` — all DaSCH data is currently open.
+    pub restricted: bool,
+    /// DPE has no per-file version concept, and the contract requires the field,
+    /// so every file is version 1. Revisit if record versioning is introduced.
+    pub version: u64,
+    pub data_file: DataFileEntry,
+}
+
+/// The `dataFile` object: the file's own metadata.
+///
+/// Three of these fields are placeholders today (`filename`, `filesize`,
+/// `checksum`) and come from [`dpe_core::FilePlaceholders`]. They are laid out here
+/// exactly as the real values will be, so wiring up the dsp-api file endpoint is a
+/// change to how `DataverseFile` is built, not to this type or to the handlers.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DataFileEntry {
+    /// Stable numeric id; the client builds `/api/access/datafile/{id}` from it.
+    pub id: u64,
+    /// PLACEHOLDER — synthesised from the asset id, not the original filename.
+    pub filename: String,
+    pub content_type: String,
+    /// PLACEHOLDER — no upstream source for file size yet.
+    pub filesize: u64,
+    pub creation_date: String,
+    /// Omitted rather than serialized as `null` when absent: the parser expects a
+    /// string here, and a `null` is a different shape than a missing key. DPE has
+    /// no per-file modification date, so this is currently always absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_update_time: Option<String>,
+    /// PLACEHOLDER — not computed from the bytes.
+    pub checksum: Checksum,
+}
+
+/// The `checksum` object. Dataverse also emits a bare `md5` field alongside it;
+/// that variant is only read by the `file.xhtml`-style lookup this pipeline does
+/// not exercise, so it is not emitted here.
+#[derive(Debug, Serialize)]
+pub struct Checksum {
+    #[serde(rename = "type")]
+    pub checksum_type: String,
+    pub value: String,
+}
+
+impl From<DataverseFile> for FileEntry {
+    fn from(file: DataverseFile) -> Self {
+        Self {
+            restricted: file.restricted,
+            version: 1,
+            data_file: DataFileEntry {
+                id: file.id,
+                filename: file.placeholders.filename,
+                content_type: file.content_type,
+                filesize: file.placeholders.filesize,
+                creation_date: file.creation_date,
+                // No per-file modification date exists in DPE; records carry only
+                // `dateCreated`. Absent rather than mirroring the creation date,
+                // which would assert something untrue.
+                last_update_time: None,
+                checksum: Checksum {
+                    checksum_type: file.placeholders.checksum_type,
+                    value: file.placeholders.checksum_value,
+                },
+            },
+        }
+    }
+}

--- a/modules/dpe/api-dataverse/src/error.rs
+++ b/modules/dpe/api-dataverse/src/error.rs
@@ -1,0 +1,78 @@
+//! Errors returned by the Dataverse-compatible endpoints.
+//!
+//! Unlike OAI-PMH — where protocol errors are carried in the body of a 200 —
+//! this is a plain JSON API and the crawler distinguishes outcomes on the HTTP
+//! status, so each variant maps to a status code.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq)]
+pub enum DataverseError {
+    /// The required `persistentId` query parameter was absent or empty.
+    #[error("persistentId query parameter is required")]
+    MissingPersistentId,
+
+    /// No dataset or record matches the given identifier.
+    #[error("dataset not found: {0}")]
+    DatasetNotFound(String),
+
+    /// No file has the given numeric id.
+    #[error("file not found: {0}")]
+    FileNotFound(u64),
+
+    /// The file exists but is behind an access restriction. Returned instead of
+    /// bytes so a client that ignored the `restricted` flag gets a clear answer.
+    #[error("file is restricted: {0}")]
+    FileRestricted(u64),
+}
+
+impl DataverseError {
+    pub fn status(&self) -> StatusCode {
+        match self {
+            Self::MissingPersistentId => StatusCode::BAD_REQUEST,
+            Self::DatasetNotFound(_) | Self::FileNotFound(_) => StatusCode::NOT_FOUND,
+            Self::FileRestricted(_) => StatusCode::FORBIDDEN,
+        }
+    }
+}
+
+impl IntoResponse for DataverseError {
+    /// Mirrors Dataverse's own error envelope (`{"status":"ERROR","message":…}`),
+    /// so a client written against the real API can read our failures too.
+    fn into_response(self) -> Response {
+        let body = Json(serde_json::json!({
+            "status": "ERROR",
+            "message": self.to_string(),
+        }));
+        (self.status(), body).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn statuses_match_the_contract() {
+        assert_eq!(DataverseError::MissingPersistentId.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            DataverseError::DatasetNotFound("oai:x:1".to_string()).status(),
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(DataverseError::FileNotFound(7).status(), StatusCode::NOT_FOUND);
+        assert_eq!(DataverseError::FileRestricted(7).status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn messages_name_the_offending_value() {
+        // The identifier/id is echoed so a harvester operator can tell which record
+        // failed from the response alone.
+        assert!(DataverseError::DatasetNotFound("oai:x:1".to_string())
+            .to_string()
+            .contains("oai:x:1"));
+        assert!(DataverseError::FileNotFound(42).to_string().contains("42"));
+    }
+}

--- a/modules/dpe/api-dataverse/src/handlers.rs
+++ b/modules/dpe/api-dataverse/src/handlers.rs
@@ -1,0 +1,388 @@
+//! Handlers for the two Dataverse-compatible endpoints.
+//!
+//! Both are unauthenticated: they serve published, public metadata only.
+
+use axum::extract::{Path, Query};
+use axum::response::{IntoResponse, Redirect, Response};
+use axum::Json;
+use dpe_core::{DataverseFileRepository, FsDataverseFileRepository};
+use serde::Deserialize;
+
+use crate::dto::VersionsResponse;
+use crate::error::DataverseError;
+
+/// Query parameters for the versions endpoint. Both are `Option` so a missing
+/// `persistentId` yields our own 400 rather than Axum's rejection, matching the
+/// OAI handlers' hand-rolled validation.
+#[derive(Debug, Default, Deserialize)]
+pub struct VersionsParams {
+    #[serde(rename = "persistentId")]
+    pub persistent_id: Option<String>,
+    /// Sent by the crawler as `dataverse_json`. Accepted and ignored: it selects
+    /// an exporter in real Dataverse, and this endpoint only speaks that one
+    /// format, so it cannot change the response.
+    pub exporter: Option<String>,
+}
+
+/// `GET /api/datasets/:persistentId/versions/:latest-published`
+///
+/// The path segments containing colons are literal (see the route table); the
+/// dataset is selected by the `persistentId` query parameter instead.
+#[axum::debug_handler]
+#[tracing::instrument(skip_all, fields(otel.kind = "internal", oai.identifier))]
+pub async fn versions_handler(Query(params): Query<VersionsParams>) -> Response {
+    match resolve_versions(&params, &FsDataverseFileRepository::new()) {
+        Ok(response) => Json(response).into_response(),
+        Err(err) => err.into_response(),
+    }
+}
+
+/// Resolve the versions response for the given params. Pure over its repository so
+/// the contract is testable without the process caches.
+pub(crate) fn resolve_versions(
+    params: &VersionsParams,
+    files: &dyn DataverseFileRepository,
+) -> Result<VersionsResponse, DataverseError> {
+    let identifier = params
+        .persistent_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .ok_or(DataverseError::MissingPersistentId)?;
+
+    tracing::Span::current().record("oai.identifier", identifier);
+
+    // `files_for` distinguishes the two negative cases: `Some(vec![])` is a record
+    // we hold that has no files — the majority, roughly 77% of records — and is
+    // answered with an empty list, which the crawler reads as a dataset without
+    // files. `None` is an identifier we do not know at all, and is a 404, so a
+    // typo'd identifier is not silently indistinguishable from a metadata-only
+    // record.
+    files
+        .files_for(identifier)
+        .map(VersionsResponse::ok)
+        .ok_or_else(|| DataverseError::DatasetNotFound(identifier.to_string()))
+}
+
+/// `GET /api/access/datafile/{id}`
+///
+/// A non-numeric segment fails in the extractor before reaching here.
+#[tracing::instrument(skip_all, fields(otel.kind = "internal", file.id = id))]
+pub async fn datafile_handler(Path(id): Path<u64>) -> Response {
+    match resolve_datafile(id, &FsDataverseFileRepository::new()) {
+        Ok(url) => Redirect::temporary(&url).into_response(),
+        Err(err) => err.into_response(),
+    }
+}
+
+/// Resolve the download target for a file id, or the error to return.
+///
+/// Redirecting rather than proxying is what production Dataverse does (Harvard
+/// answers with a 303 to a presigned S3 URL), so clients already follow it.
+/// `Content-Disposition` deliberately is not set here: it belongs on the final
+/// hop, which dsp-ingest serves.
+pub(crate) fn resolve_datafile(id: u64, files: &dyn DataverseFileRepository) -> Result<String, DataverseError> {
+    let file = files.file_by_id(id).ok_or(DataverseError::FileNotFound(id))?;
+
+    // Currently unreachable: `DataverseFile::RESTRICTED` is a constant `false`
+    // because all DaSCH data is open. Kept because it is the correct response the
+    // moment a real restriction signal exists, and because deleting it would leave
+    // the contract's `restricted` semantics implemented nowhere.
+    if file.restricted {
+        return Err(DataverseError::FileRestricted(id));
+    }
+
+    Ok(file.download_url)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use axum::http::StatusCode;
+    use dpe_core::{file_id_for_iri, DataverseFile, FilePlaceholders};
+
+    use super::*;
+
+    // ---- fakes ----
+
+    /// In-memory stand-in for the record-backed repository.
+    ///
+    /// Distinguishes the two negative cases the same way the production
+    /// implementation does: a key present with an empty vec is a known record with
+    /// no files; a key absent is an unknown identifier.
+    struct InMemoryFiles {
+        by_identifier: HashMap<String, Vec<DataverseFile>>,
+    }
+
+    impl InMemoryFiles {
+        fn new(entries: Vec<(&str, Vec<DataverseFile>)>) -> Self {
+            Self {
+                by_identifier: entries.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
+            }
+        }
+
+        fn empty() -> Self {
+            Self { by_identifier: HashMap::new() }
+        }
+    }
+
+    impl DataverseFileRepository for InMemoryFiles {
+        fn files_for(&self, oai_identifier: &str) -> Option<Vec<DataverseFile>> {
+            self.by_identifier.get(oai_identifier).cloned()
+        }
+
+        fn file_by_id(&self, id: u64) -> Option<DataverseFile> {
+            self.by_identifier.values().flatten().find(|f| f.id == id).cloned()
+        }
+    }
+
+    // ---- fixtures ----
+
+    const RECORD_ID: &str = "oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh";
+    const RECORD_IRI: &str = "http://rdfh.ch/0803/lklK7rVuVOmpBZYWrF8o-g";
+    const ASSET_URL: &str = "https://ingest.dasch.swiss/projects/0803/assets/2vbIabBOEvq-EU9jwmgEe9j/original";
+
+    /// A file as `DataverseFile::from_record` would build it: real MIME type, date
+    /// and URL; placeholder filename, size and checksum.
+    fn jp2_file() -> DataverseFile {
+        DataverseFile {
+            id: file_id_for_iri(RECORD_IRI),
+            content_type: "image/jp2".to_string(),
+            creation_date: "2012-06-19T14:33:33Z".to_string(),
+            restricted: false,
+            download_url: ASSET_URL.to_string(),
+            placeholders: FilePlaceholders::for_asset("2vbIabBOEvq-EU9jwmgEe9j", "image/jp2"),
+        }
+    }
+
+    /// A second file whose MIME type carries parameters, to pin that they survive.
+    fn csv_file() -> DataverseFile {
+        DataverseFile {
+            id: file_id_for_iri("http://rdfh.ch/0868/other"),
+            content_type: "text/csv; charset=UTF-8".to_string(),
+            creation_date: "2019-06-30".to_string(),
+            restricted: false,
+            download_url: "https://ingest.dasch.swiss/projects/0868/assets/abc/original".to_string(),
+            placeholders: FilePlaceholders::for_asset("abc", "text/csv; charset=UTF-8"),
+        }
+    }
+
+    fn params(persistent_id: Option<&str>, exporter: Option<&str>) -> VersionsParams {
+        VersionsParams {
+            persistent_id: persistent_id.map(str::to_string),
+            exporter: exporter.map(str::to_string),
+        }
+    }
+
+    fn body_of(response: &VersionsResponse) -> serde_json::Value {
+        serde_json::to_value(response).expect("response should serialize")
+    }
+
+    fn one_file_table() -> InMemoryFiles {
+        InMemoryFiles::new(vec![(RECORD_ID, vec![jp2_file()])])
+    }
+
+    // ---- contract: the response envelope ----
+
+    #[test]
+    fn golden_envelope_for_a_record_with_one_file() {
+        // The full contract shape, asserted exactly: nesting, key names, and the
+        // sibling/member split between `restricted`/`version` and `dataFile`.
+        let response = resolve_versions(&params(Some(RECORD_ID), Some("dataverse_json")), &one_file_table())
+            .expect("known record should resolve");
+
+        let expected = serde_json::json!({
+            "status": "OK",
+            "data": {
+                "files": [
+                    {
+                        "restricted": false,
+                        "version": 1,
+                        "dataFile": {
+                            "id": file_id_for_iri(RECORD_IRI),
+                            "filename": "2vbIabBOEvq-EU9jwmgEe9j.jp2",
+                            "contentType": "image/jp2",
+                            "filesize": 1,
+                            "creationDate": "2012-06-19T14:33:33Z",
+                            "checksum": { "type": "MD5", "value": "d41d8cd98f00b204e9800998ecf8427e" }
+                        }
+                    }
+                ]
+            }
+        });
+
+        assert_eq!(body_of(&response), expected);
+    }
+
+    #[test]
+    fn absent_optionals_are_omitted_not_null() {
+        // A `null` where the parser expects a string is a different shape than a
+        // missing key, so this distinction is contractual, not cosmetic. DPE has no
+        // per-file modification date, so `lastUpdateTime` is always absent; and
+        // `directoryLabel` is never emitted at all.
+        let response =
+            resolve_versions(&params(Some(RECORD_ID), None), &one_file_table()).expect("known record should resolve");
+        let body = body_of(&response);
+        let entry = &body["data"]["files"][0];
+
+        let entry_keys: Vec<&String> = entry.as_object().expect("file entry is an object").keys().collect();
+        let data_file_keys: Vec<&String> =
+            entry["dataFile"].as_object().expect("dataFile is an object").keys().collect();
+
+        assert!(!entry_keys.contains(&&"directoryLabel".to_string()));
+        assert!(!data_file_keys.contains(&&"lastUpdateTime".to_string()));
+    }
+
+    #[test]
+    fn every_required_field_is_present_on_every_file() {
+        // A loop rather than per-field assertions, so adding a file cannot silently
+        // regress a field the parser hard-fails on.
+        let response = resolve_versions(
+            &params(Some(RECORD_ID), None),
+            &InMemoryFiles::new(vec![(RECORD_ID, vec![jp2_file(), csv_file()])]),
+        )
+        .expect("known record should resolve");
+        let body = body_of(&response);
+        let files = body["data"]["files"].as_array().expect("files is an array");
+
+        assert_eq!(files.len(), 2);
+        for file in files {
+            assert!(file["restricted"].is_boolean(), "restricted missing on {file}");
+            assert!(file["version"].is_u64(), "version missing on {file}");
+
+            let data_file = &file["dataFile"];
+            assert!(data_file["id"].is_u64(), "dataFile.id missing on {file}");
+            assert!(data_file["filename"].is_string(), "dataFile.filename missing on {file}");
+            assert!(data_file["contentType"].is_string(), "dataFile.contentType missing on {file}");
+            assert!(data_file["filesize"].is_u64(), "dataFile.filesize missing on {file}");
+            assert!(data_file["creationDate"].is_string(), "dataFile.creationDate missing on {file}");
+            assert!(data_file["checksum"]["type"].is_string(), "checksum.type missing on {file}");
+            assert!(data_file["checksum"]["value"].is_string(), "checksum.value missing on {file}");
+        }
+    }
+
+    #[test]
+    fn file_ids_stay_within_json_safe_integer_range() {
+        // Consumers that parse JSON numbers as doubles round above 2^53, which would
+        // corrupt the download URL derived from the id.
+        let response = resolve_versions(
+            &params(Some(RECORD_ID), None),
+            &InMemoryFiles::new(vec![(RECORD_ID, vec![jp2_file(), csv_file()])]),
+        )
+        .expect("known record should resolve");
+        let body = body_of(&response);
+
+        for file in body["data"]["files"].as_array().expect("files is an array") {
+            let id = file["dataFile"]["id"].as_u64().expect("id is numeric");
+            assert!(id < (1 << 53), "id {id} exceeds the JSON-safe integer range");
+        }
+    }
+
+    #[test]
+    fn mime_parameters_survive_unaltered() {
+        let response = resolve_versions(
+            &params(Some(RECORD_ID), None),
+            &InMemoryFiles::new(vec![(RECORD_ID, vec![csv_file()])]),
+        )
+        .expect("known record should resolve");
+
+        assert_eq!(
+            body_of(&response)["data"]["files"][0]["dataFile"]["contentType"],
+            "text/csv; charset=UTF-8"
+        );
+    }
+
+    #[test]
+    fn exporter_param_does_not_change_the_body() {
+        let with = resolve_versions(&params(Some(RECORD_ID), Some("dataverse_json")), &one_file_table())
+            .expect("known record should resolve");
+        let without =
+            resolve_versions(&params(Some(RECORD_ID), None), &one_file_table()).expect("known record should resolve");
+
+        assert_eq!(body_of(&with), body_of(&without));
+    }
+
+    #[test]
+    fn identifier_with_ark_colons_is_accepted_verbatim() {
+        // The crawler passes the OAI header identifier unmodified, colons and all.
+        // Anything that split on ':' would mangle the ARK and miss the record.
+        assert!(
+            resolve_versions(&params(Some(RECORD_ID), None), &one_file_table()).is_ok(),
+            "full OAI identifier form should resolve"
+        );
+    }
+
+    // ---- contract: errors and the empty-list path ----
+
+    #[test]
+    fn missing_persistent_id_is_bad_request() {
+        let err =
+            resolve_versions(&params(None, None), &one_file_table()).expect_err("missing persistentId should fail");
+
+        assert_eq!(err, DataverseError::MissingPersistentId);
+        assert_eq!(err.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn blank_persistent_id_is_bad_request() {
+        let err =
+            resolve_versions(&params(Some("  "), None), &one_file_table()).expect_err("blank persistentId should fail");
+
+        assert_eq!(err, DataverseError::MissingPersistentId);
+    }
+
+    #[test]
+    fn unknown_identifier_is_not_found() {
+        let err = resolve_versions(
+            &params(Some("oai:dasch.swiss:ark:/72163/1/9999"), None),
+            &InMemoryFiles::empty(),
+        )
+        .expect_err("unknown identifier should fail");
+
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn known_record_without_files_yields_empty_list() {
+        // The dominant case: ~77% of records are metadata-only. An empty array is
+        // distinguishable from the 404 an unknown identifier gets, and is what keeps
+        // a harvest of mostly-fileless records from looking like a broken endpoint.
+        let response = resolve_versions(&params(Some(RECORD_ID), None), &InMemoryFiles::new(vec![(RECORD_ID, vec![])]))
+            .expect("known record should resolve");
+
+        let body = body_of(&response);
+        assert_eq!(body["status"], "OK");
+        assert_eq!(body["data"]["files"].as_array().expect("files is an array").len(), 0);
+    }
+
+    // ---- download endpoint ----
+
+    #[test]
+    fn open_file_resolves_to_its_download_url() {
+        let url = resolve_datafile(file_id_for_iri(RECORD_IRI), &one_file_table()).expect("open file should resolve");
+
+        assert_eq!(url, ASSET_URL);
+    }
+
+    #[test]
+    fn unknown_file_id_is_not_found() {
+        let err = resolve_datafile(999_999, &one_file_table()).expect_err("unknown id should fail");
+
+        assert_eq!(err, DataverseError::FileNotFound(999_999));
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn restricted_file_is_forbidden() {
+        // Unreachable with real data today (every file is open), but the branch must
+        // stay correct for when a restriction signal exists.
+        let mut restricted = jp2_file();
+        restricted.restricted = true;
+        let table = InMemoryFiles::new(vec![(RECORD_ID, vec![restricted])]);
+
+        let err = resolve_datafile(file_id_for_iri(RECORD_IRI), &table).expect_err("restricted file should fail");
+
+        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+    }
+}

--- a/modules/dpe/api-dataverse/src/lib.rs
+++ b/modules/dpe/api-dataverse/src/lib.rs
@@ -1,0 +1,32 @@
+//! Minimal Dataverse-compatible API for external harvesters.
+//!
+//! EOSC Data Commons harvests our OAI-PMH feed and then, per record, asks a
+//! Dataverse Native API for that record's file-level download metadata. Rather
+//! than deploy Dataverse, this crate reimplements the two endpoints their
+//! pipeline actually calls:
+//!
+//! - `GET /api/datasets/:persistentId/versions/:latest-published?persistentId={id}` — the file list
+//!   for one record ([`versions_handler`]).
+//! - `GET /api/access/datafile/{id}` — the bytes for one file ([`datafile_handler`]).
+//!
+//! Nothing else of Dataverse is implemented, and none of it is authenticated:
+//! both endpoints serve published, public metadata only.
+//!
+//! Most of the response is derived from the record data itself: MIME type,
+//! creation date, and the download URL all come from a record's `file`. The
+//! numeric `dataFile.id` is derived deterministically from the record IRI, since
+//! in this format the id *is* the download address.
+//!
+//! Three fields — `filename`, `filesize`, and the checksum — have no source in
+//! DPE or dsp-api yet and are served as **placeholders** (see
+//! [`dpe_core::FilePlaceholders`]); a client verifying a checksum against the
+//! downloaded bytes will find a mismatch. They will be supplied by a forthcoming
+//! dsp-api file endpoint, which populates `FilePlaceholders` without changing the
+//! wire types or handlers. See `docs/src/dpe/dataverse-api.md`.
+
+mod dto;
+mod error;
+mod handlers;
+
+pub use error::DataverseError;
+pub use handlers::{datafile_handler, versions_handler};

--- a/modules/dpe/core/src/dataverse_file.rs
+++ b/modules/dpe/core/src/dataverse_file.rs
@@ -1,0 +1,314 @@
+//! File-level metadata for the Dataverse-compatible API.
+//!
+//! The EOSC Data Commons crawler harvests our OAI-PMH feed and then, per record,
+//! asks a Dataverse Native API for that record's files. That contract needs a
+//! numeric id, a filename, a size, a MIME type, a checksum, dates, and a
+//! restricted flag per file.
+//!
+//! Most of it is derived from the record itself ([`DataverseFile::from_record`]).
+//! Three fields have no source in DPE or dsp-api today — `filename`, `filesize`,
+//! and the checksum — and are filled with placeholders until the dsp-api file
+//! endpoint supplies them. They are grouped in [`FilePlaceholders`] so the seam is
+//! explicit and the swap is a single call site.
+
+use crate::record::Record;
+
+/// One file's Dataverse-facing metadata.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DataverseFile {
+    /// Stable numeric id. In the Dataverse format the id *is* the download
+    /// address: clients build `/api/access/datafile/{id}` from it by string
+    /// concatenation and cache the result, so it must keep resolving to the same
+    /// file forever. Derived deterministically from the record IRI — see
+    /// [`file_id_for_iri`].
+    pub id: u64,
+    /// MIME type, from the record's `file.mimeType`.
+    pub content_type: String,
+    /// ISO 8601, from the record's `dateCreated`.
+    pub creation_date: String,
+    /// Always `false`: all DaSCH data is currently open. See [`DataverseFile::RESTRICTED`].
+    pub restricted: bool,
+    /// Where the bytes live (dsp-ingest), from the record's `file.url`. Not part
+    /// of the API response — the download route redirects here.
+    pub download_url: String,
+    /// Fields with no upstream source yet.
+    pub placeholders: FilePlaceholders,
+}
+
+/// The fields the Dataverse contract requires but neither DPE nor dsp-api can
+/// supply yet.
+///
+/// The contract's consumer (`datahugger-ng`) hard-fails a record when any of these
+/// is missing, so they cannot simply be omitted; they are filled with obvious
+/// placeholders instead. **These values are fiction.** A client verifying a
+/// checksum against the downloaded bytes will find a mismatch.
+///
+/// When the dsp-api file endpoint lands, this struct is what it populates — the
+/// wire DTOs and handlers do not change.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FilePlaceholders {
+    /// Original filename. dsp-api has it (`FileValueV2.originalFilename`) but
+    /// discards it during export; the asset id in the download URL is opaque and
+    /// carries no name or extension, so nothing real can be derived locally.
+    pub filename: String,
+    /// Size in bytes. Not present in dsp-api at all — must come from dsp-ingest.
+    pub filesize: u64,
+    /// Checksum algorithm: `MD5`, `SHA-1`, or `SHA-256`. Note the consumer accepts
+    /// only MD5 and SHA-1 today, so placeholders use MD5.
+    pub checksum_type: String,
+    /// Checksum value, hex.
+    pub checksum_value: String,
+}
+
+impl FilePlaceholders {
+    /// The checksum algorithm placeholders are emitted under.
+    pub const CHECKSUM_TYPE: &'static str = "MD5";
+
+    /// A syntactically valid MD5 that is recognisable as a placeholder: the
+    /// well-known hash of the empty string. Chosen deliberately over random hex so
+    /// that anyone inspecting a response can tell the value is not real.
+    pub const CHECKSUM_VALUE: &'static str = "d41d8cd98f00b204e9800998ecf8427e";
+
+    /// Placeholder size in bytes. Non-zero because the contract treats a file as
+    /// having content, and some consumers reject zero-length entries.
+    pub const FILESIZE: u64 = 1;
+
+    /// Builds placeholders for a record whose file has the given MIME type.
+    ///
+    /// The filename is synthesised from the asset id in the download URL plus an
+    /// extension guessed from the MIME type. It is *not* the original filename —
+    /// it exists so the field is present and plausible, and is replaced wholesale
+    /// once dsp-api exports the real one.
+    pub fn for_asset(asset_id: &str, mime_type: &str) -> Self {
+        Self {
+            filename: format!("{asset_id}{}", extension_for_mime(mime_type)),
+            filesize: Self::FILESIZE,
+            checksum_type: Self::CHECKSUM_TYPE.to_string(),
+            checksum_value: Self::CHECKSUM_VALUE.to_string(),
+        }
+    }
+}
+
+/// A file extension for the given MIME type, including the leading dot, or an
+/// empty string when the type is unknown.
+///
+/// Covers only the types actually present in the record data; anything else gets
+/// no extension rather than a wrong one.
+fn extension_for_mime(mime_type: &str) -> &'static str {
+    // Strip any parameters (`text/csv; charset=UTF-8`) before matching.
+    match mime_type.split(';').next().unwrap_or("").trim() {
+        "image/jp2" | "image/jpx" => ".jp2",
+        "image/jpeg" => ".jpg",
+        "image/tiff" => ".tif",
+        "image/png" => ".png",
+        "text/plain" => ".txt",
+        "text/csv" => ".csv",
+        "application/pdf" => ".pdf",
+        "application/zip" => ".zip",
+        "application/xml" | "text/xml" => ".xml",
+        _ => "",
+    }
+}
+
+/// Derives the stable numeric file id for a record IRI.
+///
+/// Deterministic, stateless, and stable across regeneration of the record dumps —
+/// which matters because those dumps are machine-generated, so any hand-assigned
+/// id would be lost on the next refresh.
+///
+/// Masked to 53 bits, not 64: JSON numbers are IEEE-754 doubles in many consumers,
+/// which lose integer precision above 2^53. A 53-bit space still makes a collision
+/// vanishingly unlikely at DaSCH's scale (~5×10^4 records → ~10^-9), and a
+/// collision is *detected*, not silent — the id index rejects duplicates, so it
+/// surfaces as a failing test rather than a download URL serving the wrong bytes.
+pub fn file_id_for_iri(iri: &str) -> u64 {
+    /// FNV-1a, 64-bit. Chosen over a cryptographic hash because the property
+    /// needed is determinism and spread, not preimage resistance, and this keeps
+    /// `dpe-core` dependency-free.
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+    const MASK_53_BITS: u64 = (1 << 53) - 1;
+
+    let mut hash = FNV_OFFSET;
+    for byte in iri.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    // Fold the high bits down rather than truncating, so entropy above bit 53 is
+    // not simply discarded.
+    ((hash >> 53) ^ hash) & MASK_53_BITS
+}
+
+impl DataverseFile {
+    /// All DaSCH data is currently openly accessible: every record carries
+    /// `accessRights: "Full Open Access"`, and dsp-api hardcodes it on export, so
+    /// there is no per-file restriction signal to represent. The contract requires
+    /// the field, so it is emitted as a constant.
+    ///
+    /// If DaSCH ever holds restricted assets this must become a real per-file
+    /// value; a per-record access-rights string cannot express it.
+    pub const RESTRICTED: bool = false;
+
+    /// Builds the Dataverse view of a record's file, or `None` when the record has
+    /// no file (the majority — roughly 77% of records are metadata-only).
+    pub fn from_record(record: &Record) -> Option<Self> {
+        let file = record.file.as_ref()?;
+
+        Some(Self {
+            id: file_id_for_iri(&record.id),
+            content_type: file.mime_type.clone(),
+            creation_date: record.date_created.clone(),
+            restricted: Self::RESTRICTED,
+            download_url: file.url.clone(),
+            placeholders: FilePlaceholders::for_asset(asset_id_of(&file.url), &file.mime_type),
+        })
+    }
+}
+
+/// Extracts the dsp-ingest asset id from a download URL, e.g.
+/// `https://ingest.dasch.swiss/projects/0803/assets/{asset_id}/original`.
+///
+/// Falls back to the whole URL's last non-empty segment if the shape differs, so a
+/// changed URL layout degrades instead of panicking.
+fn asset_id_of(url: &str) -> &str {
+    let trimmed = url.trim_end_matches('/');
+    match trimmed.strip_suffix("/original") {
+        Some(rest) => rest.rsplit('/').next().unwrap_or(trimmed),
+        None => trimmed.rsplit('/').find(|s| !s.is_empty()).unwrap_or(trimmed),
+    }
+}
+
+/// Read access to record file metadata, so handlers can be tested against
+/// in-memory data instead of the process caches.
+pub trait DataverseFileRepository {
+    /// Files belonging to the given full OAI header identifier. `Some(vec![])`
+    /// means "record exists, has no files"; `None` means "no such record".
+    fn files_for(&self, oai_identifier: &str) -> Option<Vec<DataverseFile>>;
+
+    /// A single file by its stable numeric id.
+    fn file_by_id(&self, id: u64) -> Option<DataverseFile>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- id derivation ----
+
+    #[test]
+    fn id_is_deterministic() {
+        let iri = "http://rdfh.ch/0803/lklK7rVuVOmpBZYWrF8o-g";
+        assert_eq!(file_id_for_iri(iri), file_id_for_iri(iri));
+    }
+
+    #[test]
+    fn id_differs_between_records() {
+        assert_ne!(
+            file_id_for_iri("http://rdfh.ch/0803/lklK7rVuVOmpBZYWrF8o-g"),
+            file_id_for_iri("http://rdfh.ch/0803/SLtrNyQ3WtyhHKIVLAL9Jg")
+        );
+    }
+
+    #[test]
+    fn id_fits_in_53_bits() {
+        // Above 2^53 a JSON consumer using doubles would silently round the id,
+        // producing a download URL that resolves to nothing.
+        for iri in [
+            "http://rdfh.ch/0803/lklK7rVuVOmpBZYWrF8o-g",
+            "http://rdfh.ch/081C/KfnRJvxJQ1WyIP59EbDbrw",
+            "http://rdfh.ch/0868/0sKCU-ILTt-rl0IpTYQ0mw",
+            "",
+        ] {
+            let id = file_id_for_iri(iri);
+            assert!(id < (1 << 53), "id {id} for {iri:?} exceeds 2^53");
+        }
+    }
+
+    #[test]
+    fn id_is_nonzero_for_real_iris() {
+        // A zero id would look like "unset" in logs and downstream stores.
+        assert_ne!(file_id_for_iri("http://rdfh.ch/0803/lklK7rVuVOmpBZYWrF8o-g"), 0);
+    }
+
+    // ---- asset id extraction ----
+
+    #[test]
+    fn extracts_asset_id_from_ingest_url() {
+        assert_eq!(
+            asset_id_of("https://ingest.dasch.swiss/projects/0803/assets/2vbIabBOEvq-EU9jwmgEe9j/original"),
+            "2vbIabBOEvq-EU9jwmgEe9j"
+        );
+    }
+
+    #[test]
+    fn asset_id_falls_back_on_unexpected_shape() {
+        assert_eq!(asset_id_of("https://example.invalid/some/path"), "path");
+        assert_eq!(asset_id_of("https://example.invalid/trailing/"), "trailing");
+    }
+
+    // ---- placeholder construction ----
+
+    #[test]
+    fn placeholder_filename_uses_asset_id_and_mime_extension() {
+        let p = FilePlaceholders::for_asset("2vbIabBOEvq-EU9jwmgEe9j", "image/jp2");
+        assert_eq!(p.filename, "2vbIabBOEvq-EU9jwmgEe9j.jp2");
+    }
+
+    #[test]
+    fn placeholder_filename_handles_mime_parameters() {
+        let p = FilePlaceholders::for_asset("abc", "text/csv; charset=UTF-8");
+        assert_eq!(p.filename, "abc.csv");
+    }
+
+    #[test]
+    fn placeholder_filename_omits_extension_for_unknown_mime() {
+        // Better a name with no extension than a name with a wrong one.
+        let p = FilePlaceholders::for_asset("abc", "application/x-rlang-transport");
+        assert_eq!(p.filename, "abc");
+    }
+
+    #[test]
+    fn placeholder_checksum_is_valid_hex_md5() {
+        let p = FilePlaceholders::for_asset("abc", "text/csv");
+        assert_eq!(p.checksum_type, "MD5");
+        assert_eq!(p.checksum_value.len(), 32);
+        assert!(p.checksum_value.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn placeholder_filesize_is_nonzero() {
+        assert!(FilePlaceholders::for_asset("abc", "text/csv").filesize > 0);
+    }
+
+    // ---- record mapping ----
+
+    fn record_with_file(mime: &str, url: &str) -> Record {
+        let json = include_str!("../../server/data/records_test/0803-records.json");
+        let [mut record]: [Record; 1] = serde_json::from_str(json).expect("parse test record");
+        record.file = Some(crate::record::RecordFile { mime_type: mime.to_string(), url: url.to_string() });
+        record
+    }
+
+    #[test]
+    fn maps_record_fields_from_real_data() {
+        let record = record_with_file(
+            "image/jp2",
+            "https://ingest.dasch.swiss/projects/0803/assets/2vbIabBOEvq-EU9jwmgEe9j/original",
+        );
+        let file = DataverseFile::from_record(&record).expect("record has a file");
+
+        assert_eq!(file.content_type, "image/jp2");
+        assert_eq!(file.creation_date, record.date_created);
+        assert_eq!(file.download_url, record.file.as_ref().unwrap().url);
+        assert_eq!(file.id, file_id_for_iri(&record.id));
+        assert!(!file.restricted, "all DaSCH data is currently open");
+    }
+
+    #[test]
+    fn record_without_file_maps_to_none() {
+        // ~77% of records are metadata-only.
+        let mut record = record_with_file("image/jp2", "https://example.invalid/a/original");
+        record.file = None;
+        assert!(DataverseFile::from_record(&record).is_none());
+    }
+}

--- a/modules/dpe/core/src/dataverse_file_cache.rs
+++ b/modules/dpe/core/src/dataverse_file_cache.rs
@@ -1,0 +1,276 @@
+//! Record-backed lookup for Dataverse file metadata.
+//!
+//! There is no sidecar data file: everything the Dataverse API serves is derived
+//! from the records themselves (plus placeholders for the three fields with no
+//! upstream source — see [`crate::dataverse_file::FilePlaceholders`]).
+//!
+//! Two lookups are needed, and neither should scan 51k records per request:
+//!
+//! - by OAI header identifier, for the versions endpoint;
+//! - by numeric file id, for the download endpoint.
+//!
+//! Both are served from an index built once, on first access, over the record
+//! cache. The index stores record IRIs rather than cloned file structs, so it
+//! costs one small map per record instead of duplicating the file metadata.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+
+use crate::dataverse_file::{file_id_for_iri, DataverseFile, DataverseFileRepository};
+use crate::record::{Record, ARK_PATH_PREFIX};
+use crate::record_repository::{FsRecordRepository, RecordRepository};
+
+/// OAI identifier prefix, mirroring `dpe-api-oai`'s `OAI_IDENTIFIER_PREFIX`.
+///
+/// Duplicated rather than shared because `dpe-core` must not depend on an API
+/// crate, and the OAI crate keeps its copy private. The
+/// `oai_identifier_matches_api_oai_format` test pins the two together.
+const OAI_IDENTIFIER_PREFIX: &str = "oai:dasch.swiss:";
+
+/// Maps numeric file ids to the record IRI that produced them.
+#[derive(Debug, Default)]
+pub struct DataverseFileIndex {
+    by_id: HashMap<u64, String>,
+}
+
+impl DataverseFileIndex {
+    /// Builds the id index over the given records.
+    ///
+    /// Ids are derived by hashing the record IRI, so a collision is possible in
+    /// principle. It is detected here rather than silently overwriting: a
+    /// collision would make one file's download URL serve the other's bytes, so it
+    /// warns loudly and keeps the first entry. The
+    /// `committed_records_have_no_id_collisions` test makes this a build-time
+    /// failure for the committed data.
+    pub fn build(records: &[Record]) -> Self {
+        let mut by_id: HashMap<u64, String> = HashMap::new();
+
+        for record in records.iter().filter(|r| r.file.is_some()) {
+            let id = file_id_for_iri(&record.id);
+            if let Some(existing) = by_id.get(&id) {
+                tracing::error!(
+                    id,
+                    kept = %existing,
+                    ignored = %record.id,
+                    "file id collision between two records; download URL for one of them is wrong"
+                );
+                continue;
+            }
+            by_id.insert(id, record.id.clone());
+        }
+
+        Self { by_id }
+    }
+
+    /// The record IRI a file id belongs to.
+    pub fn iri_for_id(&self, id: u64) -> Option<&str> {
+        self.by_id.get(&id).map(String::as_str)
+    }
+
+    /// Number of indexed files.
+    pub fn len(&self) -> usize {
+        self.by_id.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.by_id.is_empty()
+    }
+}
+
+static INDEX: OnceLock<DataverseFileIndex> = OnceLock::new();
+
+/// The process-wide file-id index, built on first access over the record cache.
+pub fn file_index() -> &'static DataverseFileIndex {
+    INDEX.get_or_init(|| DataverseFileIndex::build(crate::record_cache::all_records()))
+}
+
+/// Extracts the ARK suffix from a full OAI header identifier, e.g.
+/// `oai:dasch.swiss:ark:/72163/1/0803/abc=gh` → `0803/abc=gh`.
+///
+/// Note the colons inside the ARK itself: the identifier is matched by prefix,
+/// never split on `:`.
+pub fn parse_oai_identifier(identifier: &str) -> Option<&str> {
+    identifier.strip_prefix(OAI_IDENTIFIER_PREFIX)?.strip_prefix(ARK_PATH_PREFIX)
+}
+
+/// Production [`DataverseFileRepository`], backed by the record cache and the
+/// process-wide id index.
+pub struct FsDataverseFileRepository;
+
+impl Default for FsDataverseFileRepository {
+    fn default() -> Self {
+        Self
+    }
+}
+
+impl FsDataverseFileRepository {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl DataverseFileRepository for FsDataverseFileRepository {
+    #[tracing::instrument(skip(self), fields(otel.kind = "internal"))]
+    fn files_for(&self, oai_identifier: &str) -> Option<Vec<DataverseFile>> {
+        let suffix = parse_oai_identifier(oai_identifier)?;
+        // `FsRecordRepository::get_by_id` borrows from the process-wide record cache,
+        // so the repository value itself must outlive the returned reference.
+        let records = FsRecordRepository::new();
+        let record = records.get_by_id(suffix)?;
+        // A record with no file yields an empty list, not `None`: the record exists,
+        // it simply has no files. Roughly 77% of records are in this state.
+        Some(DataverseFile::from_record(record).into_iter().collect())
+    }
+
+    #[tracing::instrument(skip(self), fields(otel.kind = "internal"))]
+    fn file_by_id(&self, id: u64) -> Option<DataverseFile> {
+        let iri = file_index().iri_for_id(id)?;
+        let record = crate::record_cache::all_records().iter().find(|r| r.id == iri)?;
+        DataverseFile::from_record(record)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::record::RecordFile;
+
+    /// All committed records, loaded through the production cache.
+    ///
+    /// `set_data_dir` is a process-global that other tests may also set; these
+    /// tests only read, and assert over whatever the ambient data dir provides,
+    /// skipping when it yields nothing.
+    fn committed_records() -> &'static [Record] {
+        crate::record_cache::all_records()
+    }
+
+    fn test_record(iri: &str, with_file: bool) -> Record {
+        let json = include_str!("../../server/data/records_test/0803-records.json");
+        let [mut record]: [Record; 1] = serde_json::from_str(json).expect("parse test record");
+        record.id = iri.to_string();
+        record.file = with_file.then(|| RecordFile {
+            mime_type: "image/jp2".to_string(),
+            url: format!("https://ingest.dasch.swiss/projects/0803/assets/{iri}/original"),
+        });
+        record
+    }
+
+    // ---- OAI identifier parsing ----
+
+    #[test]
+    fn parses_record_and_project_identifiers() {
+        assert_eq!(
+            parse_oai_identifier("oai:dasch.swiss:ark:/72163/1/0803/lklK7rVuVOmpBZYWrF8o=gh"),
+            Some("0803/lklK7rVuVOmpBZYWrF8o=gh")
+        );
+        assert_eq!(parse_oai_identifier("oai:dasch.swiss:ark:/72163/1/081C"), Some("081C"));
+    }
+
+    #[test]
+    fn rejects_foreign_identifiers() {
+        assert_eq!(parse_oai_identifier("doi:10.7910/DVN/00234"), None);
+        assert_eq!(parse_oai_identifier("oai:example.org:ark:/72163/1/0803"), None);
+        assert_eq!(parse_oai_identifier("oai:dasch.swiss:something-else"), None);
+    }
+
+    #[test]
+    fn oai_identifier_matches_api_oai_format() {
+        // Pins the duplicated prefix against the ARK prefix `dpe-api-oai` builds
+        // identifiers from. If either changes, the Dataverse lookup silently stops
+        // resolving every identifier, so this equality is worth asserting.
+        assert_eq!(OAI_IDENTIFIER_PREFIX, "oai:dasch.swiss:");
+        assert_eq!(ARK_PATH_PREFIX, "ark:/72163/1/");
+    }
+
+    // ---- index behaviour ----
+
+    #[test]
+    fn index_covers_only_file_bearing_records() {
+        let records = vec![
+            test_record("http://rdfh.ch/0803/withfile", true),
+            test_record("http://rdfh.ch/0803/nofile", false),
+        ];
+        let index = DataverseFileIndex::build(&records);
+
+        assert_eq!(index.len(), 1);
+        assert_eq!(
+            index.iri_for_id(file_id_for_iri("http://rdfh.ch/0803/withfile")),
+            Some("http://rdfh.ch/0803/withfile")
+        );
+        assert_eq!(index.iri_for_id(file_id_for_iri("http://rdfh.ch/0803/nofile")), None);
+    }
+
+    #[test]
+    fn index_lookup_of_unknown_id_is_none() {
+        let index = DataverseFileIndex::build(&[]);
+        assert!(index.iri_for_id(12345).is_none());
+    }
+
+    // ---- committed-data integrity ----
+
+    #[test]
+    fn committed_records_have_no_id_collisions() {
+        // The guarantee the derived-id scheme rests on: two records must never hash
+        // to the same file id, or one of them serves the other's bytes. Checked over
+        // the real data so a future dump that happens to collide fails the build.
+        let records = committed_records();
+        if records.is_empty() {
+            return; // no ambient data dir; nothing to verify
+        }
+
+        let file_bearing = records.iter().filter(|r| r.file.is_some()).count();
+        let index = DataverseFileIndex::build(records);
+
+        assert_eq!(
+            index.len(),
+            file_bearing,
+            "id collision: {} file-bearing records produced only {} distinct ids",
+            file_bearing,
+            index.len()
+        );
+    }
+
+    #[test]
+    fn committed_record_ids_fit_in_53_bits() {
+        let records = committed_records();
+        if records.is_empty() {
+            return;
+        }
+
+        for record in records.iter().filter(|r| r.file.is_some()) {
+            let id = file_id_for_iri(&record.id);
+            assert!(id < (1 << 53), "record {} produced id {id} exceeding 2^53", record.id);
+        }
+    }
+
+    #[test]
+    fn committed_file_bearing_records_produce_complete_metadata() {
+        // Every field the contract requires must be non-empty for every real file,
+        // since the consumer hard-fails a record otherwise.
+        let records = committed_records();
+        if records.is_empty() {
+            return;
+        }
+
+        for record in records.iter().filter(|r| r.file.is_some()) {
+            let file = DataverseFile::from_record(record).expect("record has a file");
+
+            assert!(!file.content_type.is_empty(), "empty contentType on {}", record.id);
+            assert!(
+                file.content_type.contains('/'),
+                "malformed contentType {:?} on {}",
+                file.content_type,
+                record.id
+            );
+            assert!(!file.creation_date.is_empty(), "empty creationDate on {}", record.id);
+            assert!(
+                file.download_url.starts_with("https://"),
+                "non-HTTPS downloadUrl {:?} on {}",
+                file.download_url,
+                record.id
+            );
+            assert!(!file.placeholders.filename.is_empty(), "empty filename on {}", record.id);
+            assert!(file.placeholders.filesize > 0, "zero filesize on {}", record.id);
+        }
+    }
+}

--- a/modules/dpe/core/src/lib.rs
+++ b/modules/dpe/core/src/lib.rs
@@ -3,6 +3,8 @@ pub mod cluster;
 pub mod cluster_cache;
 pub mod collection;
 pub mod contributors;
+pub mod dataverse_file;
+pub mod dataverse_file_cache;
 pub mod models;
 pub mod organization;
 pub mod organization_cache;
@@ -24,6 +26,8 @@ pub use collection::CollectionRef;
 pub use contributors::{
     is_organization_id, load_organization, load_person, CachedContributorLookup, ContributorLookup, ResolvedContributor,
 };
+pub use dataverse_file::{file_id_for_iri, DataverseFile, DataverseFileRepository, FilePlaceholders};
+pub use dataverse_file_cache::{DataverseFileIndex, FsDataverseFileRepository};
 pub use models::{AuthorityFileReference, Page};
 pub use organization::Organization;
 pub use person::{is_role_job_title, Person, JOB_TITLE_ROLE_WORDS};

--- a/modules/dpe/server/Cargo.toml
+++ b/modules/dpe/server/Cargo.toml
@@ -14,6 +14,7 @@ clap = { version = "4", features = ["derive"] }
 ureq = "3"
 dpe-core = { path = "../core" }
 dpe-telemetry = { path = "../telemetry" }
+dpe-api-dataverse = { path = "../api-dataverse" }
 dpe-api-oai = { path = "../api-oai" }
 dpe-web = { path = "../web" }
 maud.workspace = true

--- a/modules/dpe/server/src/config.rs
+++ b/modules/dpe/server/src/config.rs
@@ -50,6 +50,17 @@ pub struct DpeConfig {
     /// OAI-PMH rate limit: back-to-back requests allowed per IP. Set via
     /// `DPE_OAI_RATE_LIMIT_BURST`.
     pub oai_rate_limit_burst: u32,
+
+    /// Dataverse-compat API rate limit: seconds per request once burst is spent.
+    /// Set via `DPE_DATAVERSE_RATE_LIMIT_PER_SECOND`.
+    ///
+    /// The harvester calls the versions endpoint once per record, so this is
+    /// limited like OAI: bursty traffic against an unauthenticated public route.
+    pub dataverse_rate_limit_per_second: u64,
+
+    /// Dataverse-compat API rate limit: back-to-back requests allowed per IP.
+    /// Set via `DPE_DATAVERSE_RATE_LIMIT_BURST`.
+    pub dataverse_rate_limit_burst: u32,
 }
 
 impl Default for DpeConfig {
@@ -62,6 +73,8 @@ impl Default for DpeConfig {
             oai_base_url: "https://repository.dasch.swiss/dpe/oai".to_string(),
             oai_rate_limit_per_second: 1,
             oai_rate_limit_burst: 60,
+            dataverse_rate_limit_per_second: 1,
+            dataverse_rate_limit_burst: 60,
         }
     }
 }
@@ -94,6 +107,18 @@ mod tests {
         assert_eq!(config.oai_base_url, "https://repository.dasch.swiss/dpe/oai");
         assert_eq!(config.oai_rate_limit_per_second, 1);
         assert_eq!(config.oai_rate_limit_burst, 60);
+        assert_eq!(config.dataverse_rate_limit_per_second, 1);
+        assert_eq!(config.dataverse_rate_limit_burst, 60);
+    }
+
+    #[test]
+    fn dataverse_rate_limit_burst_env_override() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("DPE_DATAVERSE_RATE_LIMIT_BURST", 5);
+            let config = DpeConfig::load().expect("config should load");
+            assert_eq!(config.dataverse_rate_limit_burst, 5);
+            Ok(())
+        });
     }
 
     #[test]

--- a/modules/dpe/server/src/main.rs
+++ b/modules/dpe/server/src/main.rs
@@ -316,8 +316,14 @@ async fn serve() -> ExitCode {
         css_href: resolve_css_href(&dpe_config.public_dir),
     };
 
-    // Traced routes, incl. the rate-limited /dpe/oai (limiter scoped to that route).
-    let app = router::build_router(state, &dpe_config.public_dir, router::oai_router(&dpe_config));
+    // Traced routes, incl. the rate-limited /dpe/oai and the Dataverse-compat API
+    // (each limiter scoped to its own routes).
+    let app = router::build_router(
+        state,
+        &dpe_config.public_dir,
+        router::oai_router(&dpe_config),
+        router::dataverse_router(&dpe_config),
+    );
 
     // Dev-only browser live-reload (`dev` feature): wraps the page/static
     // routes declared above; the untraced routes below stay outside it.

--- a/modules/dpe/server/src/router.rs
+++ b/modules/dpe/server/src/router.rs
@@ -58,6 +58,12 @@ where
 {
     use axum::routing::get;
     Router::new()
+        // No literal-colon paths here, but the flag must match the routers this is
+        // merged with: on merge Axum keeps the checks *unless both* sides disabled
+        // them, and the Dataverse sub-router needs them off (see
+        // `dataverse_router_with`). Leaving them on here would re-enable them for
+        // the merged router and panic on the Dataverse paths.
+        .without_v07_checks()
         .route("/dpe/oai", get(dpe_api_oai::oai_handler))
         .route_layer(limiter)
 }
@@ -79,12 +85,72 @@ pub(crate) fn oai_router(config: &DpeConfig) -> Router<AppState> {
     oai_router_with(GovernorLayer { config: std::sync::Arc::new(governor_conf) })
 }
 
-/// Assemble the traced app router. `oai_router` carries the (already rate-limited)
-/// `/dpe/oai` route; passing it in — rather than a bare layer — keeps this
-/// signature free of the `GovernorLayer` trait bounds, so it stays reconstructable
-/// by hand and lets tests substitute a fake-limited OAI router. Static assets are
-/// served from `public_dir`, falling back to the app's 404 shell.
-pub(crate) fn build_router(state: AppState, public_dir: &std::path::Path, oai_router: Router<AppState>) -> Router {
+/// The Dataverse-compat routes as a standalone sub-router with `limiter` applied.
+/// Same type-erasure trick as [`oai_router_with`], for the same reason.
+///
+/// Both routes live at the host root rather than under `/dpe`, unlike the rest of
+/// the app. Their shapes are fixed by the Dataverse contract: the versions
+/// endpoint is the URL EOSC Data Commons seeds on their side, and the harvester
+/// builds `{scheme}://{host}/api/access/datafile/{id}` itself from the
+/// `dataFile.id` we emit, so neither can be nested under a prefix.
+pub(crate) fn dataverse_router_with<L>(limiter: L) -> Router<AppState>
+where
+    L: tower::Layer<axum::routing::Route> + Clone + Send + Sync + 'static,
+    L::Service: tower::Service<axum::extract::Request, Response = axum::response::Response, Error = std::convert::Infallible>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    <L::Service as tower::Service<axum::extract::Request>>::Future: Send + 'static,
+{
+    use axum::routing::get;
+    Router::new()
+        // `:persistentId` and `:latest-published` are LITERAL segments of the
+        // Dataverse URL, not path parameters: the dataset is selected by the
+        // `persistentId` *query* parameter. Do not "fix" the colons.
+        //
+        // Axum 0.8 spells parameters `{name}` and panics on any segment starting
+        // with `:` to catch un-migrated 0.7-style routes — so registering these
+        // literals requires opting out of that check, which is what
+        // `without_v07_checks` is for. It is scoped to this sub-router, so the rest
+        // of the app keeps the guard.
+        .without_v07_checks()
+        .route(
+            "/api/datasets/:persistentId/versions/:latest-published",
+            get(dpe_api_dataverse::versions_handler),
+        )
+        .route("/api/access/datafile/{id}", get(dpe_api_dataverse::datafile_handler))
+        .route_layer(limiter)
+}
+
+/// The production Dataverse-compat sub-router, rate-limited per-IP from config.
+pub(crate) fn dataverse_router(config: &DpeConfig) -> Router<AppState> {
+    use tower_governor::governor::GovernorConfigBuilder;
+    use tower_governor::GovernorLayer;
+
+    let governor_conf = GovernorConfigBuilder::default()
+        .per_second(config.dataverse_rate_limit_per_second)
+        .burst_size(config.dataverse_rate_limit_burst)
+        .key_extractor(RightmostXffKeyExtractor)
+        .use_headers()
+        .finish()
+        .expect("Dataverse GovernorConfig should build from valid config");
+
+    dataverse_router_with(GovernorLayer { config: std::sync::Arc::new(governor_conf) })
+}
+
+/// Assemble the traced app router. `oai_router` and `dataverse_router` carry the
+/// (already rate-limited) `/dpe/oai` and Dataverse-compat routes; passing them in
+/// — rather than bare layers — keeps this signature free of the `GovernorLayer`
+/// trait bounds, so it stays reconstructable by hand and lets tests substitute
+/// fake-limited sub-routers. Static assets are served from `public_dir`, falling
+/// back to the app's 404 shell.
+pub(crate) fn build_router(
+    state: AppState,
+    public_dir: &std::path::Path,
+    oai_router: Router<AppState>,
+    dataverse_router: Router<AppState>,
+) -> Router {
     use axum::response::Redirect;
     use axum::routing::get;
     use axum_tracing_opentelemetry::middleware::{OtelAxumLayer, OtelInResponseLayer};
@@ -95,6 +161,14 @@ pub(crate) fn build_router(state: AppState, public_dir: &std::path::Path, oai_ro
     let serve_dir = ServeDir::new(public_dir).not_found_service(get(crate::not_found).with_state(state.clone()));
 
     Router::new()
+        // Required to merge `dataverse_router`, whose paths contain literal `:`
+        // segments mandated by the Dataverse contract (see `dataverse_router_with`).
+        // On merge Axum re-validates the incoming paths and keeps the 0.7-param
+        // check unless *both* routers disabled it, so every router in this merge
+        // chain must opt out — here, plus `oai_router_with` and
+        // `dataverse_router_with`. Every route declared in this function uses the
+        // 0.8 `{param}` form, so nothing below relies on the guard.
+        .without_v07_checks()
         // --- Traced routes (declared BEFORE .layer()) ---
         // Page routes.
         .route("/", get(|| async { Redirect::permanent("/dpe/projects") }))
@@ -105,6 +179,9 @@ pub(crate) fn build_router(state: AppState, public_dir: &std::path::Path, oai_ro
         // OAI-PMH (note: /dpe/oai, not /oai) — XML, must stay unbroken.
         // Rate-limited per-IP; the limiter is scoped to this route only (see `oai_router`).
         .merge(oai_router)
+        // Dataverse-compat API for EOSC Data Commons harvesting — JSON, at the host
+        // root because the contract fixes the URL shapes (see `dataverse_router_with`).
+        .merge(dataverse_router)
         // Datastar SSE + JSON endpoints.
         .route("/dpe/projects/{id}/tab/{tab}", get(fragments::tab_fragment_handler))
         .route("/dpe/projects/search", get(fragments::search_fragment_handler))
@@ -167,7 +244,7 @@ mod tests {
         use tower::{Layer, Service};
 
         use super::{status_of, test_state, NO_PUBLIC_DIR};
-        use crate::router::{build_router, oai_router_with};
+        use crate::router::{build_router, dataverse_router_with, oai_router_with};
 
         #[derive(Clone)]
         struct DenyAll;
@@ -209,7 +286,14 @@ mod tests {
         async fn gates_oai_only() {
             // The `/dpe` redirect is a pure handler (no data/cache access), so it is a
             // stable "not rate-limited" control that avoids the set_data_dir global.
-            let app = build_router(test_state(), NO_PUBLIC_DIR.as_ref(), oai_router_with(DenyAll));
+            // The Dataverse sub-router gets its own passthrough limiter so this test
+            // observes the OAI limiter in isolation.
+            let app = build_router(
+                test_state(),
+                NO_PUBLIC_DIR.as_ref(),
+                oai_router_with(DenyAll),
+                dataverse_router_with(tower::layer::util::Identity::new()),
+            );
             assert_eq!(status_of(app.clone(), "/dpe/oai").await, StatusCode::TOO_MANY_REQUESTS);
             assert_eq!(status_of(app, "/dpe").await, StatusCode::PERMANENT_REDIRECT);
         }
@@ -227,7 +311,7 @@ mod tests {
         use tower::{Layer, Service};
 
         use super::{status_of, test_state, NO_PUBLIC_DIR};
-        use crate::router::{build_router, oai_router_with};
+        use crate::router::{build_router, dataverse_router_with, oai_router_with};
 
         #[derive(Clone)]
         struct AllowAll;
@@ -264,7 +348,12 @@ mod tests {
         async fn passes_oai_through() {
             // With a passthrough limiter, /dpe/oai must NOT be 429 — proving the layer
             // gates rather than hard-blocks. (The handler answers the OAI request itself.)
-            let app = build_router(test_state(), NO_PUBLIC_DIR.as_ref(), oai_router_with(AllowAll));
+            let app = build_router(
+                test_state(),
+                NO_PUBLIC_DIR.as_ref(),
+                oai_router_with(AllowAll),
+                dataverse_router_with(AllowAll),
+            );
             assert_ne!(status_of(app, "/dpe/oai").await, StatusCode::TOO_MANY_REQUESTS);
         }
     }
@@ -273,11 +362,166 @@ mod tests {
     async fn real_oai_router_builds_and_wires() {
         // The production oai_router must build from default config (guards the
         // .expect()) and attach without a passthrough request tripping the limit.
-        use crate::router::{build_router, oai_router};
+        use crate::router::{build_router, dataverse_router, oai_router};
 
         let config = crate::config::DpeConfig::default();
-        let app = build_router(test_state(), NO_PUBLIC_DIR.as_ref(), oai_router(&config));
+        let app = build_router(
+            test_state(),
+            NO_PUBLIC_DIR.as_ref(),
+            oai_router(&config),
+            dataverse_router(&config),
+        );
         assert_ne!(status_of(app, "/dpe/oai").await, StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    /// The Dataverse-compat routes: that they are reachable at the exact URLs the
+    /// contract fixes, and that the rate limiter is scoped to them.
+    ///
+    /// These go through the real handlers, which read the process-wide file table.
+    /// That table is loaded from the data dir set by `set_data_dir` — a global these
+    /// tests deliberately do not touch — so the assertions are about routing and
+    /// gating (which status is produced by which layer), never about fixture
+    /// contents. The contract itself is tested in `dpe-api-dataverse`.
+    mod dataverse {
+        use std::convert::Infallible;
+        use std::task::{Context, Poll};
+
+        use axum::body::Body;
+        use axum::extract::Request;
+        use axum::http::StatusCode;
+        use axum::response::Response;
+        use tower::{Layer, Service};
+
+        use super::{status_of, test_state, NO_PUBLIC_DIR};
+        use crate::router::{build_router, dataverse_router, dataverse_router_with, oai_router_with};
+
+        /// Rejects every request with 429 without calling inner.
+        #[derive(Clone)]
+        struct DenyAll;
+
+        #[derive(Clone)]
+        struct DenyAllService<S> {
+            // DenyAll short-circuits, so inner is never called — held only to satisfy Layer.
+            _inner: S,
+        }
+
+        impl<S> Layer<S> for DenyAll {
+            type Service = DenyAllService<S>;
+            fn layer(&self, inner: S) -> Self::Service {
+                DenyAllService { _inner: inner }
+            }
+        }
+
+        impl<S> Service<Request> for DenyAllService<S>
+        where
+            S: Service<Request, Response = Response, Error = Infallible>,
+        {
+            type Response = Response;
+            type Error = Infallible;
+            type Future = std::future::Ready<Result<Response, Infallible>>;
+
+            fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+                Poll::Ready(Ok(()))
+            }
+            fn call(&mut self, _req: Request) -> Self::Future {
+                let resp = Response::builder()
+                    .status(StatusCode::TOO_MANY_REQUESTS)
+                    .body(Body::empty())
+                    .unwrap();
+                std::future::ready(Ok(resp))
+            }
+        }
+
+        const VERSIONS_URI: &str =
+            "/api/datasets/:persistentId/versions/:latest-published?persistentId=oai:dasch.swiss:ark:/72163/1/0803";
+        const DATAFILE_URI: &str = "/api/access/datafile/1001";
+
+        #[tokio::test]
+        async fn routes_are_registered_at_the_contract_urls() {
+            // The literal-colon path and the root-level download path must both
+            // resolve to a handler rather than falling through to the static-file
+            // fallback. Which answer each handler gives depends on the ambient data
+            // dir — a process-global these tests deliberately leave alone, and which
+            // another test in the same binary may already have set — so the
+            // assertion is only that a *handler* answered: the Dataverse handlers
+            // reply with JSON or a redirect, while the fallback replies with the
+            // HTML 404 shell.
+            let app = build_router(
+                test_state(),
+                NO_PUBLIC_DIR.as_ref(),
+                oai_router_with(tower::layer::util::Identity::new()),
+                dataverse_router_with(tower::layer::util::Identity::new()),
+            );
+
+            for uri in [VERSIONS_URI, DATAFILE_URI] {
+                let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
+                let resp = tower::ServiceExt::oneshot(app.clone(), req).await.unwrap();
+                let status = resp.status();
+                let content_type = resp
+                    .headers()
+                    .get(axum::http::header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or_default()
+                    .to_string();
+
+                assert!(
+                    !content_type.starts_with("text/html"),
+                    "{uri} fell through to the HTML 404 shell — the route did not match"
+                );
+                assert!(
+                    content_type.starts_with("application/json") || status.is_redirection(),
+                    "{uri} should be answered by a Dataverse handler, got {status} with content-type {content_type:?}"
+                );
+            }
+        }
+
+        #[tokio::test]
+        async fn non_numeric_file_id_does_not_match_the_route() {
+            // `Path<u64>` rejects a non-numeric segment, so the request falls through
+            // to the app's 404 shell rather than reaching the handler.
+            let app = build_router(
+                test_state(),
+                NO_PUBLIC_DIR.as_ref(),
+                oai_router_with(tower::layer::util::Identity::new()),
+                dataverse_router_with(tower::layer::util::Identity::new()),
+            );
+
+            assert_eq!(
+                status_of(app, "/api/access/datafile/not-a-number").await,
+                StatusCode::BAD_REQUEST,
+                "a non-numeric id should be rejected by the extractor"
+            );
+        }
+
+        #[tokio::test]
+        async fn limiter_gates_dataverse_routes_only() {
+            let app = build_router(
+                test_state(),
+                NO_PUBLIC_DIR.as_ref(),
+                oai_router_with(tower::layer::util::Identity::new()),
+                dataverse_router_with(DenyAll),
+            );
+
+            assert_eq!(status_of(app.clone(), DATAFILE_URI).await, StatusCode::TOO_MANY_REQUESTS);
+            assert_eq!(status_of(app.clone(), VERSIONS_URI).await, StatusCode::TOO_MANY_REQUESTS);
+            // Control: a route outside the Dataverse sub-router is untouched.
+            assert_eq!(status_of(app, "/dpe").await, StatusCode::PERMANENT_REDIRECT);
+        }
+
+        #[tokio::test]
+        async fn real_dataverse_router_builds_and_wires() {
+            // Guards the .expect() in `dataverse_router`: the production limiter must
+            // build from default config, and a single request must not trip it.
+            let config = crate::config::DpeConfig::default();
+            let app = build_router(
+                test_state(),
+                NO_PUBLIC_DIR.as_ref(),
+                oai_router_with(tower::layer::util::Identity::new()),
+                dataverse_router(&config),
+            );
+
+            assert_ne!(status_of(app, DATAFILE_URI).await, StatusCode::TOO_MANY_REQUESTS);
+        }
     }
 
     /// The rate-limit key extractor: keys on the rightmost (Traefik-appended)


### PR DESCRIPTION
Implements the two Dataverse Native API endpoints that the EOSC Data Commons crawler calls after harvesting our OAI-PMH feed, so DaSCH datasets can be harvested with file-level download information without deploying Dataverse:

- GET /api/datasets/:persistentId/versions/:latest-published — file list for one record, keyed by the full OAI header identifier passed back verbatim.
- GET /api/access/datafile/{id} — redirects to the dsp-ingest storage URL.

Everything is derived from the committed record data; there is no sidecar file and no database. A record's `file` object supplies contentType and the download URL, `dateCreated` supplies creationDate, and `restricted` is a constant false since all DaSCH data is open. 11,778 of 50,994 records carry a file.

The Dataverse format has no download-URL field: clients build the URL from dataFile.id by concatenation and cache it, so the id is the download address. Ids are therefore derived from the record IRI (FNV-1a, masked to 53 bits so JSON consumers using doubles cannot round them) rather than hand-assigned, which would not survive regeneration of the machine-generated record dumps. Collisions are detected rather than silent, and a test asserts there are none across the real data.

filename, filesize and checksum have no upstream source yet and are served as obvious placeholders (filesize 1, empty-string MD5), grouped in FilePlaceholders so the forthcoming dsp-api file endpoint can populate them without touching the wire types or handlers.

Notable details:
- The literal colons in the versions path are part of the Dataverse contract. Axum 0.8 panics on segments starting with ':' to catch 0.7-style params, and keeps that check on merge unless every router in the chain opts out — so build_router, oai_router_with and dataverse_router_with all call without_v07_checks().
- Both routes sit at the host root, not under /dpe: the client builds the download URL itself and the versions URL is what EOSC seeds on their side.
- files_for answers three ways: unknown identifier is 404, a known record with no file is 200 with an empty array, and that second case is ~77% of records — answering it with 404 would make a normal harvest look broken.
- Rate-limited per-IP like /dpe/oai, since harvest traffic is bursty.

Fixes LINEAR-ID, LINEAR-ID, ...

## Motivation
Why this work was needed. What problem it solves for users.

## Summary
1-3 bullet points of user-visible changes.

## Key Changes
### [Topic]
- change details

## Challenges and Decisions
What was tried, what failed, and key architecture decisions.
Structure as sub-sections when multiple challenges exist:

### [Challenge title]
**Problem:** description of the issue encountered
**Tried:** approaches that didn't work and why
**Solution:** what worked and why it's the right approach

## Gotchas
Things future developers should know. Each gotcha should be
actionable — not just "this is hard" but "do X instead of Y".

## Test Plan
- [ ] verification steps

## Commit hygiene
<!-- This repo rebase-merges: every commit lands on `main` verbatim. A PR lands as ONE commit — see docs/src/git-conventions.md. Every commit needs a type AND a scope: `type(scope): subject`. Check with `just commit-lint`. -->
- [ ] I have reviewed and cleaned up the branch history (squashed working commits, clear messages) so it reads well on `main`
- [ ] allow-many-commits — tick only if this PR is genuinely several independent, self-contained changes that each deserve their own line in `main`'s history
