### PR TITLE
refactor(editor-server): make the data directory an explicit, unset-by-default seam

### DIFF
--- a/docs/src/editor/operations.md
+++ b/docs/src/editor/operations.md
@@ -18,6 +18,14 @@ cross-linker, which macOS does not have. It defaults to the host architecture so
 the build is native; `just build-docker-editor arch=x86_64` reproduces the amd64
 image CI publishes, under emulation.
 
+### Data directory (a deliberate build input)
+
+The published project/person/organization set is **DPE's content**, not the editor's. Both `.github/actions/build-editor` and `just build-docker-editor` copy `modules/dpe/server/data` into the staging directory, and the Dockerfile places it at `/app/server/data`, where `EDITOR_DATA_DIR` points. Git stays the source of truth and the editor reads an image-baked snapshot, so a data change reaches the editor by rebuilding the image, not at runtime.
+
+That copy is the seam, and it is explicit on both sides. `EditorConfig` carries **no default** for `data_dir`: the only plausible one is a relative path into DPE's tree, which would let a records reader resolve another module's directory instead of failing on an unconfigured seam. Every environment that reads records names the directory — the image via `ENV EDITOR_DATA_DIR`, local development via `just dev-editor`. Unset is a legitimate state while nothing reads records, and is reported as `<unset>` at startup rather than as an invented path.
+
+Moving the directory under `modules/platform/` was considered and rejected: the shared-crate rule in [Repo Structure](../repo_structure.md#shared-crates) is about crates, and this is DPE's owned content consumed through an existing explicit seam. Reopen it only if a third consumer appears.
+
 ## CLI Commands
 
 | Command | Description |
@@ -42,7 +50,7 @@ Locally the default is `127.0.0.1:4100`, deliberately not DPE's 4000, so `just d
 | `RUST_LOG` | No | `info` | Log level filter (e.g. `editor_server=info,tower_http=debug`) |
 | `EDITOR_SITE_ADDR` | No | `127.0.0.1:4100` | Listen address and port. The Docker image sets `0.0.0.0:8080`. |
 | `EDITOR_PUBLIC_DIR` | No | `modules/editor/public` | Directory served as static assets by `ServeDir` (favicon, logo, vendored JS, the telemetry module, and the compiled `app.<hash>.css`). |
-| `EDITOR_DATA_DIR` | No | `modules/dpe/server/data` | Directory holding the published project/person/organization set baked into the image. Reported at startup. |
+| `EDITOR_DATA_DIR` | Yes, to read records | *(none)* | Directory holding the published project/person/organization set baked into the image. No default — see [Data directory](#data-directory-a-deliberate-build-input). Reported at startup, as `<unset>` when absent. |
 | `EDITOR_ENV` | No | `DEV` | Deployment environment (`DEV` or `PROD`). Controls OTLP log export (see [Logging](#logging)). The Docker image sets `PROD`. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | No | *(none)* | OTLP gRPC endpoint (e.g. `http://alloy:4317`). When unset, OTel falls back to no-op export. |
 | `OTEL_SERVICE_NAME` | No | *(none)* | Service name for OTel resource attributes (e.g. `editor`) |

--- a/docs/src/repo_structure.md
+++ b/docs/src/repo_structure.md
@@ -60,6 +60,8 @@ The directory is the ownership signal, and four things read it:
 
 `mosaic-*` predates the convention and stays as it is: it is already a peer of the services rather than a child of one, which is the property that matters.
 
+**The rule covers crates, not content.** `modules/dpe/server/data` stays under DPE even though the editor consumes it: DPE owns it, and the editor reads an image-baked snapshot through an explicit `EDITOR_DATA_DIR` seam rather than a compiled-in path — see [Editor Operations](./editor/operations.md#data-directory-a-deliberate-build-input). Two of the four signals do have analogues there, accepted knowingly: a data-only change matches `modules/dpe/**`, so it deploys a DPE preview but no editor preview, and `serve-editor`'s watch list does not restart the editor on a data edit. Both become visible only once the editor reads records, and both are cheaper to fix in place than a wholesale move would be.
+
 ## API Crate Pattern
 
 Each API is a separate crate under `modules/dpe/`:

--- a/justfile
+++ b/justfile
@@ -371,6 +371,10 @@ dev-editor:
     "$bin" -i modules/editor/style/main.css -o modules/editor/public/assets/app.css --watch &
     tw=$!
     trap 'kill $tw 2>/dev/null || true' EXIT
+    # The editor has no default data directory: the published set is DPE's
+    # content, consumed through EDITOR_DATA_DIR. Locally that is DPE's
+    # checked-out data; the image bakes a snapshot at /app/server/data.
+    EDITOR_DATA_DIR=modules/dpe/server/data \
     bacon serve-editor
 
 # Start the editor with hot reload, exporting traces/metrics/logs to a local LGTM stack (run `just lgtm-up` in another terminal first)
@@ -382,6 +386,7 @@ dev-editor-otel:
     "$bin" -i modules/editor/style/main.css -o modules/editor/public/assets/app.css --watch &
     tw=$!
     trap 'kill $tw 2>/dev/null || true' EXIT
+    EDITOR_DATA_DIR=modules/dpe/server/data \
     OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
     OTEL_SERVICE_NAME=editor \
     OTEL_RESOURCE_ATTRIBUTES="service.namespace=editor,service.version={{ CARGO_VERSION }},deployment.environment=dev" \
@@ -435,6 +440,9 @@ build-docker-editor arch="": css-editor-release
     mkdir -p "$stage"
     cp "target/container/$target/release/editor-server" "$stage/"
     cp -r modules/editor/public "$stage/"
+    # DPE's published set, copied in deliberately: git stays the source of truth
+    # and the editor reads an image-baked snapshot via EDITOR_DATA_DIR, so a data
+    # change reaches the editor by rebuilding the image, not at runtime.
     cp -r modules/dpe/server/data "$stage/"
     cp modules/editor/Dockerfile "$stage/"
     docker build --platform "$platform" -f "$stage/Dockerfile" -t metadata-editor "$stage"

--- a/modules/editor/server/src/config.rs
+++ b/modules/editor/server/src/config.rs
@@ -30,10 +30,14 @@ pub struct EditorConfig {
     pub public_dir: PathBuf,
 
     /// Directory holding the published project/person/organization set baked
-    /// into the image. Set via `EDITOR_DATA_DIR`. Reported at startup so an
-    /// operator can see what the container resolved; the startup comparison
-    /// that derives project status is what will read the files themselves.
-    pub data_dir: PathBuf,
+    /// into the image, set via `EDITOR_DATA_DIR`. Deliberately has **no
+    /// default**: the only plausible one is a relative path into DPE's tree,
+    /// which the editor does not own, and which would hide the dependency from
+    /// the code that reads records. Every environment that reads them sets the
+    /// variable — the image to `/app/server/data`, `just dev-editor` to DPE's
+    /// checked-out data. `None` therefore means "no data directory
+    /// configured", and is reported as such at startup.
+    pub data_dir: Option<PathBuf>,
 
     /// Deployment environment, `DEV` or `PROD`. `DEV` additionally exports logs
     /// over OTLP when an endpoint is configured; `PROD` logs to stdout only.
@@ -46,7 +50,7 @@ impl Default for EditorConfig {
         Self {
             site_addr: "127.0.0.1:4100".to_string(),
             public_dir: PathBuf::from("modules/editor/public"),
-            data_dir: PathBuf::from("modules/dpe/server/data"),
+            data_dir: None,
             env: "DEV".to_string(),
         }
     }
@@ -79,7 +83,7 @@ mod tests {
         let config = EditorConfig::default();
         assert_eq!(config.site_addr, "127.0.0.1:4100");
         assert_eq!(config.public_dir, PathBuf::from("modules/editor/public"));
-        assert_eq!(config.data_dir, PathBuf::from("modules/dpe/server/data"));
+        assert_eq!(config.data_dir, None);
         assert_eq!(config.env, "DEV");
     }
 
@@ -118,7 +122,20 @@ mod tests {
         figment::Jail::expect_with(|jail| {
             jail.set_env("EDITOR_DATA_DIR", "/app/server/data");
             let config = EditorConfig::load().expect("config should load");
-            assert_eq!(config.data_dir, PathBuf::from("/app/server/data"));
+            assert_eq!(config.data_dir, Some(PathBuf::from("/app/server/data")));
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn data_dir_is_unset_without_the_env_var() {
+        // No default on purpose. The only plausible one is a relative path into
+        // DPE's tree (`modules/dpe/server/data`), which the editor does not own;
+        // baking it in would let a records reader silently resolve another
+        // module's directory instead of failing on an unconfigured seam.
+        figment::Jail::expect_with(|_| {
+            let config = EditorConfig::load().expect("config should load without EDITOR_DATA_DIR");
+            assert_eq!(config.data_dir, None);
             Ok(())
         });
     }

--- a/modules/editor/server/src/main.rs
+++ b/modules/editor/server/src/main.rs
@@ -217,10 +217,17 @@ async fn serve() -> ExitCode {
         None
     };
 
+    // An unset data directory is a legitimate state today (nothing reads
+    // records yet), so report it rather than failing — but report it as unset,
+    // not as some path the editor invented.
+    let data_dir = config
+        .data_dir
+        .as_deref()
+        .map_or_else(|| "<unset>".to_string(), |path| path.display().to_string());
     tracing::info!(
         env = %config.env,
         public_dir = %config.public_dir.display(),
-        data_dir = %config.data_dir.display(),
+        data_dir = %data_dir,
         "editor configuration loaded"
     );
 


### PR DESCRIPTION
Fixes DEV-6996

The `platform-metadata` extraction that DEV-6996 originally also covered was split out to [DEV-6999](https://linear.app/dasch/issue/DEV-6999), blocked by DEV-6905 + DEV-6906 and landing inside DEV-6911. Not part of this PR.

## Motivation

PR #322 (the editor scaffold, DEV-6904) left `EditorConfig::default()` pointing `data_dir` at `modules/dpe/server/data` — a relative path into DPE's tree, compiled into the editor binary. The editor does not own that directory. It consumes an image-baked snapshot of DPE's published set through `EDITOR_DATA_DIR`, which the Dockerfile already sets, so the default bought nothing and hid the dependency.

It is latent today because nothing reads records. It stops being latent in DEV-6911, whose record reader would have silently resolved another module's directory instead of failing on an unconfigured seam.

## Summary

- `EditorConfig::data_dir` is now `Option<PathBuf>` with **no default**; every environment that reads records names the directory explicitly.
- `just dev-editor` / `just dev-editor-otel` set `EDITOR_DATA_DIR` — the cross-module path now lives in the dev environment, where it is visible, instead of in the binary.
- The staging copy is unchanged, and documented as a deliberate build input.

## Key Changes

### `editor-server`
- `data_dir: Option<PathBuf>`, defaulting to `None` (`config.rs`).
- Startup reports `data_dir="<unset>"` rather than a path the editor invented (`main.rs`).
- New test `data_dir_is_unset_without_the_env_var` pins the no-default contract.

### Build and dev loop
- `EDITOR_DATA_DIR=modules/dpe/server/data` in both editor dev recipes, so the local loop keeps working once DEV-6911's reader lands.
- Comment on `build-docker-editor`'s `cp -r modules/dpe/server/data`, matching the one already in `.github/actions/build-editor`.

### Docs
- `docs/src/editor/operations.md`: new **Data directory (a deliberate build input)** section; `EDITOR_DATA_DIR` row now reads *Required: yes, to read records* with no default.
- `docs/src/repo_structure.md`: the shared-crate rule covers **crates, not content** — with the two signals that do have data-directory analogues named honestly rather than waved away.

## Challenges and Decisions

### Moving the data directory was considered and rejected
**Problem:** read literally, the shared-crate rule ("if DPE and EDITOR depend on it, move it under `/modules`") points at `modules/dpe/server/data`.
**Tried:** costing the move — ~25 edits across `include_str!` and `CARGO_MANIFEST_DIR`-relative test paths in `dpe-core`, DPE's Dockerfile and `DPE_DATA_DIR`, both build actions, the justfile and eight docs, and a head-on collision with DEV-6906's 85-file normalisation commit.
**Solution:** the rule is about crates; this is DPE's owned content. Make the existing seam honest instead. Both `repo_structure.md` and `operations.md` now say so, so the next reader does not re-derive the move.

### The dev recipes still name DPE's path — deliberately
**Problem:** dropping the default could just move the coupling into the justfile.
**Solution:** it does, and that is the point. The shipped binary no longer contains a path into DPE's tree; the wiring sits next to the recipe's other env wiring (`OTEL_*`, `PYROSCOPE_*`), visible in source. Leaving it out instead would break `just dev-editor` for every developer the moment DEV-6911's reader lands.

## Gotchas

- **Do not re-add a default for `data_dir`.** `None` is a legitimate state only while nothing reads records. When DEV-6911 adds the reader, make it *fail* on `None` naming `EDITOR_DATA_DIR` — do not `unwrap_or_else` back to DPE's path.
- **A data-only change deploys no editor preview.** `cloud-run-editor-pull-request.yml` filters on `modules/editor/**`, and `serve-editor`'s bacon watch list covers `modules/editor` only, so a `modules/dpe/server/data` edit neither previews nor hot-reloads the editor. Harmless today; worth fixing in place once the editor reads records.

## Test Plan

- [x] `just check` — fmt, clippy, cargo-machete: clean
- [x] `just test` — 563 tests, 0 failures
- [x] `just commit-lint` — one commit, type+scope OK
- [x] `just docs-build` — clean; both new anchors verified against the generated HTML
- [x] Ran `editor-server serve` both ways: `data_dir="<unset>"` without the variable, `data_dir="modules/dpe/server/data"` with it

## Commit hygiene

- [x] I have reviewed and cleaned up the branch history (squashed working commits, clear messages) so it reads well on `main`
- [ ] allow-many-commits
