### PR TITLE
fix(dpe-data): correct solec (0868) data link and contact email

### DIFF
--- a/modules/dpe/server/data/persons/person-360.json
+++ b/modules/dpe/server/data/persons/person-360.json
@@ -28,5 +28,5 @@
         "organization-056",
         "organization-032"
     ],
-    "email": "rita.gautschy@dasch.swiss"
+    "email": "rita.gautschy@unibas.ch"
 }

--- a/modules/dpe/server/data/projects/0868_solec.json
+++ b/modules/dpe/server/data/projects/0868_solec.json
@@ -13,6 +13,7 @@
     "startDate": "2008-11-01",
     "endDate": "2010-10-31",
     "url": [
+        "https://app.dasch.swiss/project/Ooez-W-1Q5i4rg54GAwGpw",
         "https://gautschy.ch/~rita/archast/solec/solec.html"
     ],
     "howToCite": "Gautschy R. (2026). Canon of solar eclipses from 2501 BCE to 1000 CE [Dataset]. DaSCH. https://ark.dasch.swiss/ark:/72163/1/0868.",


### PR DESCRIPTION
Fixes DEV-6984

## Motivation

On https://repository.dasch.swiss/dpe/projects/0868 the **"Discover Project Data"** button points at `https://gautschy.ch/~rita/archast/solec/solec.html` — Rita Gautschy's own project webpage. There is no route to the data on DSP at all, and no "External Project Website" button, so the external page is being advertised as the archived dataset.

The page also renders `mailto:rita.gautschy@dasch.swiss` as the contact. The archived v1 record (`dsp-meta/data/json/solec.json:202`) held `rita.gautschy@unibas.ch`; the v1→v2 migration (`470c473f`) replaced it with a DaSCH address. This restores her institutional one.

## Summary

- 0868 now renders two buttons: "Discover Project Data" → the project on DSP-APP, "External Project Website" → the existing gautschy.ch page.
- The contact and contributor email for Rita Gautschy is `rita.gautschy@unibas.ch`.

## Key Changes

### `modules/dpe/server/data/projects/0868_solec.json`
- `url[0]` is now `https://app.dasch.swiss/project/Ooez-W-1Q5i4rg54GAwGpw`; the existing gautschy.ch URL moves to `url[1]`.

### `modules/dpe/server/data/persons/person-360.json`
- `email` restored to `rita.gautschy@unibas.ch`.

## Challenges and Decisions

### The shortcode URL form would have shipped a dead link

**Problem:** the obvious URL is `https://app.dasch.swiss/project/0868`, and 11 project files already use that shortcode form.

**Tried:** it 404s. DSP-APP's only project route is `project/:uuid` (`dsp-das/apps/dsp-app/src/app/app.routes.ts:49`), and `ProjectService.uuidToIri()` concatenates `http://rdfh.ch/projects/` + the path segment with no shortcode lookup, so `/project/0868` asks the API for `http://rdfh.ch/projects/0868` and `ProjectPageGuard` redirects to `/404`. The 11 files that use the shortcode form work only because those are legacy projects whose IRI literally *is* their shortcode (0102, 082A, 0807, 081C…).

**Solution:** use the project's IRI segment. `GET /admin/projects/shortcode/0868` gives `http://rdfh.ch/projects/Ooez-W-1Q5i4rg54GAwGpw`, and `GET /admin/projects/iri/…Ooez-W-1Q5i4rg54GAwGpw` returns 200. Same form as #318 (`afe7ab98`) used for 0863.

### Editing the shared person record rather than duplicating it

`person-360` is the `contactPoint` only on 0868, but is also an attribution on `0861_Proto4DigEd` and `085E_hamidi`, so their contributors tabs now show the unibas.ch address too — intended, since it is her institutional address. A solec-scoped second Rita record was rejected: `validate` keys on filename, not on the internal `"id"`, so a duplicate person entity would pass unnoticed.

### Legacy array kept over the object form

`url` also accepts `{"type":"URL","url":"…"}` plus a separate `secondaryUrl` key, which is the shape documented at `docs/src/dpe/metadata-model.md:652-653`. Kept the legacy array: 83 of 85 project files use it, no committed file currently exercises the `Value::Object` branch, and this fix does not need to be the one that changes that.

## Gotchas

- **`url` is positional, and nothing validates the semantics.** `parse_url_value()` (`modules/dpe/core/src/project.rs:23-42`) takes `url[0]` → primary and `url[1]` → secondary; `project_header.rs:38-67` then labels them "Discover Project Data" and "External Project Website". Put an external site first and it is silently advertised as the DSP data. `just validate-data` checks cross-references and deserialization only. 10 other projects are in this state — tracked in DEV-6985.
- **When adding a DSP link, derive the path segment from the project IRI, not the shortcode.** Check `GET https://api.dasch.swiss/admin/projects/shortcode/<shortcode>` first. Only projects created before IRIs went UUID-based have shortcode IRIs.
- **`just validate-data` is not wired into CI** — only `just check` and `just test` run there, so run it locally for any data edit.
- **Project data is cached at server startup** (`project_cache.rs:36-39`), so `just dev` hot-reload does not pick up JSON edits; restart the server.

## Test Plan

- [x] `just validate-data` → `Validated: 85 projects, 50994 records, 416 persons, 142 organizations / All data files are valid.`
- [x] `just test` → 532 tests, 0 failures. No snapshot churn (snapshots pin 0803 and 0102).
- [x] `just check` → `just --fmt`, maudfmt no-op check and `cargo +nightly fmt --check --all` clean; `cargo clippy --all-features -D warnings` clean. (`cargo machete` is not installed locally; a JSON-only change cannot affect dependencies.)
- [x] Ran the server against the edited data and fetched `/dpe/projects/0868`: primary `btn btn-primary` → `https://app.dasch.swiss/project/Ooez-W-1Q5i4rg54GAwGpw`, outline `btn btn-outline` → `https://gautschy.ch/~rita/archast/solec/solec.html`, sidebar contact → `mailto:rita.gautschy@unibas.ch`.
- [x] `https://api.dasch.swiss/admin/projects/iri/http%3A%2F%2Frdfh.ch%2Fprojects%2FOoez-W-1Q5i4rg54GAwGpw` → 200.
- [x] Contributors tab on 0868, 0861 and 085E all render `rita.gautschy@unibas.ch`.
- [ ] Reviewer: open the DSP-APP link and confirm it loads the solec project.

## Commit hygiene
- [x] I have reviewed and cleaned up the branch history (squashed working commits, clear messages) so it reads well on `main`
- [ ] allow-many-commits — tick only if this PR is genuinely several independent, self-contained changes that each deserve their own line in `main`'s history
