### PR TITLE
feat(dpe-server): add temporal-coverage resolution check to validate

### DIFF
--- a/docs/src/dpe/oai-pmh.md
+++ b/docs/src/dpe/oai-pmh.md
@@ -123,6 +123,8 @@ Ranges are resolved offline (no network or LLM calls at request time), in two ti
 
 When no range resolves (a `date: null` row, or a name absent from both sources), the element is emitted with the `dateInformation` attribute only and an empty body, so the original label is never dropped.
 
+Resolution lives in `dpe_core::temporal_coverage`, shared by the OAI-PMH mapping above, `dpe-server validate` (`just validate-data`), and the `every_committed_temporal_coverage_resolves` test — a distinct `temporalCoverage` name with no resolvable range fails `validate` (and CI) rather than only surfacing as a name-only DataCite date at request time.
+
 ### Record files
 
 A bitstream Record may carry a single `file` (its MIME type and a direct download link, served by dsp-ingest). When present it is exposed in both formats:

--- a/docs/src/dpe/operations.md
+++ b/docs/src/dpe/operations.md
@@ -32,6 +32,7 @@ dpe-server validate ./data
 - Cross-references between projects, persons, and organizations
 - Orphaned files that are not referenced by any parent entity
 - Project roles misplaced in a person's `jobTitles` (e.g. "Project Leader", "Project staff", "Creator"). Such a role belongs in the project's `attributions` (`contributorType`), where the OAI-PMH creator/contributor logic can read it. The role vocabulary is `JOB_TITLE_ROLE_WORDS` in `dpe-core`.
+- Every distinct `temporalCoverage` name resolves to a structured date (ChronOntology or the offline enrichment table), or is explicitly marked `source: "unresolved"`. See `docs/src/dpe/oai-pmh.md` → *Temporal coverage*.
 
 **Exit codes:**
 - `0` — all data files are valid

--- a/modules/dpe/CLAUDE.md
+++ b/modules/dpe/CLAUDE.md
@@ -73,8 +73,8 @@ cd modules/dpe/web-e2e-tests && npx playwright test
 Project descriptive metadata lives as JSON under `modules/dpe/server/data/`.
 
 1. Add `<shortcode>_<slug>.json` under `projects/` (and any new `persons/person-NNN.json` / `organizations/organization-NNN.json`); pick new person/org ids by scanning existing internal `"id"` values, and reuse existing organizations rather than duplicating them.
-2. **Every `temporalCoverage` value must resolve to a structured date for OAI-PMH.** Free-text values (e.g. `{"en": "11th-15th centuries"}`) resolve against `modules/dpe/server/data/temporal-coverage-enrichment.json`, keyed by the display text. Add a row with a W3CDTF range and `"source": "llm"` (e.g. `"11th-15th centuries": {"date": "1001/1500", "original_name": "11th-15th centuries", "source": "llm"}`); if the value is not a time period, use `"date": null, "source": "unresolved"`. The `every_committed_temporal_coverage_resolves` test fails otherwise. See `docs/src/dpe/oai-pmh.md` → *Temporal coverage*.
-3. Run `just validate-data` (cross-references) and `just test`.
+2. **Every `temporalCoverage` value must resolve to a structured date for OAI-PMH.** Free-text values (e.g. `{"en": "11th-15th centuries"}`) resolve against `modules/dpe/server/data/temporal-coverage-enrichment.json`, keyed by the display text. Add a row with a W3CDTF range and `"source": "llm"` (e.g. `"11th-15th centuries": {"date": "1001/1500", "original_name": "11th-15th centuries", "source": "llm"}`); if the value is not a time period, use `"date": null, "source": "unresolved"`. Both `just validate-data` (`dpe-server validate`) and the `every_committed_temporal_coverage_resolves` test enforce this, over the same `dpe_core::temporal_coverage` resolution logic — so the two can't disagree. See `docs/src/dpe/oai-pmh.md` → *Temporal coverage*.
+3. Run `just validate-data` (cross-references, temporal-coverage resolution) and `just test`.
 
 ### Adding a New Component
 

--- a/modules/dpe/api-oai/src/metadata/datacite.rs
+++ b/modules/dpe/api-oai/src/metadata/datacite.rs
@@ -287,15 +287,12 @@ fn resolve_temporal_coverage(tc: &TemporalCoverage) -> Option<DataCiteDate> {
 }
 
 /// Pure resolution of a `temporalCoverage` entry over the given lookup maps, so
-/// the fallback chain can be unit-tested without the process-global caches (the
-/// same `*_in` shape used by the cache modules themselves).
+/// the fallback chain can be unit-tested without the process-global caches.
 ///
-/// Resolution order:
-/// 1. A ChronOntology reference URL → its timespan range (`periods`).
-/// 2. Otherwise (or on a cache miss) the offline enrichment table (`enrichment`), keyed by the same
-///    name the mapping computes here.
-/// 3. Otherwise a name-only date (`dateInformation` with an empty `date`), so the original
-///    information is never silently dropped.
+/// The actual resolution (ChronOntology URL → enrichment table → name-only
+/// fallback) lives in `dpe_core::temporal_coverage`, shared with `dpe-server`'s
+/// `validate` command so the two can never disagree about what counts as
+/// resolved. This wraps that outcome into the DataCite `Coverage` date shape.
 ///
 /// Returns `None` only when there is neither a resolvable range nor any name to
 /// carry — a date with neither value nor information would be useless.
@@ -304,43 +301,11 @@ fn resolve_temporal_coverage_in(
     periods: &HashMap<String, dpe_core::w3cdtf::W3cdtfRange>,
     enrichment: &HashMap<String, dpe_core::temporal_enrichment_cache::EnrichedDate>,
 ) -> Option<DataCiteDate> {
-    use dpe_core::{chronontology_cache, temporal_enrichment_cache};
-
-    // The display name, used both as the enrichment key and as dateInformation.
-    let name = match tc {
-        TemporalCoverage::Reference(ref_data) => ref_data.text.clone(),
-        TemporalCoverage::Text(text_map) => get_multilingual_value(text_map),
-    };
-
-    // 1. ChronOntology URL → timespan.
-    if let TemporalCoverage::Reference(ref_data) = tc {
-        if !ref_data.url.is_empty() {
-            if let Some(range) = chronontology_cache::timespan_for_in(periods, &ref_data.url) {
-                return Some(DataCiteDate {
-                    date: range.into(),
-                    date_type: "Coverage".to_string(),
-                    date_information: name,
-                });
-            }
-        }
-    }
-
-    // 2. Enrichment table, keyed by the display name.
-    if let Some(ref key) = name {
-        if let Some(enriched) = temporal_enrichment_cache::enriched_for_in(enrichment, key) {
-            return Some(DataCiteDate {
-                date: enriched.date.unwrap_or_default(),
-                date_type: "Coverage".to_string(),
-                date_information: Some(enriched.original_name),
-            });
-        }
-    }
-
-    // 3. Name-only fallback (empty date body, dateInformation set).
-    name.map(|n| DataCiteDate {
-        date: String::new(),
+    let resolution = dpe_core::temporal_coverage::resolve_in(tc, periods, enrichment)?;
+    Some(DataCiteDate {
+        date: resolution.date,
         date_type: "Coverage".to_string(),
-        date_information: Some(n),
+        date_information: resolution.date_information,
     })
 }
 
@@ -461,16 +426,10 @@ mod temporal_tests {
         assert_eq!(date.date_information.as_deref(), Some("Vague Period"));
     }
 
-    /// Derive the lookup key / name for a temporalCoverage entry exactly as
-    /// `resolve_temporal_coverage_in` does (Reference → `text`; Text map →
-    /// `get_multilingual_value`). Mirrors `normalized_key` in
-    /// `scripts/build-temporal-coverage-enrichment.py`.
-    fn coverage_name(tc: &TemporalCoverage) -> Option<String> {
-        match tc {
-            TemporalCoverage::Reference(ref_data) => ref_data.text.clone(),
-            TemporalCoverage::Text(text_map) => get_multilingual_value(text_map),
-        }
-    }
+    // The same lookup-key derivation `resolve_temporal_coverage_in` uses
+    // (Reference → `text`; Text map → `get_multilingual_value`), shared via
+    // dpe-core so the two can't drift apart.
+    use dpe_core::temporal_coverage::coverage_name;
 
     /// Completeness guard over the committed project data: every distinct
     /// `temporalCoverage` entry across all in-repo project files must resolve to a
@@ -525,22 +484,13 @@ mod temporal_tests {
                 let Some(name) = coverage_name(tc) else {
                     continue; // no name to key on; nothing to resolve.
                 };
-                if !seen.insert(name.clone()) {
+                if !seen.insert(name) {
                     continue; // already checked this distinct name.
                 }
 
-                let resolved = resolve_temporal_coverage_in(tc, &periods, &enriched);
-                let has_date = resolved.as_ref().is_some_and(|d| !d.date.is_empty());
-                if has_date {
-                    continue;
-                }
-
-                // Empty date: allowed only if the name is an explicitly reviewed
-                // non-period label (enrichment row, no date, source "unresolved").
-                let intentional_label = enriched
-                    .get(&name)
-                    .is_some_and(|e| e.date.is_none() && e.source == "unresolved");
-                if !intentional_label {
+                // The same gap decision `dpe-server validate` applies, so the
+                // two can't drift apart.
+                if let Some(name) = dpe_core::temporal_coverage::completeness_gap(tc, &periods, &enriched) {
                     unresolved.push(name);
                 }
             }

--- a/modules/dpe/api-oai/src/metadata/helpers.rs
+++ b/modules/dpe/api-oai/src/metadata/helpers.rs
@@ -6,15 +6,12 @@ use dpe_core::AccessRightsType;
 
 /// Extracts a value from a multilingual HashMap, preferring English.
 ///
-/// When `en` is absent the entry with the lexicographically smallest language
-/// code is chosen. This makes the result deterministic (a plain `values().next()`
-/// depends on `HashMap` iteration order) — important because the temporal-coverage
-/// enrichment lookup keys on this value at both collection and request time, so
-/// the two must agree.
+/// Delegates to `dpe_core::multilingual_value` — kept as a local alias since
+/// it is imported throughout this module tree. See that function's docs for
+/// the deterministic-fallback rationale (it backs the temporal-coverage
+/// enrichment lookup key, where collection and lookup must agree).
 pub fn get_multilingual_value(map: &HashMap<String, String>) -> Option<String> {
-    map.get("en")
-        .or_else(|| map.iter().min_by(|(a, _), (b, _)| a.cmp(b)).map(|(_, v)| v))
-        .cloned()
+    dpe_core::multilingual_value(map)
 }
 
 /// Extracts the year from a date string (YYYY-MM-DD or YYYY).

--- a/modules/dpe/core/src/lib.rs
+++ b/modules/dpe/core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod project_repository;
 pub mod record;
 pub mod record_cache;
 pub mod record_repository;
+pub mod temporal_coverage;
 pub mod temporal_enrichment_cache;
 pub mod utils;
 pub mod w3cdtf;
@@ -38,6 +39,6 @@ pub use record::{
 };
 pub use record_repository::{FsRecordRepository, RecordRepository};
 pub use utils::{
-    get_data_dir, is_placeholder, lang_value, language_display_name, set_data_dir, set_show_placeholder_values,
-    show_placeholder_values,
+    get_data_dir, is_placeholder, lang_value, language_display_name, multilingual_value, set_data_dir,
+    set_show_placeholder_values, show_placeholder_values,
 };

--- a/modules/dpe/core/src/temporal_coverage.rs
+++ b/modules/dpe/core/src/temporal_coverage.rs
@@ -1,0 +1,230 @@
+//! Resolution of a `temporalCoverage` entry to a W3CDTF date range.
+//!
+//! Shared by `dpe-api-oai` (DataCite `Coverage` dates) and `dpe-server`'s
+//! `validate` command, over the same ChronOntology period cache and offline
+//! enrichment table, so the two can never disagree about what counts as
+//! "resolved".
+
+use std::collections::HashMap;
+
+use super::chronontology_cache;
+use super::project::TemporalCoverage;
+use super::temporal_enrichment_cache::{self, EnrichedDate};
+use super::utils::multilingual_value;
+use super::w3cdtf::W3cdtfRange;
+
+/// The outcome of resolving one `temporalCoverage` entry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Resolution {
+    /// W3CDTF date range, or empty when only a name could be carried (a
+    /// name-only fallback, e.g. DataCite's `dateInformation`-only case).
+    pub date: String,
+    /// The display name backing the entry (e.g. DataCite's `dateInformation`).
+    pub date_information: Option<String>,
+}
+
+impl Resolution {
+    /// Whether resolution produced a machine-readable date, as opposed to a
+    /// name-only fallback.
+    pub fn has_date(&self) -> bool {
+        !self.date.is_empty()
+    }
+}
+
+/// The display name / enrichment lookup key for a `temporalCoverage` entry: a
+/// Reference's authority-file label, or a Text map's preferred-language value.
+pub fn coverage_name(tc: &TemporalCoverage) -> Option<String> {
+    match tc {
+        TemporalCoverage::Reference(ref_data) => ref_data.text.clone(),
+        TemporalCoverage::Text(text_map) => multilingual_value(text_map),
+    }
+}
+
+/// Resolve one `temporalCoverage` entry over the given period and enrichment
+/// tables (pure, for testability without the process-global caches).
+///
+/// Resolution order:
+/// 1. A ChronOntology reference URL -> its timespan range (`periods`).
+/// 2. Otherwise (or on a cache miss) the offline enrichment table (`enrichment`), keyed by the same
+///    name `coverage_name` computes.
+/// 3. Otherwise a name-only outcome (empty `date`), so the original information is never silently
+///    dropped.
+///
+/// Returns `None` only when there is neither a resolvable range nor any name
+/// to carry — nothing to report.
+pub fn resolve_in(
+    tc: &TemporalCoverage,
+    periods: &HashMap<String, W3cdtfRange>,
+    enrichment: &HashMap<String, EnrichedDate>,
+) -> Option<Resolution> {
+    let name = coverage_name(tc);
+
+    // 1. ChronOntology URL -> timespan.
+    if let TemporalCoverage::Reference(ref_data) = tc {
+        if !ref_data.url.is_empty() {
+            if let Some(range) = chronontology_cache::timespan_for_in(periods, &ref_data.url) {
+                return Some(Resolution { date: range.into(), date_information: name });
+            }
+        }
+    }
+
+    // 2. Enrichment table, keyed by the display name.
+    if let Some(ref key) = name {
+        if let Some(enriched) = temporal_enrichment_cache::enriched_for_in(enrichment, key) {
+            return Some(Resolution {
+                date: enriched.date.unwrap_or_default(),
+                date_information: Some(enriched.original_name),
+            });
+        }
+    }
+
+    // 3. Name-only fallback.
+    name.map(|n| Resolution { date: String::new(), date_information: Some(n) })
+}
+
+/// Whether an unresolved (empty-date) `temporalCoverage` entry is an
+/// intentionally reviewed non-period label rather than a genuine gap: an
+/// enrichment row with no `date` and `source == "unresolved"` (e.g. "Swiss",
+/// "English (culture or style)").
+pub fn is_intentionally_unresolved(name: &str, enrichment: &HashMap<String, EnrichedDate>) -> bool {
+    enrichment
+        .get(name)
+        .is_some_and(|e| e.date.is_none() && e.source == "unresolved")
+}
+
+/// Whether one `temporalCoverage` entry is a genuine completeness gap: it has
+/// a name to key on, resolves to no machine-readable date, and is not
+/// explicitly reviewed as a non-period label. Returns the name (for
+/// reporting) when it is a gap, `None` otherwise (resolved, intentionally
+/// unresolved, or nameless).
+///
+/// The single decision both `dpe-server validate` and the
+/// `every_committed_temporal_coverage_resolves` completeness test apply per
+/// entry, so the two enforcement points can't drift apart on what counts as a
+/// gap even though each walks its own project data independently.
+pub fn completeness_gap(
+    tc: &TemporalCoverage,
+    periods: &HashMap<String, W3cdtfRange>,
+    enrichment: &HashMap<String, EnrichedDate>,
+) -> Option<String> {
+    let name = coverage_name(tc)?;
+    let resolved = resolve_in(tc, periods, enrichment);
+    if resolved.as_ref().is_some_and(Resolution::has_date) {
+        return None;
+    }
+    if is_intentionally_unresolved(&name, enrichment) {
+        return None;
+    }
+    Some(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::AuthorityFileReference;
+
+    fn reference(url: &str, text: Option<&str>) -> TemporalCoverage {
+        TemporalCoverage::Reference(AuthorityFileReference {
+            type_: "Chronontology".to_string(),
+            url: url.to_string(),
+            text: text.map(str::to_string),
+        })
+    }
+
+    fn text(en: &str) -> TemporalCoverage {
+        let mut map = HashMap::new();
+        map.insert("en".to_string(), en.to_string());
+        TemporalCoverage::Text(map)
+    }
+
+    fn periods() -> HashMap<String, W3cdtfRange> {
+        let mut map = HashMap::new();
+        map.insert(
+            "0vGXxVln724L".to_string(),
+            crate::w3cdtf::to_w3cdtf_range(Some("98"), Some("117")).unwrap(),
+        );
+        map
+    }
+
+    fn enrichment(entries: &[(&str, Option<&str>, &str, &str)]) -> HashMap<String, EnrichedDate> {
+        entries
+            .iter()
+            .map(|(key, date, name, source)| {
+                (
+                    key.to_string(),
+                    EnrichedDate {
+                        date: date.map(str::to_string),
+                        original_name: name.to_string(),
+                        source: source.to_string(),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn chronontology_url_resolves_to_range() {
+        let tc = reference("https://chronontology.dainst.org/period/0vGXxVln724L", Some("Trajanic"));
+        let resolution = resolve_in(&tc, &periods(), &HashMap::new()).unwrap();
+        assert_eq!(resolution.date, "0098/0117");
+        assert_eq!(resolution.date_information.as_deref(), Some("Trajanic"));
+    }
+
+    #[test]
+    fn free_text_resolves_via_enrichment() {
+        let tc = text("Early Christianity");
+        let enrich = enrichment(&[("Early Christianity", Some("0030/0451"), "Early Christianity", "llm")]);
+        let resolution = resolve_in(&tc, &HashMap::new(), &enrich).unwrap();
+        assert_eq!(resolution.date, "0030/0451");
+    }
+
+    #[test]
+    fn unresolved_emits_name_only_empty_date() {
+        let tc = text("Mysterious Era");
+        let resolution = resolve_in(&tc, &periods(), &HashMap::new()).unwrap();
+        assert!(!resolution.has_date());
+        assert_eq!(resolution.date_information.as_deref(), Some("Mysterious Era"));
+    }
+
+    #[test]
+    fn no_name_and_no_resolution_is_none() {
+        let tc = reference("", None);
+        assert!(resolve_in(&tc, &periods(), &HashMap::new()).is_none());
+    }
+
+    #[test]
+    fn intentionally_unresolved_label_is_recognised() {
+        let enrich = enrichment(&[("Swiss", None, "Swiss", "unresolved")]);
+        assert!(is_intentionally_unresolved("Swiss", &enrich));
+        assert!(!is_intentionally_unresolved("Unknown", &enrich));
+    }
+
+    #[test]
+    fn completeness_gap_flags_genuinely_unresolved_name() {
+        let tc = text("Mysterious Era");
+        assert_eq!(
+            completeness_gap(&tc, &HashMap::new(), &HashMap::new()).as_deref(),
+            Some("Mysterious Era")
+        );
+    }
+
+    #[test]
+    fn completeness_gap_is_none_when_resolved() {
+        let tc = text("Early Christianity");
+        let enrich = enrichment(&[("Early Christianity", Some("0030/0451"), "Early Christianity", "llm")]);
+        assert_eq!(completeness_gap(&tc, &HashMap::new(), &enrich), None);
+    }
+
+    #[test]
+    fn completeness_gap_is_none_when_intentionally_unresolved() {
+        let tc = text("Swiss");
+        let enrich = enrichment(&[("Swiss", None, "Swiss", "unresolved")]);
+        assert_eq!(completeness_gap(&tc, &HashMap::new(), &enrich), None);
+    }
+
+    #[test]
+    fn completeness_gap_is_none_when_nameless() {
+        let tc = reference("", None);
+        assert_eq!(completeness_gap(&tc, &HashMap::new(), &HashMap::new()), None);
+    }
+}

--- a/modules/dpe/core/src/utils.rs
+++ b/modules/dpe/core/src/utils.rs
@@ -14,6 +14,23 @@ pub fn lang_value(map: &HashMap<String, String>) -> Option<&String> {
         .or_else(|| map.values().next())
 }
 
+/// Extracts a value from a multilingual map, preferring English.
+///
+/// When `en` is absent the entry with the lexicographically smallest language
+/// code is chosen. This makes the result deterministic (a plain `values().next()`
+/// depends on `HashMap` iteration order) — important for values used as lookup
+/// keys, such as the temporal-coverage enrichment table, where collection and
+/// lookup must agree on the same key.
+///
+/// Distinct from [`lang_value`]: that one prioritizes a fixed language order
+/// (en -> de -> fr -> it) with a non-deterministic fallback, which is fine for
+/// display but unsafe as a lookup key.
+pub fn multilingual_value(map: &HashMap<String, String>) -> Option<String> {
+    map.get("en")
+        .or_else(|| map.iter().min_by(|(a, _), (b, _)| a.cmp(b)).map(|(_, v)| v))
+        .cloned()
+}
+
 /// Maps a BCP 47 language code to a human-readable English display name.
 pub fn language_display_name(code: &str) -> &str {
     match code {
@@ -123,5 +140,30 @@ mod tests {
         assert!(!is_placeholder(""));
         assert!(!is_placeholder("missing")); // case-sensitive
         assert!(!is_placeholder("calculated")); // case-sensitive
+    }
+
+    #[test]
+    fn multilingual_value_prefers_english() {
+        let map = HashMap::from([
+            ("de".to_string(), "Hallo".to_string()),
+            ("en".to_string(), "Hello".to_string()),
+        ]);
+        assert_eq!(multilingual_value(&map).as_deref(), Some("Hello"));
+    }
+
+    #[test]
+    fn multilingual_value_falls_back_to_lexicographically_smallest_key() {
+        let map = HashMap::from([
+            ("it".to_string(), "Ciao".to_string()),
+            ("fr".to_string(), "Bonjour".to_string()),
+        ]);
+        // No "en" entry: "fr" sorts before "it", deterministically, regardless of
+        // HashMap iteration order.
+        assert_eq!(multilingual_value(&map).as_deref(), Some("Bonjour"));
+    }
+
+    #[test]
+    fn multilingual_value_empty_map_is_none() {
+        assert_eq!(multilingual_value(&HashMap::new()), None);
     }
 }

--- a/modules/dpe/server/src/main.rs
+++ b/modules/dpe/server/src/main.rs
@@ -404,6 +404,37 @@ async fn shutdown_signal() {
 }
 
 fn validate(data_dir: PathBuf) -> ExitCode {
+    let report = collect_validation_errors(&data_dir);
+
+    println!(
+        "Validated: {} projects, {} records, {} persons, {} organizations",
+        report.project_count, report.record_count, report.person_count, report.org_count
+    );
+
+    if report.errors.is_empty() {
+        println!("All data files are valid.");
+        ExitCode::SUCCESS
+    } else {
+        println!("\n{} error(s) found:", report.errors.len());
+        for err in &report.errors {
+            println!("  - {err}");
+        }
+        ExitCode::FAILURE
+    }
+}
+
+/// Counts and errors gathered by [`collect_validation_errors`]. Factored out of
+/// `validate` so the validation logic is testable without capturing a process
+/// exit code.
+struct ValidationReport {
+    project_count: usize,
+    record_count: usize,
+    person_count: usize,
+    org_count: usize,
+    errors: Vec<String>,
+}
+
+fn collect_validation_errors(data_dir: &std::path::Path) -> ValidationReport {
     use std::fs;
 
     let mut errors: Vec<String> = Vec::new();
@@ -415,6 +446,12 @@ fn validate(data_dir: PathBuf) -> ExitCode {
     // Validate projects
     let projects_dir = data_dir.join("projects");
     let mut contributor_ids: Vec<String> = Vec::new();
+    // Temporal-coverage resolution: the same ChronOntology period cache and
+    // offline enrichment table the OAI-PMH `every_committed_temporal_coverage_resolves`
+    // test loads, so the two can never disagree about what counts as resolved.
+    let temporal_periods = dpe_core::chronontology_cache::load_from(data_dir);
+    let temporal_enrichment = dpe_core::temporal_enrichment_cache::load_from(data_dir);
+    let mut seen_temporal_coverage: std::collections::HashSet<String> = std::collections::HashSet::new();
     if projects_dir.is_dir() {
         if let Ok(entries) = fs::read_dir(&projects_dir) {
             for entry in entries.flatten() {
@@ -438,7 +475,32 @@ fn validate(data_dir: PathBuf) -> ExitCode {
                                 }
                                 project_count += 1;
                                 // Validate conversion from raw to domain
-                                let _project: dpe_core::Project = raw.into();
+                                let project: dpe_core::Project = raw.into();
+
+                                for tc in &project.temporal_coverage {
+                                    let Some(name) = dpe_core::temporal_coverage::coverage_name(tc) else {
+                                        continue; // no name to key on; nothing to resolve.
+                                    };
+                                    if !seen_temporal_coverage.insert(name) {
+                                        continue; // already checked this distinct name.
+                                    }
+
+                                    // The same gap decision (resolved / intentionally
+                                    // unresolved / genuine gap) the
+                                    // `every_committed_temporal_coverage_resolves` test
+                                    // applies, so the two can't drift apart.
+                                    if let Some(name) = dpe_core::temporal_coverage::completeness_gap(
+                                        tc,
+                                        &temporal_periods,
+                                        &temporal_enrichment,
+                                    ) {
+                                        errors.push(format!(
+                                            "{filename}: temporalCoverage '{name}' has no resolved date \
+                                             (add a W3CDTF range to temporal-coverage-enrichment.json, \
+                                             or mark source=\"unresolved\" if not a time period)"
+                                        ));
+                                    }
+                                }
                             }
                             Err(e) => errors.push(format!("{filename}: {e}")),
                         }
@@ -544,21 +606,82 @@ fn validate(data_dir: PathBuf) -> ExitCode {
         }
     }
 
-    // Report results
-    println!(
-        "Validated: {} projects, {} records, {} persons, {} organizations",
-        project_count, record_count, person_count, org_count
-    );
+    ValidationReport { project_count, record_count, person_count, org_count, errors }
+}
 
-    if errors.is_empty() {
-        println!("All data files are valid.");
-        ExitCode::SUCCESS
-    } else {
-        println!("\n{} error(s) found:", errors.len());
-        for err in &errors {
-            println!("  - {err}");
+#[cfg(test)]
+mod validate_tests {
+    use super::collect_validation_errors;
+
+    /// A minimal `ProjectRaw`, valid except for its `temporalCoverage`, which
+    /// the caller supplies as a raw JSON array literal.
+    fn project_json(temporal_coverage: &str) -> String {
+        format!(
+            r#"{{
+                "id": "0000", "pid": "MISSING", "name": "Test Project", "shortcode": "0000",
+                "officialName": "Test Project", "status": "Finished", "shortDescription": "test",
+                "description": {{}}, "startDate": "MISSING", "endDate": "MISSING",
+                "howToCite": "test", "accessRights": {{ "accessRights": "Full Open Access" }},
+                "legalInfo": [], "keywords": [], "disciplines": [],
+                "temporalCoverage": {temporal_coverage}, "spatialCoverage": [], "attributions": [],
+                "funding": "No funding"
+            }}"#
+        )
+    }
+
+    /// Writes `project_json(temporal_coverage)` as the sole project file under a
+    /// fresh temp data dir (with an empty `projects/`), plus an optional
+    /// `temporal-coverage-enrichment.json` at the data dir root, and returns the
+    /// collected validation errors.
+    fn validate_with(temporal_coverage: &str, enrichment_json: Option<&str>) -> Vec<String> {
+        // An atomic counter (not e.g. the JSON literal's length) guarantees a
+        // distinct dir per call even if two callers happen to pass same-length
+        // literals — `cargo test` runs test fns concurrently, so a collision
+        // would let one test's cleanup race another's still-in-progress write.
+        static CALL_COUNT: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let call_id = CALL_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!("dpe_validate_temporal_{}_{call_id}", std::process::id()));
+        let projects_dir = dir.join("projects");
+        std::fs::create_dir_all(&projects_dir).unwrap();
+        std::fs::write(projects_dir.join("0000_test.json"), project_json(temporal_coverage)).unwrap();
+        if let Some(enrichment) = enrichment_json {
+            std::fs::write(dir.join("temporal-coverage-enrichment.json"), enrichment).unwrap();
         }
-        ExitCode::FAILURE
+
+        let report = collect_validation_errors(&dir);
+        std::fs::remove_dir_all(&dir).ok();
+        report.errors
+    }
+
+    #[test]
+    fn flags_temporal_coverage_with_no_resolved_date() {
+        let errors = validate_with(r#"[{"en": "Mysterious Era"}]"#, None);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("Mysterious Era") && e.contains("no resolved date")),
+            "expected an unresolved temporalCoverage error, got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn accepts_temporal_coverage_resolved_via_enrichment() {
+        let errors = validate_with(
+            r#"[{"en": "Early Christianity"}]"#,
+            Some(
+                r#"{"Early Christianity": {"date": "0030/0451", "original_name": "Early Christianity", "source": "llm"}}"#,
+            ),
+        );
+        assert!(errors.is_empty(), "expected no errors, got: {errors:?}");
+    }
+
+    #[test]
+    fn accepts_temporal_coverage_explicitly_marked_unresolved() {
+        let errors = validate_with(
+            r#"[{"en": "Swiss"}]"#,
+            Some(r#"{"Swiss": {"date": null, "original_name": "Swiss", "source": "unresolved"}}"#),
+        );
+        assert!(errors.is_empty(), "expected no errors, got: {errors:?}");
     }
 }
 


### PR DESCRIPTION
[DEV-6905](https://linear.app/dasch/issue/DEV-6905)

## Summary
- `dpe-server validate` (and `just validate-data`) now checks that every distinct `temporalCoverage` name resolves to a structured W3CDTF date, over the same ChronOntology period cache and offline enrichment table the OAI-PMH `every_committed_temporal_coverage_resolves` test loads.
- Previously `validate` did JSON parsing, cross-reference checks, orphan detection and the job-title role check, but no temporal check — REQ-1.12 credited it with one that didn't exist, so a depositor could submit successfully and only find out the resulting PR fails CI in `dpe-api-oai`.
- The editor inherits the check for free by reusing `validate` (Balduin's call in review of dasch-specs#168, Phase 4), rather than duplicating resolution logic there.

## Changes
- **New `dpe_core::temporal_coverage` module** — the resolution logic (ChronOntology URL → enrichment table → name-only fallback) and the "is this a genuine gap" decision (`completeness_gap`), extracted from `dpe-api-oai`'s DataCite mapping so it can be shared with `dpe-server`. `dpe-api-oai`'s `resolve_temporal_coverage_in` and the `every_committed_temporal_coverage_resolves` test now both call into it — the two enforcement points can't drift apart on what counts as resolved.
- **`dpe_core::multilingual_value`** — moved from `dpe-api-oai`'s `get_multilingual_value` (deterministic English-preferring picker used as the enrichment lookup key); `dpe-api-oai`'s helper now delegates to it.
- **`dpe-server::validate`** — refactored into `collect_validation_errors` (testable, returns a `ValidationReport`) wrapped by a thin `validate` that prints and sets the exit code; the projects loop now checks each distinct `temporalCoverage` name via `completeness_gap`.
- **Docs** — `modules/dpe/CLAUDE.md`, `docs/src/dpe/oai-pmh.md`, and `docs/src/dpe/operations.md` updated to describe the new check and the shared resolution module.

## Test Plan
- `just check` — fmt, clippy, unused-deps: clean.
- `just test` — full workspace suite: all green, including 3 new `dpe-server` tests (`validate_tests`) and 4 new `dpe-core` tests (`temporal_coverage::tests`).
- Fix-confirmation: temporarily disabled the new check block and confirmed `flags_temporal_coverage_with_no_resolved_date` fails against the unfixed code, then restored the fix and confirmed it passes.
- `cargo run --bin dpe-server -- validate modules/dpe/server/data` against all 85 committed project files: `All data files are valid.` (no false positives against production data).
- Adversarial review (rust-reviewer, consistency-reviewer, dune-reviewer) surfaced 3 findings, all fixed: a test temp-dir naming fragility (atomic counter instead of string-length uniqueness), a missed `operations.md` doc update, and a duplicated resolution-decision branch (extracted into `completeness_gap`).

## Screenshots
N/A — backend-only change, no UI.