### PR TITLE
chore(ci): serialize Release Please runs to prevent force-push races

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,14 @@ on:
     branches:
       - main
 
+# Serialize runs: several pushes to main in quick succession each start a run,
+# and they all force-push the same release-please branch. Without this guard the
+# earlier runs lose the race and fail with "stale info" on --force-with-lease.
+# Queue (don't cancel) so each run re-evaluates against the previous one's push.
+concurrency:
+  group: release-please
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
No Linear issue — ad-hoc CI reliability fix.

## Motivation
When several commits land on `main` in quick succession, each push starts its own Release Please run, and every run force-pushes the same `release-please--branches--main` branch. The earlier runs lose the race and fail on `git push --force-with-lease` with `! [rejected] ... (stale info)`. This produces spurious ❌ runs (e.g. [32158779457](https://github.com/dasch-swiss/dsp-repository/actions/runs/32158779457), [32158809546](https://github.com/dasch-swiss/dsp-repository/actions/runs/32158809546)) even though the release PR itself ends up correct — the last run wins.

## Summary
- Add a `concurrency` group to the Release Please workflow so its runs are serialized instead of racing.

## Key Changes
### .github/workflows/release-please.yml
- Add `concurrency: { group: release-please, cancel-in-progress: false }`.
- Queue (don't cancel) so each run re-evaluates against the previous run's push, keeping the final release branch consistent with the newest commit.

## Challenges and Decisions
### Cancel vs. queue
**Problem:** Two ways to guard concurrency — cancel the in-progress run, or queue.
**Solution:** Queue (`cancel-in-progress: false`). release-please recomputes from full git history, so cancelling would also be correct, but queueing avoids interrupting a run mid force-push and guarantees the branch reflects the last push. It's the more conservative choice for a release pipeline.

## Gotchas
- This serializes Release Please only; other workflows are unaffected.
- `--force-with-lease` rejecting with "stale info" is the safety net working, not a script bug — the fix removes the race that triggers it rather than weakening the push.

## Test Plan
- [ ] Merge, then push two commits to `main` in quick succession and confirm the second Release Please run queues behind the first rather than failing on force-push.