### PR TITLE
fix(ci): gate the Claude workflow to org members (DEV-6884)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,10 +17,21 @@ concurrency:
 
 jobs:
   # Job 1: Dedicated code review with predefined prompt which triggers on commands: '@claude review' posted in the comments of a PR
+  #
+  # Both jobs gate on author_association (DEV-6884): comment-triggered workflows always run
+  # from the default branch with secrets available, and the repo setting "Require approval
+  # for all external contributors" gates only fork pull_request events — not comment events,
+  # so without this gate any GitHub account that can comment could spend the org's API key.
+  # CONTRIBUTOR is deliberately outside the allowlist; a member can trigger on an outside
+  # contributor's behalf. A blocked trigger skips silently, like a non-matching comment.
   claude-code-review:
     if: |
       (github.event.issue.pull_request || github.event.pull_request) &&
-      (contains(github.event.comment.body, '@claude review') || contains(github.event.review.body, '@claude review'))
+      (contains(github.event.comment.body, '@claude review') || contains(github.event.review.body, '@claude review')) &&
+      (
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) ||
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -80,10 +91,23 @@ jobs:
 
   # Job 2: General Claude assistant (flexible) available on this repository PRs, issues etc. triggered by "@claude <PROMPT>"
   claude-general:
+    # The allowlist check sits inside each trigger arm instead of being AND-ed once across
+    # all three: issue_comment payloads also carry issue.author_association, so a single
+    # OR-ed check would let a stranger's comment pass on any issue or PR a member opened.
     if: |
-      (contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude review')) ||
-      (contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '@claude review')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude review') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        contains(github.event.review.body, '@claude') && !contains(github.event.review.body, '@claude review') &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association)
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
[DEV-6884](https://linear.app/dasch/issue/DEV-6884)

## Summary
- Same org-wide gap as dasch-swiss/dsp-app#3337: this Claude workflow inherited the Anthropic quickstart without an author check, and comment-triggered workflows always run from the default branch with secrets available — so any GitHub account able to comment could fire the job and spend the org's `ANTHROPIC_API_KEY`.
- The triggering author must now be `OWNER`, `MEMBER` or `COLLABORATOR`; anything else (including `CONTRIBUTOR`, per the decision in DEV-6884) skips silently, exactly like a non-matching comment.

## Changes
- The allowlist check sits inside each trigger arm: `issue_comment` payloads also carry `issue.author_association` (the issue/PR author's), so a single OR-ed check would pass a stranger's comment on any issue or PR a member opened.

## Test Plan
- YAML parse validated locally; `contains(fromJSON('[...]'), ...author_association)` is the documented GitHub Actions idiom.
- Live verification (a member's trigger still fires) is only possible after merge — comment-event workflows run the workflow file from the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)