### PR TITLE
fix(dpe-data): stop advertising external websites as DSP data

### DIFF
--- a/modules/dpe/server/data/projects/0805_tdk.json
+++ b/modules/dpe/server/data/projects/0805_tdk.json
@@ -11,9 +11,10 @@
     },
     "startDate": "2015-03-01",
     "endDate": "MISSING",
-    "url": [
-        "https://aegyptologie.philhist.unibas.ch/de/forschung/forschungsprojekte/university-of-basel-kings-valley-project/"
-    ],
+    "secondaryUrl": {
+        "type": "URL",
+        "url": "https://aegyptologie.philhist.unibas.ch/de/forschung/forschungsprojekte/university-of-basel-kings-valley-project/"
+    },
     "howToCite": "University of Basel Kings’ Valley Project Online (UBKVP), 2021, DaSCH. ark.dasch.swiss/ark:/72163/1/0805",
     "accessRights": {
         "accessRights": "Full Open Access"

--- a/modules/dpe/server/data/projects/0816_vitrocentre.json
+++ b/modules/dpe/server/data/projects/0816_vitrocentre.json
@@ -11,9 +11,10 @@
     },
     "startDate": "2014-01-01",
     "endDate": "MISSING",
-    "url": [
-        "https://vitrosearch.ch/en"
-    ],
+    "secondaryUrl": {
+        "type": "URL",
+        "url": "https://vitrosearch.ch/en"
+    },
     "howToCite": "Vitrocentre Romont has to be mentioned, in regards to images: Vitrocentre Romont and where mentioned the photographer has to be mentioned",
     "accessRights": {
         "accessRights": "Open Access with Restrictions"

--- a/modules/dpe/server/data/projects/081B_delille.json
+++ b/modules/dpe/server/data/projects/081B_delille.json
@@ -11,9 +11,10 @@
     },
     "startDate": "2015-02-01",
     "endDate": "2019-01-31",
-    "url": [
-        "https://delille.philhist.unibas.ch/"
-    ],
+    "secondaryUrl": {
+        "type": "URL",
+        "url": "https://delille.philhist.unibas.ch/"
+    },
     "howToCite": "Reconstruire Delille, 2021",
     "accessRights": {
         "accessRights": "Open Access with Restrictions"

--- a/modules/dpe/server/data/projects/083C_eHKKA.json
+++ b/modules/dpe/server/data/projects/083C_eHKKA.json
@@ -11,9 +11,10 @@
     },
     "startDate": "1991-04-01",
     "endDate": "2013-07-31",
-    "url": [
-        "https://www.ehkka.ch/ehkka/"
-    ],
+    "secondaryUrl": {
+        "type": "URL",
+        "url": "https://www.ehkka.ch/ehkka/"
+    },
     "howToCite": "Morgenthaler et al., historisch-kritsche Kellerausgabe online, 1996-2013",
     "accessRights": {
         "accessRights": "Full Open Access"

--- a/modules/dpe/server/data/projects/0843_woposs.json
+++ b/modules/dpe/server/data/projects/0843_woposs.json
@@ -11,9 +11,10 @@
     },
     "startDate": "2019-02-01",
     "endDate": "2025-01-31",
-    "url": [
-        "https://woposs.unine.ch/"
-    ],
+    "secondaryUrl": {
+        "type": "URL",
+        "url": "https://woposs.unine.ch/"
+    },
     "howToCite": "The WoPoss modality corpus. University of Neuchâtel. SNSF. Distributed by DaSCH.",
     "accessRights": {
         "accessRights": "Full Open Access"

--- a/modules/dpe/server/data/projects/084D_gossembrot.json
+++ b/modules/dpe/server/data/projects/084D_gossembrot.json
@@ -11,9 +11,10 @@
     },
     "startDate": "2021-02-01",
     "endDate": "2026-01-31",
-    "url": [
-        "https://gossembrot.unibe.ch/gossembrot-portal/"
-    ],
+    "secondaryUrl": {
+        "type": "URL",
+        "url": "https://gossembrot.unibe.ch/gossembrot-portal/"
+    },
     "howToCite": "Michael Stolz, Ioanna Georgiou, Elena Brandazza (2026). Lesen als soziale Negotiation - Rekonstruktion der Bibliothek von Sigmund Gossembrot (1417–1493) [Dataset]. DaSCH. https://ark.dasch.swiss/ark:/72163/1/084D",
     "accessRights": {
         "accessRights": "Full Open Access"

--- a/modules/dpe/server/data/projects/0853_deir-el-medina.json
+++ b/modules/dpe/server/data/projects/0853_deir-el-medina.json
@@ -11,9 +11,10 @@
     },
     "startDate": "2021-02-01",
     "endDate": "2027-12-31",
-    "url": [
-        "https://beyondthetext.ch/deir-el-medina"
-    ],
+    "secondaryUrl": {
+        "type": "URL",
+        "url": "https://beyondthetext.ch/deir-el-medina"
+    },
     "howToCite": "Deir el-Medina Hieroglyph Palaeography (2028). DaSCH. https://ark.dasch.swiss/ark:/72163/1/0853",
     "accessRights": {
         "accessRights": "Open Access with Restrictions"

--- a/modules/dpe/server/data/projects/085D_digitalshores.json
+++ b/modules/dpe/server/data/projects/085D_digitalshores.json
@@ -12,10 +12,10 @@
     "startDate": "2020-08-01",
     "endDate": "2025-07-31",
     "dataPublicationYear": "2025",
-    "url": [
-        "https://readingthebeach.unibe.ch/",
-        "https://dhbern.github.io/reading-the-beach/"
-    ],
+    "secondaryUrl": {
+        "type": "URL",
+        "url": "https://readingthebeach.unibe.ch/"
+    },
     "howToCite": "Guðrun í Jákupsstovu, Ursula Kluwick, Virginia Richter, Katharina Scheller, Marion Troxler (2025). Digital Shores: An Interactive Atlas of Beach Narratives. [Dataset]. DaSCH. https://ark.dasch.swiss/ark:/72163/1/085D.",
     "accessRights": {
         "accessRights": "Full Open Access"
@@ -319,5 +319,8 @@
         {
             "en": "Digital Shores: An Interactive Atlas of Beach Narratives"
         }
+    ],
+    "additionalMaterial": [
+        "https://dhbern.github.io/reading-the-beach/"
     ]
 }

--- a/modules/dpe/server/data/projects/085E_hamidi.json
+++ b/modules/dpe/server/data/projects/085E_hamidi.json
@@ -11,9 +11,10 @@
     },
     "startDate": "2025-07-01",
     "endDate": "2028-07-31",
-    "url": [
-        "https://sites.google.com/site/hamidiyataidu/home"
-    ],
+    "secondaryUrl": {
+        "type": "URL",
+        "url": "https://sites.google.com/site/hamidiyataidu/home"
+    },
     "howToCite": "© Tall al-Hamidiya Online project. DaSCH. https://ark.dasch.swiss/ark:/72163/1/085E.",
     "accessRights": {
         "accessRights": "Full Open Access"

--- a/modules/dpe/server/data/projects/0867_nietzsche-dm.json
+++ b/modules/dpe/server/data/projects/0867_nietzsche-dm.json
@@ -12,6 +12,7 @@
     "startDate": "2022-01-01",
     "endDate": "2024-12-31",
     "url": [
+        "https://app.dasch.swiss/project/6b1_SmIPQg-pDwJ5tJTqaA",
         "https://nietzsche.philhist.unibas.ch"
     ],
     "howToCite": "Der späte Nietzsche. Digitale Edition der Druckdokumente (2024). DaSCH. https://ark.dasch.swiss/ark:/72163/1/0867.",


### PR DESCRIPTION
Fixes DEV-6985

## Motivation

`url` is positional. `parse_url_value()` (`modules/dpe/core/src/project.rs:23-42`) takes `url[0]` as the primary reference and `url[1]` as the secondary, and `project_header.rs:38-67` renders the primary as the filled **"Discover Project Data"** button and the secondary as the outline **"External Project Website"** button. Nothing validates the distinction — `validate-data` checks cross-references and deserialization only.

Ten projects had a single `url` entry pointing at an external website, so that website was being advertised as the archived dataset. Follow-on from DEV-6984 / #323, which fixed the same defect on 0868.

## Summary

- Nine projects now render only an "External Project Website" button and no data CTA.
- 0867 (nietzsche-dm) gains a working "Discover Project Data" link to its project on DSP.
- No project still presents an external website as DSP data.

## Key Changes

### Availability check first

Every shortcode was checked against both DSP servers before deciding. **Only 0867 has data on a DSP server**; the other nine 404 on both:

| Project | api.dasch.swiss | api.ls-prod-server | Action |
|---|---|---|---|
| `0867_nietzsche-dm` | **200** | 404 | DSP link added as `url[0]` |
| `0805_tdk` | 404 | 404 | → `secondaryUrl` |
| `0816_vitrocentre` | 404 | 404 | → `secondaryUrl` |
| `081B_delille` | 404 | 404 | → `secondaryUrl` |
| `083C_eHKKA` | 404 | 404 | → `secondaryUrl` |
| `0843_woposs` | 404 | 404 | → `secondaryUrl` |
| `084D_gossembrot` | 404 | 404 | → `secondaryUrl` |
| `0853_deir-el-medina` | 404 | 404 | → `secondaryUrl` |
| `085D_digitalshores` | 404 | 404 | → `secondaryUrl` + `additionalMaterial` |
| `085E_hamidi` | 404 | 404 | → `secondaryUrl` |

### `0867_nietzsche-dm.json`
- `url[0]` is now `https://app.dasch.swiss/project/6b1_SmIPQg-pDwJ5tJTqaA`; the existing `nietzsche.philhist.unibas.ch` stays as `url[1]`.

### The nine with no DSP data
- The website moves from `url` to `secondaryUrl`, following `085F_streetart.json` and commit `4be31183` (DEV-6585). With no primary reference, no data CTA renders — which is the honest state for a project whose data is not on DSP.

### `085D_digitalshores.json`
- Only one secondary slot exists, so `readingthebeach.unibe.ch` takes it and the companion site `dhbern.github.io/reading-the-beach` moves to `additionalMaterial`, which renders as an "Additional Material" link list. It would otherwise have been silently dropped, since `parse_url_value` reads at most two array entries.

## Challenges and Decisions

### The ticket assumed most of these would gain a DSP link; only one does

**Problem:** DEV-6985 was written expecting "data on DSP → prepend the DSP link" to be the common case.

**Tried:** checking each shortcode. Nine are absent from production *and* from `ls-prod-server` — where legacy projects such as 0103 and 0105 live.

**Solution:** apply the second branch of the ticket to those nine. Moving the website to `secondaryUrl` is correct regardless of *why* the data is absent, it stops the mislabelling now, and it does not foreclose adding a DSP link when data is ingested.

### The shortcode URL form would not have worked

`https://app.dasch.swiss/project/0867` 404s. dsp-app's only project route is `project/:uuid` (`dsp-das/apps/dsp-app/src/app/app.routes.ts:49`), and `ProjectService.uuidToIri()` concatenates `http://rdfh.ch/projects/` onto the path segment with no shortcode lookup. The 11 existing files using the shortcode form work only because those are legacy projects whose IRI literally *is* their shortcode. The segment must come from the project IRI — here `6b1_SmIPQg-pDwJ5tJTqaA`.

### accessRights is out of scope

This PR changes link fields only. `accessRights` is curation-owned metadata and is not inferred from an API 404, so it is left exactly as it is on every one of the ten files.

### Edits are surgical, not reformatted

Each file was patched by exact string replacement, asserting after every write that the file still parses, that the parsed object differs *only* in the intended keys, and that the trailing newline survives. Whole-file normalisation is DEV-6906's job and would have buried these changes.

## Gotchas

- **A placeholder cannot express "no primary URL".** `parse_url_value` filters `MISSING`/`CALCULATED` before slotting, so `["MISSING", "<website>"]` promotes the website to primary. The explicit `secondaryUrl` key is the only way to leave the primary empty.
- **The key is `secondaryUrl`, not `secondaryURL`.** `ProjectRaw` carries `#[serde(rename_all = "camelCase")]`; the doc comment at `project.rs:187-188` says `secondaryURL` and is wrong. The misspelling deserializes to `None` silently — no error, no button.
- **When adding a DSP link, derive the segment from the project IRI**, never the shortcode. Check `GET https://api.dasch.swiss/admin/projects/shortcode/<shortcode>` first, and remember `ls-prod-server` is a second home for legacy projects.
- **`additionalMaterial` had no users before this PR.** 085D is the first project file to set it; the field and its "Additional Material" rendering already existed (`dataset_overview_section/mod.rs:83`).
- **`just validate-data` is not wired into CI.** It will not catch a mislabelled primary URL either — it has no semantic checks. Worth considering a "primary url must be a DSP URL" guard alongside DEV-6905.

## Test Plan

- [x] `just validate-data` → `Validated: 85 projects, 50994 records, 416 persons, 142 organizations / All data files are valid.`
- [x] `just test` → 532 tests, 0 failures. Snapshots pin 0803/0102, so no `cargo insta` churn.
- [x] Served the edited data and checked all ten rendered pages: the nine show no primary button and their website on the outline button; 0867 shows primary → `app.dasch.swiss/project/6b1_SmIPQg-pDwJ5tJTqaA` and outline → `nietzsche.philhist.unibas.ch`.
- [x] 085D renders an "Additional Material" section containing `https://dhbern.github.io/reading-the-beach/`.
- [x] `GET /admin/projects/iri/http%3A%2F%2Frdfh.ch%2Fprojects%2F6b1_SmIPQg-pDwJ5tJTqaA` → 200.
- [x] Diff is 10 files, +40/-28, confined to `url` / `secondaryUrl` / `additionalMaterial`.
- [ ] Reviewer: open the 0867 DSP link and confirm it loads the project.
- [ ] Reviewer: sanity-check the availability table above — the nine projects returning 404 on both servers is what justifies giving them no data CTA.

## Commit hygiene
- [x] I have reviewed and cleaned up the branch history (squashed working commits, clear messages) so it reads well on `main`
- [ ] allow-many-commits — tick only if this PR is genuinely several independent, self-contained changes that each deserve their own line in `main`'s history
