### PR TITLE
feat(editor-server): add the SQLite persistence layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,6 +550,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883466cb8db62725aee5f4a6011e8a5d42912b42632df32aad57fc91127c6e04"
+dependencies = [
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2657f61fb1dd8bf37a8d51093cc7cee4e77125b22f7753f49b289f831bec2bae"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-sqlite"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cea80311362fbc476e1f9568f50d5ec576a8bbb9375b7cdc1856e3216870440"
+dependencies = [
+ "deadpool",
+ "deadpool-sync",
+ "rusqlite",
+]
+
+[[package]]
+name = "deadpool-sync"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e385cc95d3d582c328b36d1ff90feac061102b001894b555e6b465a2e0eaabbf"
+dependencies = [
+ "deadpool-runtime",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,14 +704,24 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 [[package]]
 name = "editor-core"
 version = "0.8.2"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "thiserror 2.0.18",
+ "uuid",
+]
 
 [[package]]
 name = "editor-server"
 version = "0.8.2"
 dependencies = [
+ "async-trait",
  "axum",
  "axum-tracing-opentelemetry",
+ "chrono",
  "clap",
+ "deadpool-sqlite",
+ "editor-core",
  "editor-web",
  "figment",
  "init-tracing-opentelemetry",
@@ -682,7 +732,9 @@ dependencies = [
  "opentelemetry_sdk",
  "platform-telemetry",
  "pyroscope",
+ "rusqlite",
  "serde",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tower-http",
@@ -691,6 +743,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "ureq",
+ "uuid",
 ]
 
 [[package]]
@@ -753,6 +806,12 @@ name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1098,10 +1157,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -1769,6 +1843,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,6 +2083,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2239,6 +2334,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "platform-telemetry"
@@ -2669,6 +2770,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
+dependencies = [
+ "bitflags 2.11.0",
+ "chrono",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3017,6 +3144,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3686,6 +3825,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,21 @@ thiserror = "2.0.12"
 quick-xml = "0.37"
 chrono = { version = "0.4" }
 proptest = "1"
+# SQLite for the metadata editor. `bundled` compiles the amalgamation via `cc`,
+# which is what makes the static musl binary self-contained — the known musl
+# segfault report against `rusqlite` is about dynamically linking a host
+# `libsqlite3` without it.
+#
+# Pinned to 0.38 rather than 0.40 because `deadpool-sqlite` 0.13 (latest)
+# requires `rusqlite ^0.38`, and the two cannot coexist: `libsqlite3-sys` 0.36
+# and 0.38 both declare `links = "sqlite3"`, so cargo refuses to link both.
+# Bump both together once deadpool-sqlite tracks 0.40.
+rusqlite = { version = "0.38", features = ["bundled", "chrono"] }
+# Async pool wrapping each `rusqlite::Connection` in a thread of its own, so
+# every call reaches it through `interact()` and the `!Sync` connection can
+# never be held across an `.await`.
+deadpool-sqlite = "0.13"
+async-trait = "0.1"
 
 # Build profiles
 [profile.release]

--- a/docs/src/editor/architecture.md
+++ b/docs/src/editor/architecture.md
@@ -21,13 +21,44 @@ Same as DPE: server-rendered HTML with **Maud**, served by **Axum**, with **Data
 
 | Crate | Folder | Role |
 |-------|--------|------|
-| `editor-core` | `editor/core` | Pure domain types (no Axum, Maud or database dependency) |
+| `editor-core` | `editor/core` | Pure domain types and the persistence ports (no Axum, Maud or database dependency) |
 | `editor-web` | `editor/web` | Maud view library — the document shell, pages and components |
 | `editor-server` | `editor/server` | Composition root: configuration, observability, routing, persistence |
 
 Dependency direction is `server → web → core`. Neither library depends on `mosaic-tiles` yet: the form widgets are the first surface to render a tile. The Tailwind entry already scans the crate, so component CSS ships regardless of the Cargo dependency.
 
 Unlike DPE, the **HTML document shell lives in the view crate** (`editor-web/src/view.rs`), not the server crate. DPE keeps `head()` + `page()` in `dpe-server`; here the server is a composition root for routing, auth and persistence, and a document shell is a view concern like any other partial.
+
+## Persistence
+
+One SQLite database, `rusqlite` with the `bundled` feature — the amalgamation is compiled by `cc` into the binary, which is what keeps the static musl image self-contained. `editor-core` owns the records and one repository trait per aggregate; `editor-server/src/db/` implements all six against SQLite, so handlers depend on the ports and not on the driver.
+
+`rusqlite` is pinned to **0.38, not 0.40**, because `deadpool-sqlite` 0.13 (the latest) requires `rusqlite ^0.38` and the two cannot coexist: `libsqlite3-sys` 0.36 and 0.38 both declare `links = "sqlite3"`, so cargo refuses to link both. Bump the pair together once `deadpool-sqlite` tracks 0.40.
+
+### Two pools, and what that buys
+
+`Database` holds a **writer** pool of exactly one connection and a **reader** pool of several. The split makes two rules structural instead of conventional:
+
+- Reader connections carry `query_only=ON`, set in the pool's per-connection init hook, so a write cannot go through `Database::read`. The only way to write is `Database::write`, and that always opens `BEGIN IMMEDIATE` — after which SQLite guarantees nothing up to the matching `COMMIT` returns `SQLITE_BUSY`. A deferred `BEGIN` takes a read lock and can fail to upgrade it at the first write, which surfaces only under concurrency, as `database is locked`, and looks like something `busy_timeout` should fix.
+- SQLite allows one writer at a time regardless, so a second writer connection would move the queue out of the pool (a bounded, observable wait) and into SQLite. One writer connection means writes serialise in the pool.
+
+`rusqlite::Connection` is `!Sync`. `deadpool-sqlite` keeps each connection on a thread of its own and only lends it inside an `interact` closure, so the connection cannot escape, no `.await` can happen while it is held, and there is no `Mutex` guard to hold across one. `pool.get()` is async, so nothing blocks a Tokio worker either. The same shape is why no read transaction outlives a call, which would otherwise starve WAL checkpointing and let `-wal` grow without bound.
+
+### PRAGMAs
+
+All of them are applied in the pool's `post_create` hook, not once after the pool is built: everything except `journal_mode` is per-connection state, so central setup would leave every connection after the first at `busy_timeout=0` and `foreign_keys=OFF` while the code read as though they were configured. `foreign_keys` in particular is a documented **silent no-op inside a transaction**, so it must never be set from a migration — `ON DELETE CASCADE` would never fire, orphaned `sessions` would accumulate against deleted `users`, and an integrity check would pass because the constraint was never enforced.
+
+File databases get `journal_mode=WAL` and `synchronous=NORMAL`; in-memory databases get neither, WAL being a file-database mode.
+
+### Schema
+
+A forward-only, append-only list of statement batches guarded by `PRAGMA user_version`, applied at startup — no migration framework and no added dependency. Everything runs in one `BEGIN IMMEDIATE` transaction including the version bump, so a crash part-way leaves the database at the version it started from. A database reporting a *higher* version than the build knows stops startup: that is a rollback to an older image, and running anyway would query columns that do not exist.
+
+The tables are `users`, `user_shortcodes`, `sessions`, `login_codes`, `drafts`, `submissions` and `approved_records`, all `STRICT`. `drafts`, `submissions` and `approved_records` carry their body as an opaque JSON `payload` string; the permissive draft representation types it later, and this layer never interprets it.
+
+### In-memory variant
+
+Selected by leaving `EDITOR_DB_DIR` unset, which is the default — see [Operations](./operations.md#database) for why that is also the preview-safety default. It is a **named shared-cache URI** (`file:<name>?mode=memory&cache=shared`), never bare `:memory:`: every `:memory:` database is distinct and visible only to the connection that opened it, so each pooled connection would get its own empty copy, and with a writer/reader split readers could never see anything the writer wrote. The symptom is `no such table` that comes and goes with pool timing and test order, which reads exactly like a migration bug. Tests use a distinct name each, because a shared-cache in-memory database is scoped to the process and parallel `cargo test` threads share one.
 
 ## URL scheme
 

--- a/docs/src/editor/operations.md
+++ b/docs/src/editor/operations.md
@@ -52,6 +52,9 @@ Locally the default is `127.0.0.1:4100`, deliberately not DPE's 4000, so `just d
 | `EDITOR_PUBLIC_DIR` | No | `modules/editor/public` | Directory served as static assets by `ServeDir` (favicon, logo, vendored JS, the telemetry module, and the compiled `app.<hash>.css`). |
 | `EDITOR_DATA_DIR` | Yes, to read records | *(none)* | Directory holding the published project/person/organization set baked into the image. No default — see [Data directory](#data-directory-a-deliberate-build-input). Reported at startup, as `<unset>` when absent. |
 | `EDITOR_ENV` | No | `DEV` | Deployment environment (`DEV` or `PROD`). Controls OTLP log export (see [Logging](#logging)). The Docker image sets `PROD`. |
+| `EDITOR_DB_DIR` | No | *(none — in-memory)* | Directory holding the SQLite database. **Unset means in-memory**, not a path — see [Database](#database). Names the *directory*, never the database file. |
+| `EDITOR_DB_READERS` | No | `4` | Size of the reader connection pool. The writer pool is always one connection. |
+| `EDITOR_DB_BUSY_TIMEOUT_MS` | No | `5000` | SQLite `busy_timeout`, applied per connection. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | No | *(none)* | OTLP gRPC endpoint (e.g. `http://alloy:4317`). When unset, OTel falls back to no-op export. |
 | `OTEL_SERVICE_NAME` | No | *(none)* | Service name for OTel resource attributes (e.g. `editor`) |
 | `OTEL_RESOURCE_ATTRIBUTES` | No | *(none)* | Comma-separated OTel resource attributes (e.g. `service.namespace=editor,service.version=0.8.2,deployment.environment=prod`) |
@@ -80,20 +83,44 @@ It deploys on a **separate hostname** from DPE, not a path under `repository.das
 Not yet in place, and blocking production deployment only:
 
 - The editor is **not registered as a deployable service in Jenkins**, so the DEV deploy trigger in `editor-docker-publish.yml` is marked `continue-on-error` and only warns. Remove that guard once the Jenkins job exists, so a genuinely broken webhook is loud again.
-- The writable data volume for SQLite. Development and tests use an in-memory database, so only production waits on it.
+- The writable data volume `EDITOR_DB_DIR` points at, tracked as [INFRA-1378](https://linear.app/dasch/issue/INFRA-1378/extend-deploy-volumes). Development and tests use the in-memory database, so only production waits on it.
 
-### Data volume (once persistence lands)
+## Database
 
-- Mount the **directory**, not the database file, so SQLite can create its `-wal` and `-shm` siblings next to it.
+One SQLite database, holding users, sessions, one-time codes, drafts, submissions and approved records. See [Architecture](./architecture.md#persistence) for the pool and PRAGMA design.
+
+### In-memory is the default, deliberately
+
+`EDITOR_DB_DIR` has **no default**, and unset means in-memory rather than some path the editor invented. That is preview safety, not a convenience: the Cloud Run PR preview has no mounted volume, runs `--max-instances=1`, and is publicly reachable, so a publicly reachable preview must not be able to accumulate login codes, sessions or drafts. It also means `just dev-editor` and `cargo test` need no volume.
+
+The Docker image deliberately does **not** set `EDITOR_DB_DIR`, for the same reason — the previews run that image. Production sets it through the deployment.
+
+### Data volume
+
+- Mount the **directory**, not the database file, so SQLite can create its `-wal` and `-shm` siblings next to it. `EDITOR_DB_DIR` names the directory and the filename is fixed at `editor.sqlite3`, so pointing it at a file fails at startup with a message saying so rather than at the first WAL write.
 - It must be **writable by uid 65532**. Chowning to 65534 produces `unable to open database file`, which reads like a wrong mount path and sends the reader hunting for a typo in a path that is perfectly correct.
 - Docker Swarm does **not** create missing bind-mount host directories the way `docker run -v` does, so Ansible must create *and* chown the directory before the stack starts.
 - Keep `replicas: 1` with `order: stop-first`, so a rolling update never briefly runs two processes against one database file. Node pinning is unnecessary — there is no multi-node Swarm.
+
+### Startup pre-flight
+
+Before opening the database, startup writes and removes a probe file in `EDITOR_DB_DIR` and reports the three failures separately: the directory is missing, it is a file rather than a directory, or it cannot be written to. Without the probe all three arrive as SQLite's `unable to open database file`, which is the same message for a typo in the path, a wrong uid and a root-owned mount. The unwritable-directory message names uid 65532 explicitly.
+
+### Storage type
+
+virtiofs is preferred over a block device with ext4, and only virtiofs gets the automatic ZFS snapshots. WAL is safe on it: SQLite's restriction is about multiple **hosts**, not multiple processes, and every accessor lives inside one guest VM.
+
+If virtiofs `mmap` ever misbehaves, the escape hatch is `locking_mode=EXCLUSIVE` set before first access, which skips the wal-index entirely — valid here because access is single-process. It is deliberately **not** a configuration knob: an untested code path is worse than a one-line change in `init_connection`, and the situation calling for it has never occurred.
+
+### Backups
+
+Optional, per the PRD. Git holds everything irreplaceable; a total loss of the volume costs drafts, in-flight submissions, approved records not yet collected and the depositor table, all re-creatable. `synchronous=NORMAL` is set with WAL on that basis: a commit no longer fsyncs, so an OS crash or power loss can lose the last transactions — never corrupt the database, and never on an application crash.
 
 ## Resource Requirements
 
 - **Memory**: ~50–100 MB typical
 - **CPU**: Minimal (server-side rendering; the published data set is cached in memory)
-- **Disk**: Data files + static assets, plus the SQLite database once persistence lands
+- **Disk**: Data files + static assets, plus the SQLite database and its `-wal`/`-shm` siblings when `EDITOR_DB_DIR` is set
 
 ## Logging
 

--- a/modules/editor/Dockerfile
+++ b/modules/editor/Dockerfile
@@ -32,6 +32,13 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD ["./editor-server", "healthcheck"]
 
 # The `:nonroot` tag runs as uid 65532 (distroless NONROOT), not 65534 (nobody).
-# This matters once SQLite lands: the mounted data *directory* must be writable
-# by 65532, and chowning it to 65534 produces `unable to open database file`,
-# which reads like a wrong mount path rather than a permissions problem.
+# The directory EDITOR_DB_DIR points at must be writable by 65532; chowning it to
+# 65534 produces `unable to open database file`, which reads like a wrong mount
+# path rather than a permissions problem. The startup pre-flight catches it and
+# says so, but the mount still has to be right.
+#
+# EDITOR_DB_DIR is deliberately NOT set here. Unset means an in-memory database,
+# and the Cloud Run PR previews run this image with no mounted volume, publicly
+# reachable — so a default path would let a preview accumulate login codes,
+# sessions and drafts in its ephemeral filesystem. Production sets the variable
+# through the deployment. See docs/src/editor/operations.md#database.

--- a/modules/editor/core/Cargo.toml
+++ b/modules/editor/core/Cargo.toml
@@ -5,3 +5,12 @@ edition = "2021"
 publish = false
 
 [dependencies]
+# Pure domain types and the repository ports. No Axum, Maud, rusqlite or
+# deadpool here — the SQLite implementations live in `editor-server`, behind
+# these traits.
+async-trait.workspace = true
+chrono.workspace = true
+thiserror.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]

--- a/modules/editor/core/src/lib.rs
+++ b/modules/editor/core/src/lib.rs
@@ -3,8 +3,15 @@
 //! Mirrors `dpe-core`'s role: framework-free types shared by `editor-web` and
 //! `editor-server`, with no Axum, Maud or database dependency.
 //!
-//! Deliberately empty at this point. The types it will own — the permissive
-//! draft representation, the order-preserving multi-language map, and the
-//! canonical `ProjectRaw` conversion — land with the draft model. The crate
-//! exists from the scaffold so the `server → web → core` dependency direction
-//! is established before anything can be written the wrong way round.
+//! What it owns today is the persistence contract: the records the editor
+//! stores ([`records`]) and one port per aggregate ([`repository`]). The SQLite
+//! implementations of those ports live in `editor-server`, which keeps the
+//! `server → web → core` direction intact and the driver out of the domain.
+//!
+//! Still to land: the permissive draft representation, the order-preserving
+//! multi-language map, and the canonical `ProjectRaw` conversion. Until then
+//! drafts, submissions and approved records carry their body as an opaque JSON
+//! `payload` — see [`records`].
+
+pub mod records;
+pub mod repository;

--- a/modules/editor/core/src/records.rs
+++ b/modules/editor/core/src/records.rs
@@ -1,0 +1,281 @@
+//! The records the editor persists.
+//!
+//! Framework-free on purpose: no `rusqlite`, no Axum, no Maud. The SQLite
+//! column mapping lives in `editor-server`, behind the ports in
+//! [`crate::repository`].
+//!
+//! Three of these carry their body as an opaque `payload: String` of JSON. The
+//! permissive draft representation is Phase 4's work (`ProjectRaw` requires
+//! fields a draft must be allowed to omit), and inventing a type for it here
+//! would mean inventing it twice. The persistence layer never interprets the
+//! payload, so typing it later changes these structs and nothing else.
+
+use std::fmt;
+use std::str::FromStr;
+
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+/// The two roles the editor recognises (REQ-7.1).
+///
+/// `rdu` members come from configuration and always exist without provisioning
+/// (REQ-7.2); depositors are rows created by RDU (REQ-7.3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Role {
+    Depositor,
+    Rdu,
+}
+
+impl Role {
+    /// The stored form. Pinned by a `CHECK` constraint in the schema, so this
+    /// and the migration have to agree.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Depositor => "depositor",
+            Self::Rdu => "rdu",
+        }
+    }
+}
+
+impl fmt::Display for Role {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A stored value outside the known set. Reachable only if the database is
+/// edited by hand or a migration adds a variant the code does not know.
+#[derive(Debug, thiserror::Error)]
+#[error("unknown {kind} {value:?}")]
+pub struct UnknownVariant {
+    pub kind: &'static str,
+    pub value: String,
+}
+
+impl FromStr for Role {
+    type Err = UnknownVariant;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "depositor" => Ok(Self::Depositor),
+            "rdu" => Ok(Self::Rdu),
+            other => Err(UnknownVariant { kind: "role", value: other.to_string() }),
+        }
+    }
+}
+
+/// A person who can log in.
+///
+/// `email` is stored as entered and in plaintext (PRD Constraints: the
+/// application must decrypt it to send mail, so a key would sit beside the
+/// data). `email_normalized` — lowercased — carries the uniqueness constraint
+/// and every lookup, so REQ-7.4 rejects `A@x.test` against a stored `a@x.test`
+/// and REQ-6.2's anti-enumeration lookup is case-insensitive too.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct User {
+    pub id: Uuid,
+    pub email: String,
+    pub name: String,
+    pub role: Role,
+    /// Project shortcodes this user may reach (REQ-1.2, REQ-7.3). Empty for an
+    /// RDU member, whose access is role-based rather than per-project
+    /// (REQ-4.2).
+    pub shortcodes: Vec<String>,
+    /// Consecutive failed authentications **for the account**, not for a code.
+    /// NIST SP 800-63B-4: "Generating a new authentication secret SHALL NOT
+    /// reset the failed authentication count" — so this survives code
+    /// invalidation and resend, and only a successful login clears it.
+    pub failed_logins: u32,
+    /// When a login code was last issued, so RDU can answer "I never got a
+    /// code" without an address reaching a log (REQ-6.10).
+    pub last_code_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+}
+
+impl User {
+    /// The lookup and uniqueness key: `email` lowercased.
+    ///
+    /// `to_lowercase` rather than `to_ascii_lowercase` so a non-ASCII address
+    /// folds too. Only the whole address is folded — the local part is
+    /// case-sensitive per RFC 5321, but no mail provider anyone here uses
+    /// treats it that way, and letting `A@x.test` and `a@x.test` both exist
+    /// would make REQ-7.4 depend on how the address was typed.
+    #[must_use]
+    pub fn normalize_email(email: &str) -> String {
+        email.trim().to_lowercase()
+    }
+
+    /// This user's normalized address.
+    #[must_use]
+    pub fn email_normalized(&self) -> String {
+        Self::normalize_email(&self.email)
+    }
+}
+
+/// An authenticated session (REQ-6.3).
+///
+/// `id` is the opaque token carried by the cookie, not a UUID: how it is minted
+/// is the auth layer's decision, and this layer only stores it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Session {
+    pub id: String,
+    pub user_id: Uuid,
+    pub created_at: DateTime<Utc>,
+    /// Advanced on use, for the idle timeout.
+    pub last_seen_at: DateTime<Utc>,
+    /// Absolute expiry, set at creation and never extended.
+    pub expires_at: DateTime<Utc>,
+}
+
+/// A one-time login code (REQ-6.1).
+///
+/// Stored unhashed, deliberately: it lives ten minutes, and anyone who can read
+/// this table already holds `sessions` (PRD Constraints).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoginCode {
+    pub id: Uuid,
+    pub user_id: Uuid,
+    pub code: String,
+    /// Wrong entries against *this* code. Three invalidates it (REQ-6.4); the
+    /// account-level counter that survives a resend is [`User::failed_logins`].
+    pub attempts: u32,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    /// Set when the code is accepted. A code is usable once, for replay
+    /// resistance (NIST SP 800-63B-4 §3.1.3.2).
+    pub consumed_at: Option<DateTime<Utc>>,
+}
+
+/// Work in progress on one project (REQ-1.10).
+///
+/// Keyed by shortcode: one draft per project, not per user — per-user multiple
+/// drafts are out of scope, and concurrency is last-write-wins.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DraftRecord {
+    pub shortcode: String,
+    /// JSON. Typed in Phase 4; see the module docs.
+    pub payload: String,
+    /// The last editor, `None` once that user is removed — the row survives so
+    /// the depositor's work is not destroyed by an account deletion, and the
+    /// review queue's "last editor" column reads as unknown rather than
+    /// dangling.
+    pub updated_by: Option<Uuid>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Where a submission sits in review.
+///
+/// `Draft` and `Online` from REQ-2.1 are deliberately absent: a draft is a
+/// `drafts` row, and Online is derived at startup by comparing against the
+/// published set, at which point the local record is discarded (REQ-2.4).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SubmissionState {
+    Submitted,
+    InReview,
+    Approved,
+}
+
+impl SubmissionState {
+    /// The stored form, pinned by a `CHECK` constraint in the schema.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Submitted => "submitted",
+            Self::InReview => "in_review",
+            Self::Approved => "approved",
+        }
+    }
+}
+
+impl fmt::Display for SubmissionState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for SubmissionState {
+    type Err = UnknownVariant;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "submitted" => Ok(Self::Submitted),
+            "in_review" => Ok(Self::InReview),
+            "approved" => Ok(Self::Approved),
+            other => Err(UnknownVariant { kind: "submission state", value: other.to_string() }),
+        }
+    }
+}
+
+/// A submission awaiting or under review (REQ-1.12, REQ-4.x).
+///
+/// One per project at a time — the schema makes `shortcode` unique, which is
+/// PRD Constraints' "one pending submission per project" rather than a
+/// convention handlers have to remember.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Submission {
+    pub id: Uuid,
+    pub shortcode: String,
+    /// JSON. Typed in Phase 4; see the module docs.
+    pub payload: String,
+    pub state: SubmissionState,
+    /// `None` once the submitter is removed; see [`DraftRecord::updated_by`].
+    pub submitted_by: Option<Uuid>,
+    pub submitted_at: DateTime<Utc>,
+    pub reviewed_by: Option<Uuid>,
+    pub reviewed_at: Option<DateTime<Utc>>,
+    /// Carried back to the depositor when RDU requests changes (REQ-4.5).
+    pub reviewer_note: Option<String>,
+}
+
+/// An approved record waiting to be collected into a pull request (REQ-5.1).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApprovedRecord {
+    pub id: Uuid,
+    pub shortcode: String,
+    /// JSON. Typed in Phase 4; see the module docs.
+    pub payload: String,
+    /// `None` once the approver is removed; see [`DraftRecord::updated_by`].
+    pub approved_by: Option<Uuid>,
+    pub approved_at: DateTime<Utc>,
+    /// `None` while uncollected. A failed collection leaves it `None` so the
+    /// next run retries it (REQ-5.7).
+    pub collected_at: Option<DateTime<Utc>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_role_round_trips_through_its_stored_form() {
+        for role in [Role::Depositor, Role::Rdu] {
+            assert_eq!(role.as_str().parse::<Role>().unwrap(), role);
+        }
+    }
+
+    #[test]
+    fn test_submission_state_round_trips_through_its_stored_form() {
+        for state in [
+            SubmissionState::Submitted,
+            SubmissionState::InReview,
+            SubmissionState::Approved,
+        ] {
+            assert_eq!(state.as_str().parse::<SubmissionState>().unwrap(), state);
+        }
+    }
+
+    #[test]
+    fn test_unknown_stored_variant_is_an_error_not_a_default() {
+        // A row the code does not understand must surface, not silently become
+        // `Depositor` — that would hand an unknown role a depositor's access.
+        assert!("admin".parse::<Role>().is_err());
+        assert!("rejected".parse::<SubmissionState>().is_err());
+    }
+
+    #[test]
+    fn test_normalize_email_folds_case_and_trims() {
+        assert_eq!(User::normalize_email("  A.User@Example.TEST "), "a.user@example.test");
+    }
+}

--- a/modules/editor/core/src/repository.rs
+++ b/modules/editor/core/src/repository.rs
@@ -1,0 +1,211 @@
+//! The persistence ports, one trait per aggregate.
+//!
+//! Framework-free: the traits name domain records and [`RepositoryError`], never
+//! a `rusqlite` type. `editor-server` implements all six against SQLite, so the
+//! handlers Phase 3 onwards writes depend on these and not on the driver.
+//!
+//! Every method is `async` and boxed via `async_trait` rather than left as a
+//! bare `async fn` in a trait: the futures have to be `Send` to be awaited
+//! inside an Axum handler, and the traits have to stay dyn-compatible so state
+//! can hold `Arc<dyn UserRepository>`. Native `async fn` in traits gives neither
+//! without spelling out `-> impl Future + Send` on every signature.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use crate::records::{ApprovedRecord, DraftRecord, LoginCode, Session, Submission, User};
+
+/// What can go wrong in a repository call.
+///
+/// [`Self::Backend`] keeps the driver error as a `source` without naming its
+/// type, so the error chain survives into the logs while this crate stays free
+/// of a database dependency.
+#[derive(Debug, thiserror::Error)]
+pub enum RepositoryError {
+    /// The row addressed by an update or delete does not exist.
+    #[error("{entity} not found")]
+    NotFound { entity: &'static str },
+
+    /// A uniqueness constraint rejected the write — a duplicate email
+    /// (REQ-7.4), or a second pending submission for one project.
+    #[error("{entity} already exists")]
+    Conflict { entity: &'static str },
+
+    /// A stored value the code cannot interpret; see
+    /// [`crate::records::UnknownVariant`].
+    #[error("stored data could not be read: {0}")]
+    Corrupt(String),
+
+    /// Anything the storage backend itself reported.
+    #[error("storage backend failed")]
+    Backend(#[source] Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl RepositoryError {
+    /// Wrap a backend error.
+    pub fn backend<E: std::error::Error + Send + Sync + 'static>(error: E) -> Self {
+        Self::Backend(Box::new(error))
+    }
+}
+
+/// Shorthand for repository results.
+pub type Result<T> = std::result::Result<T, RepositoryError>;
+
+/// Accounts (US-7) and the account-level failure counter the login flow needs.
+#[async_trait]
+pub trait UserRepository: Send + Sync {
+    /// Insert a user, together with its shortcode assignments.
+    ///
+    /// Returns [`RepositoryError::Conflict`] if the normalized address is
+    /// already taken (REQ-7.4).
+    async fn create(&self, user: &User) -> Result<()>;
+
+    /// Replace name, address, role and shortcode assignments.
+    ///
+    /// US-7 has create and remove only; update exists because removing a
+    /// shortcode from someone holding a draft on it is otherwise undefined.
+    async fn update(&self, user: &User) -> Result<()>;
+
+    /// Delete a user. `ON DELETE CASCADE` takes its sessions, codes and
+    /// shortcode assignments with it (REQ-7.5); its drafts and submissions
+    /// survive with a null author.
+    async fn delete(&self, id: Uuid) -> Result<()>;
+
+    async fn find_by_id(&self, id: Uuid) -> Result<Option<User>>;
+
+    /// Look up by address, case-insensitively — the argument is normalized
+    /// before the query, so callers pass whatever the user typed.
+    async fn find_by_email(&self, email: &str) -> Result<Option<User>>;
+
+    /// Every user, for the RDU depositor list.
+    async fn list(&self) -> Result<Vec<User>>;
+
+    /// Increment the account-level consecutive-failure counter and return its
+    /// new value. Survives code invalidation and resend by construction: it
+    /// lives on the user, not on the code.
+    async fn record_failed_login(&self, id: Uuid) -> Result<u32>;
+
+    /// Clear the counter. Only a successful authentication may call this.
+    async fn clear_failed_logins(&self, id: Uuid) -> Result<()>;
+
+    /// Stamp when a code was last issued to this user (REQ-6.10 diagnosis
+    /// without an address in a log).
+    async fn record_code_issued(&self, id: Uuid, at: DateTime<Utc>) -> Result<()>;
+}
+
+/// Sessions (REQ-6.3, REQ-6.6, REQ-7.5).
+#[async_trait]
+pub trait SessionRepository: Send + Sync {
+    async fn create(&self, session: &Session) -> Result<()>;
+
+    async fn find(&self, id: &str) -> Result<Option<Session>>;
+
+    /// Advance `last_seen_at` for the idle timeout.
+    async fn touch(&self, id: &str, at: DateTime<Utc>) -> Result<()>;
+
+    /// Delete one session (REQ-6.6). `false` if it was already gone.
+    async fn delete(&self, id: &str) -> Result<bool>;
+
+    /// Delete every session belonging to a user, for logout-everywhere and for
+    /// session rotation on login. Account removal does not need this — the
+    /// foreign key cascades — but rotation does.
+    async fn delete_for_user(&self, user_id: Uuid) -> Result<u64>;
+
+    /// Drop sessions past their absolute expiry. Returns how many went.
+    async fn delete_expired(&self, now: DateTime<Utc>) -> Result<u64>;
+}
+
+/// One-time login codes (REQ-6.1, REQ-6.4, REQ-6.5).
+#[async_trait]
+pub trait LoginCodeRepository: Send + Sync {
+    async fn create(&self, code: &LoginCode) -> Result<()>;
+
+    /// The user's newest code that has not expired and has not been consumed.
+    async fn find_active_for_user(&self, user_id: Uuid, now: DateTime<Utc>) -> Result<Option<LoginCode>>;
+
+    /// The user's newest code whatever its state, so the resend cooldown can be
+    /// measured against it (REQ-6.5).
+    async fn find_latest_for_user(&self, user_id: Uuid) -> Result<Option<LoginCode>>;
+
+    /// Increment this code's wrong-entry count and return the new value. Three
+    /// invalidates it (REQ-6.4).
+    async fn record_attempt(&self, id: Uuid) -> Result<u32>;
+
+    /// Mark a code used, once. `false` means it was already consumed — a replay,
+    /// which must not authenticate (NIST SP 800-63B-4 §3.1.3.2).
+    async fn consume(&self, id: Uuid, at: DateTime<Utc>) -> Result<bool>;
+
+    /// Delete every outstanding code for a user, for the three-strike
+    /// invalidation and before issuing a replacement.
+    async fn delete_for_user(&self, user_id: Uuid) -> Result<u64>;
+
+    /// How many codes were issued across all users since `since`, for the global
+    /// daily send cap — without it, looping resend exhausts the relay quota and
+    /// locks out every user including RDU.
+    async fn count_issued_since(&self, since: DateTime<Utc>) -> Result<u64>;
+
+    /// Drop expired codes. Returns how many went.
+    async fn delete_expired(&self, now: DateTime<Utc>) -> Result<u64>;
+}
+
+/// Drafts (REQ-1.10, REQ-1.11).
+#[async_trait]
+pub trait DraftRepository: Send + Sync {
+    /// Insert or replace the project's draft. Last write wins, per PRD
+    /// Constraints.
+    async fn upsert(&self, draft: &DraftRecord) -> Result<()>;
+
+    async fn find(&self, shortcode: &str) -> Result<Option<DraftRecord>>;
+
+    /// Every draft, newest first — RDU sees all of them, so it can help a
+    /// depositor who is stuck before submission (REQ-1.11).
+    async fn list(&self) -> Result<Vec<DraftRecord>>;
+
+    /// `false` if there was no draft to delete.
+    async fn delete(&self, shortcode: &str) -> Result<bool>;
+}
+
+/// Submissions (REQ-1.12, US-4).
+#[async_trait]
+pub trait SubmissionRepository: Send + Sync {
+    /// Record a project's pending submission. [`RepositoryError::Conflict`] if
+    /// one is already pending for that shortcode.
+    async fn create(&self, submission: &Submission) -> Result<()>;
+
+    /// Replace state, reviewer, review time and note.
+    async fn update(&self, submission: &Submission) -> Result<()>;
+
+    async fn find(&self, id: Uuid) -> Result<Option<Submission>>;
+
+    async fn find_by_shortcode(&self, shortcode: &str) -> Result<Option<Submission>>;
+
+    /// The review queue: every pending submission, oldest first (REQ-4.1).
+    async fn list(&self) -> Result<Vec<Submission>>;
+
+    /// `false` if there was no submission to delete. Covers reject (REQ-4.6),
+    /// depositor discard (REQ-4.7) and the move to approved.
+    async fn delete(&self, id: Uuid) -> Result<bool>;
+}
+
+/// Approved records awaiting collection (US-5).
+#[async_trait]
+pub trait ApprovedRecordRepository: Send + Sync {
+    async fn create(&self, record: &ApprovedRecord) -> Result<()>;
+
+    /// What the public collection endpoint serves: approved and not yet
+    /// collected, oldest first (REQ-5.1).
+    async fn list_uncollected(&self) -> Result<Vec<ApprovedRecord>>;
+
+    /// Every approved record for a project, so the startup comparison can find
+    /// the one that matches the published data (REQ-2.3).
+    async fn find_by_shortcode(&self, shortcode: &str) -> Result<Vec<ApprovedRecord>>;
+
+    /// Stamp a record as collected. Leaving it unstamped is what makes a failed
+    /// collection retry on the next run (REQ-5.7).
+    async fn mark_collected(&self, id: Uuid, at: DateTime<Utc>) -> Result<()>;
+
+    /// `false` if there was no record to delete. Used when the change goes
+    /// Online and the local record is discarded (REQ-2.4).
+    async fn delete(&self, id: Uuid) -> Result<bool>;
+}

--- a/modules/editor/server/Cargo.toml
+++ b/modules/editor/server/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 ureq = "3"
+editor-core = { path = "../core" }
 editor-web = { path = "../web" }
 # Shared so both services agree on the trace-context and beacon wire formats.
 # Not part of the DPE runtime — it reads none of DPE's data or config. Its
@@ -17,6 +18,15 @@ maud.workspace = true
 axum.workspace = true
 figment = { version = "0.10", features = ["env", "toml"] }
 serde.workspace = true
+# Persistence. `rusqlite` is synchronous and its `Connection` is `!Sync`;
+# `deadpool-sqlite` keeps each connection on a thread of its own so every
+# call goes through `interact()` and none can be held across an `.await`.
+rusqlite.workspace = true
+deadpool-sqlite.workspace = true
+async-trait.workspace = true
+chrono.workspace = true
+thiserror.workspace = true
+uuid.workspace = true
 tokio.workspace = true
 tower-http.workspace = true
 tower_governor.workspace = true

--- a/modules/editor/server/src/config.rs
+++ b/modules/editor/server/src/config.rs
@@ -43,6 +43,35 @@ pub struct EditorConfig {
     /// over OTLP when an endpoint is configured; `PROD` logs to stdout only.
     /// Set via `EDITOR_ENV`.
     pub env: String,
+
+    /// Directory holding the SQLite database, set via `EDITOR_DB_DIR`.
+    ///
+    /// **No default, and unset means in-memory** — not a path. That is the
+    /// preview-safety default: the Cloud Run PR preview has no mounted volume
+    /// and is publicly reachable, so a publicly reachable preview must not be
+    /// able to accumulate state. It also means tests and `just dev-editor` need
+    /// no volume.
+    ///
+    /// Production sets it to the mount Infra provides. It names the
+    /// **directory**, never the database file: SQLite creates `-wal` and `-shm`
+    /// siblings next to the file, which is impossible if the file itself is the
+    /// mount point. Startup writes and removes a probe file in it, so a
+    /// wrong-uid or root-owned mount fails with a message that says so.
+    pub db_dir: Option<PathBuf>,
+
+    /// Size of the reader connection pool, set via `EDITOR_DB_READERS`.
+    ///
+    /// The writer pool is always one connection: SQLite permits a single writer
+    /// at a time, so a second would move the queue from the pool into SQLite.
+    pub db_readers: usize,
+
+    /// SQLite `busy_timeout` in milliseconds, set via `EDITOR_DB_BUSY_TIMEOUT_MS`.
+    ///
+    /// Applied per connection, because that is the only place it has effect. It
+    /// is a backstop rather than the primary defence: writes serialise in the
+    /// pool and open `BEGIN IMMEDIATE`, so a reader waiting on a checkpoint is
+    /// the case it actually covers.
+    pub db_busy_timeout_ms: u64,
 }
 
 impl Default for EditorConfig {
@@ -52,6 +81,9 @@ impl Default for EditorConfig {
             public_dir: PathBuf::from("modules/editor/public"),
             data_dir: None,
             env: "DEV".to_string(),
+            db_dir: None,
+            db_readers: 4,
+            db_busy_timeout_ms: 5_000,
         }
     }
 }
@@ -72,6 +104,24 @@ impl EditorConfig {
     pub fn exports_otlp_logs(&self) -> bool {
         self.env == "DEV"
     }
+
+    /// Where the database lives: the configured directory, or a named in-memory
+    /// database when `EDITOR_DB_DIR` is unset.
+    ///
+    /// The in-memory name is fixed rather than random, because a shared-cache
+    /// in-memory database is scoped to the process and there is one per process.
+    /// It is never bare `:memory:` — see `db::Source::Memory`.
+    pub fn db_source(&self) -> crate::db::Source {
+        match &self.db_dir {
+            Some(dir) => crate::db::Source::Directory(dir.clone()),
+            None => crate::db::Source::Memory("editor".to_string()),
+        }
+    }
+
+    /// The configured `busy_timeout`.
+    pub fn db_busy_timeout(&self) -> std::time::Duration {
+        std::time::Duration::from_millis(self.db_busy_timeout_ms)
+    }
 }
 
 #[cfg(test)]
@@ -85,6 +135,45 @@ mod tests {
         assert_eq!(config.public_dir, PathBuf::from("modules/editor/public"));
         assert_eq!(config.data_dir, None);
         assert_eq!(config.env, "DEV");
+        assert_eq!(config.db_dir, None);
+        assert_eq!(config.db_readers, 4);
+        assert_eq!(config.db_busy_timeout_ms, 5_000);
+    }
+
+    #[test]
+    fn database_defaults_to_in_memory_so_a_preview_cannot_accumulate_state() {
+        // The Cloud Run PR preview has no mounted volume and is publicly
+        // reachable. If the default were a path, the preview would persist login
+        // codes, sessions and drafts in its ephemeral filesystem for as long as
+        // the revision lived.
+        figment::Jail::expect_with(|_| {
+            let config = EditorConfig::load().expect("config should load");
+            assert!(matches!(config.db_source(), crate::db::Source::Memory(_)));
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn db_dir_env_override_selects_a_file_database() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("EDITOR_DB_DIR", "/data/editor");
+            let config = EditorConfig::load().expect("config should load");
+            assert_eq!(config.db_dir, Some(PathBuf::from("/data/editor")));
+            assert_eq!(config.db_source(), crate::db::Source::Directory(PathBuf::from("/data/editor")));
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn db_pool_and_timeout_env_overrides() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("EDITOR_DB_READERS", "8");
+            jail.set_env("EDITOR_DB_BUSY_TIMEOUT_MS", "2500");
+            let config = EditorConfig::load().expect("config should load");
+            assert_eq!(config.db_readers, 8);
+            assert_eq!(config.db_busy_timeout(), std::time::Duration::from_millis(2500));
+            Ok(())
+        });
     }
 
     #[test]

--- a/modules/editor/server/src/db/approved_records.rs
+++ b/modules/editor/server/src/db/approved_records.rs
@@ -1,0 +1,269 @@
+//! [`ApprovedRecordRepository`] against SQLite.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use editor_core::records::ApprovedRecord;
+use editor_core::repository::{ApprovedRecordRepository, RepositoryError, Result};
+use rusqlite::{params, Row};
+use uuid::Uuid;
+
+use super::mapping::{optional_uuid_column, uuid_column};
+use super::Database;
+
+const ENTITY: &str = "approved record";
+
+const SELECT: &str = "SELECT id, shortcode, payload, approved_by, approved_at, collected_at FROM approved_records";
+
+fn map_row(row: &Row<'_>) -> rusqlite::Result<ApprovedRecord> {
+    Ok(ApprovedRecord {
+        id: uuid_column(row, 0)?,
+        shortcode: row.get(1)?,
+        payload: row.get(2)?,
+        approved_by: optional_uuid_column(row, 3)?,
+        approved_at: row.get(4)?,
+        collected_at: row.get(5)?,
+    })
+}
+
+#[async_trait]
+impl ApprovedRecordRepository for Database {
+    async fn create(&self, record: &ApprovedRecord) -> Result<()> {
+        let record = record.clone();
+        self.write(move |tx| {
+            tx.execute(
+                "INSERT INTO approved_records (id, shortcode, payload, approved_by, approved_at, collected_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    record.id.to_string(),
+                    record.shortcode,
+                    record.payload,
+                    record.approved_by.map(|id| id.to_string()),
+                    record.approved_at,
+                    record.collected_at,
+                ],
+            )
+        })
+        .await
+        .map_err(|e| e.into_repository_error(ENTITY))?;
+        Ok(())
+    }
+
+    async fn list_uncollected(&self) -> Result<Vec<ApprovedRecord>> {
+        Ok(self
+            .read(|conn| {
+                // Oldest first, so a run that fails part-way still makes progress
+                // from the front of the queue. `collected_at IS NULL` matches the
+                // partial index, so collected rows are never scanned.
+                let mut stmt =
+                    conn.prepare(&format!("{SELECT} WHERE collected_at IS NULL ORDER BY approved_at, shortcode"))?;
+                let rows = stmt.query_map([], map_row)?;
+                rows.collect()
+            })
+            .await?)
+    }
+
+    async fn find_by_shortcode(&self, shortcode: &str) -> Result<Vec<ApprovedRecord>> {
+        let shortcode = shortcode.to_string();
+        Ok(self
+            .read(move |conn| {
+                let mut stmt = conn.prepare(&format!("{SELECT} WHERE shortcode = ?1 ORDER BY approved_at"))?;
+                let rows = stmt.query_map(params![shortcode], map_row)?;
+                rows.collect()
+            })
+            .await?)
+    }
+
+    async fn mark_collected(&self, id: Uuid, at: DateTime<Utc>) -> Result<()> {
+        // `collected_at IS NULL` in the WHERE clause, so a re-run of a partly
+        // successful collection cannot overwrite the time a record was first
+        // collected.
+        let marked = self
+            .write(move |tx| {
+                tx.execute(
+                    "UPDATE approved_records SET collected_at = ?2 WHERE id = ?1 AND collected_at IS NULL",
+                    params![id.to_string(), at],
+                )
+            })
+            .await?;
+        if marked == 0 {
+            return Err(RepositoryError::NotFound { entity: ENTITY });
+        }
+        Ok(())
+    }
+
+    async fn delete(&self, id: Uuid) -> Result<bool> {
+        let deleted = self
+            .write(move |tx| tx.execute("DELETE FROM approved_records WHERE id = ?1", params![id.to_string()]))
+            .await?;
+        Ok(deleted > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use editor_core::records::{Role, User};
+    use editor_core::repository::UserRepository;
+
+    use super::super::tests::{count, test_db};
+    use super::*;
+
+    fn at(hour: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 21, hour, 0, 0).unwrap()
+    }
+
+    async fn an_rdu_member(db: &Database) -> Uuid {
+        let user = User {
+            id: Uuid::new_v4(),
+            email: "rdu@x.test".to_string(),
+            name: "R".to_string(),
+            role: Role::Rdu,
+            shortcodes: vec![],
+            failed_logins: 0,
+            last_code_at: None,
+            created_at: at(9),
+        };
+        UserRepository::create(db, &user).await.unwrap();
+        user.id
+    }
+
+    fn record(shortcode: &str, approver: Option<Uuid>, approved: DateTime<Utc>) -> ApprovedRecord {
+        ApprovedRecord {
+            id: Uuid::new_v4(),
+            shortcode: shortcode.to_string(),
+            payload: r#"{"name":"approved"}"#.to_string(),
+            approved_by: approver,
+            approved_at: approved,
+            collected_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_then_list_round_trips_every_field() {
+        let db = test_db("approved-round-trip").await;
+        let approver = an_rdu_member(&db).await;
+        let record = record("0801", Some(approver), at(14));
+        ApprovedRecordRepository::create(&db, &record).await.unwrap();
+
+        assert_eq!(db.list_uncollected().await.unwrap(), vec![record]);
+    }
+
+    #[tokio::test]
+    async fn test_list_uncollected_excludes_collected_records() {
+        // REQ-5.1: the public endpoint serves approved-and-uncollected only.
+        // Serving collected ones would reopen a pull request on every run.
+        let db = test_db("approved-uncollected").await;
+        let first = record("0801", None, at(12));
+        let second = record("0803", None, at(13));
+        ApprovedRecordRepository::create(&db, &first).await.unwrap();
+        ApprovedRecordRepository::create(&db, &second).await.unwrap();
+
+        db.mark_collected(first.id, at(15)).await.unwrap();
+
+        let uncollected: Vec<_> = db.list_uncollected().await.unwrap().into_iter().map(|r| r.shortcode).collect();
+        assert_eq!(uncollected, vec!["0803".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_list_uncollected_is_oldest_first() {
+        let db = test_db("approved-order").await;
+        ApprovedRecordRepository::create(&db, &record("0805", None, at(14)))
+            .await
+            .unwrap();
+        ApprovedRecordRepository::create(&db, &record("0801", None, at(12)))
+            .await
+            .unwrap();
+        ApprovedRecordRepository::create(&db, &record("0803", None, at(13)))
+            .await
+            .unwrap();
+
+        let order: Vec<_> = db.list_uncollected().await.unwrap().into_iter().map(|r| r.shortcode).collect();
+        assert_eq!(order, vec!["0801".to_string(), "0803".to_string(), "0805".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_a_failed_collection_leaves_the_record_for_the_next_run() {
+        // REQ-5.7. The record stays uncollected because nothing stamped it, which
+        // is why `mark_collected` is a separate call after the pull request is
+        // open rather than part of serving the endpoint.
+        let db = test_db("approved-retry").await;
+        let record = record("0801", None, at(12));
+        ApprovedRecordRepository::create(&db, &record).await.unwrap();
+
+        assert_eq!(db.list_uncollected().await.unwrap().len(), 1);
+        assert_eq!(db.list_uncollected().await.unwrap().len(), 1, "reading it must not consume it");
+    }
+
+    #[tokio::test]
+    async fn test_mark_collected_is_not_repeatable() {
+        // A second run must not overwrite when the record was first collected —
+        // that time is the only record of when the pull request went out.
+        let db = test_db("approved-mark-once").await;
+        let record = record("0801", None, at(12));
+        ApprovedRecordRepository::create(&db, &record).await.unwrap();
+
+        db.mark_collected(record.id, at(15)).await.unwrap();
+        let error = db
+            .mark_collected(record.id, at(16))
+            .await
+            .expect_err("a second mark must be refused");
+        assert!(
+            matches!(error, RepositoryError::NotFound { entity: "approved record" }),
+            "{error}"
+        );
+
+        let collected = db.find_by_shortcode("0801").await.unwrap()[0].collected_at;
+        assert_eq!(collected, Some(at(15)));
+    }
+
+    #[tokio::test]
+    async fn test_find_by_shortcode_returns_every_record_for_that_project() {
+        // The startup comparison (REQ-2.3) needs all of a project's records, not
+        // just the uncollected ones, to find the one that matches the published
+        // data.
+        let db = test_db("approved-by-shortcode").await;
+        let collected = record("0801", None, at(12));
+        ApprovedRecordRepository::create(&db, &collected).await.unwrap();
+        ApprovedRecordRepository::create(&db, &record("0801", None, at(13)))
+            .await
+            .unwrap();
+        ApprovedRecordRepository::create(&db, &record("0803", None, at(14)))
+            .await
+            .unwrap();
+        db.mark_collected(collected.id, at(15)).await.unwrap();
+
+        assert_eq!(db.find_by_shortcode("0801").await.unwrap().len(), 2);
+        assert_eq!(db.find_by_shortcode("0803").await.unwrap().len(), 1);
+        assert!(db.find_by_shortcode("0899").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_delete_discards_the_local_record_once_the_change_is_online() {
+        // REQ-2.4: a record identical to the published data is dropped.
+        let db = test_db("approved-delete").await;
+        let record = record("0801", None, at(12));
+        ApprovedRecordRepository::create(&db, &record).await.unwrap();
+
+        assert!(ApprovedRecordRepository::delete(&db, record.id).await.unwrap());
+        assert!(!ApprovedRecordRepository::delete(&db, record.id).await.unwrap());
+        assert_eq!(count(&db, "approved_records").await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_removing_the_approver_leaves_the_record_collectable() {
+        // ON DELETE SET NULL. An approved record must not disappear because the
+        // RDU member who approved it left — the change is already approved for
+        // publication.
+        let db = test_db("approved-approver-removed").await;
+        let approver = an_rdu_member(&db).await;
+        let record = record("0801", Some(approver), at(12));
+        ApprovedRecordRepository::create(&db, &record).await.unwrap();
+
+        UserRepository::delete(&db, approver).await.unwrap();
+
+        let uncollected = db.list_uncollected().await.unwrap();
+        assert_eq!(uncollected.len(), 1);
+        assert_eq!(uncollected[0].approved_by, None);
+        assert_eq!(uncollected[0].payload, record.payload);
+    }
+}

--- a/modules/editor/server/src/db/drafts.rs
+++ b/modules/editor/server/src/db/drafts.rs
@@ -1,0 +1,206 @@
+//! [`DraftRepository`] against SQLite.
+
+use async_trait::async_trait;
+use editor_core::records::DraftRecord;
+use editor_core::repository::{DraftRepository, Result};
+use rusqlite::{params, Row};
+
+use super::mapping::{optional_uuid_column, OptionalRow};
+use super::Database;
+
+const ENTITY: &str = "draft";
+
+const SELECT: &str = "SELECT shortcode, payload, updated_by, created_at, updated_at FROM drafts";
+
+fn map_row(row: &Row<'_>) -> rusqlite::Result<DraftRecord> {
+    Ok(DraftRecord {
+        shortcode: row.get(0)?,
+        payload: row.get(1)?,
+        updated_by: optional_uuid_column(row, 2)?,
+        created_at: row.get(3)?,
+        updated_at: row.get(4)?,
+    })
+}
+
+#[async_trait]
+impl DraftRepository for Database {
+    async fn upsert(&self, draft: &DraftRecord) -> Result<()> {
+        let draft = draft.clone();
+        self.write(move |tx| {
+            // `created_at` is kept from the existing row on conflict: it records
+            // when the depositor started, and overwriting it on every save would
+            // make a draft look newly created each time it was touched.
+            tx.execute(
+                "INSERT INTO drafts (shortcode, payload, updated_by, created_at, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5) \
+                 ON CONFLICT (shortcode) DO UPDATE SET payload = ?2, updated_by = ?3, updated_at = ?5",
+                params![
+                    draft.shortcode,
+                    draft.payload,
+                    draft.updated_by.map(|id| id.to_string()),
+                    draft.created_at,
+                    draft.updated_at,
+                ],
+            )
+        })
+        .await
+        .map_err(|e| e.into_repository_error(ENTITY))?;
+        Ok(())
+    }
+
+    async fn find(&self, shortcode: &str) -> Result<Option<DraftRecord>> {
+        let shortcode = shortcode.to_string();
+        Ok(self
+            .read(move |conn| {
+                conn.query_row(&format!("{SELECT} WHERE shortcode = ?1"), params![shortcode], map_row)
+                    .optional_row()
+            })
+            .await?)
+    }
+
+    async fn list(&self) -> Result<Vec<DraftRecord>> {
+        Ok(self
+            .read(|conn| {
+                let mut stmt = conn.prepare(&format!("{SELECT} ORDER BY updated_at DESC, shortcode"))?;
+                let rows = stmt.query_map([], map_row)?;
+                rows.collect()
+            })
+            .await?)
+    }
+
+    async fn delete(&self, shortcode: &str) -> Result<bool> {
+        let shortcode = shortcode.to_string();
+        let deleted = self
+            .write(move |tx| tx.execute("DELETE FROM drafts WHERE shortcode = ?1", params![shortcode]))
+            .await?;
+        Ok(deleted > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{DateTime, TimeZone, Utc};
+    use editor_core::records::{Role, User};
+    use editor_core::repository::UserRepository;
+    use uuid::Uuid;
+
+    use super::super::tests::{count, test_db};
+    use super::*;
+
+    fn at(hour: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 21, hour, 0, 0).unwrap()
+    }
+
+    async fn a_user(db: &Database) -> Uuid {
+        let user = User {
+            id: Uuid::new_v4(),
+            email: "a@x.test".to_string(),
+            name: "A".to_string(),
+            role: Role::Depositor,
+            shortcodes: vec!["0801".to_string()],
+            failed_logins: 0,
+            last_code_at: None,
+            created_at: at(9),
+        };
+        UserRepository::create(db, &user).await.unwrap();
+        user.id
+    }
+
+    fn draft(shortcode: &str, payload: &str, author: Option<Uuid>, updated: DateTime<Utc>) -> DraftRecord {
+        DraftRecord {
+            shortcode: shortcode.to_string(),
+            payload: payload.to_string(),
+            updated_by: author,
+            created_at: at(10),
+            updated_at: updated,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_upsert_then_find_round_trips_every_field() {
+        let db = test_db("drafts-round-trip").await;
+        let author = a_user(&db).await;
+        let draft = draft("0801", r#"{"name":"work in progress"}"#, Some(author), at(11));
+        db.upsert(&draft).await.unwrap();
+
+        assert_eq!(DraftRepository::find(&db, "0801").await.unwrap(), Some(draft));
+    }
+
+    #[tokio::test]
+    async fn test_upsert_replaces_the_payload_and_keeps_the_original_created_at() {
+        // One draft per project, last write wins (PRD Constraints). `created_at`
+        // records when the depositor started; refreshing it on every save would
+        // lose that.
+        let db = test_db("drafts-upsert").await;
+        let author = a_user(&db).await;
+        db.upsert(&draft("0801", "first", Some(author), at(11))).await.unwrap();
+
+        let mut later = draft("0801", "second", Some(author), at(13));
+        later.created_at = at(12); // A caller that does not know the original.
+        db.upsert(&later).await.unwrap();
+
+        let found = DraftRepository::find(&db, "0801").await.unwrap().unwrap();
+        assert_eq!(found.payload, "second");
+        assert_eq!(found.updated_at, at(13));
+        assert_eq!(found.created_at, at(10), "the original created_at must survive the update");
+        assert_eq!(
+            count(&db, "drafts").await,
+            1,
+            "an upsert must not add a second row for one project"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_payload_is_stored_verbatim() {
+        // This layer never interprets the payload — Phase 4 gives it a type. A
+        // byte-exact round trip is what lets that happen without a migration.
+        let db = test_db("drafts-payload").await;
+        let payload = "{\"ar\":\"مرحبا\",\"nested\":{\"a\":[1,2,null]},\"quote\":\"he said \\\"hi\\\"\"}";
+        db.upsert(&draft("0820", payload, None, at(11))).await.unwrap();
+
+        assert_eq!(DraftRepository::find(&db, "0820").await.unwrap().unwrap().payload, payload);
+    }
+
+    #[tokio::test]
+    async fn test_list_returns_every_draft_newest_first() {
+        // REQ-1.11: RDU sees all drafts, not only their own projects'.
+        let db = test_db("drafts-list").await;
+        db.upsert(&draft("0801", "a", None, at(11))).await.unwrap();
+        db.upsert(&draft("0803", "b", None, at(13))).await.unwrap();
+        db.upsert(&draft("0805", "c", None, at(12))).await.unwrap();
+
+        let shortcodes: Vec<_> = DraftRepository::list(&db)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|d| d.shortcode)
+            .collect();
+        assert_eq!(shortcodes, vec!["0803".to_string(), "0805".to_string(), "0801".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_delete_reports_whether_there_was_anything_to_delete() {
+        let db = test_db("drafts-delete").await;
+        db.upsert(&draft("0801", "a", None, at(11))).await.unwrap();
+
+        assert!(DraftRepository::delete(&db, "0801").await.unwrap());
+        assert!(!DraftRepository::delete(&db, "0801").await.unwrap());
+        assert_eq!(count(&db, "drafts").await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_a_draft_by_an_unknown_user_is_refused() {
+        // The foreign key. A draft attributed to a user id that never existed
+        // would show an author the depositor list cannot explain.
+        let db = test_db("drafts-orphan").await;
+        let error = db
+            .upsert(&draft("0801", "a", Some(Uuid::new_v4()), at(11)))
+            .await
+            .expect_err("a draft for an unknown user must be refused");
+        assert!(
+            matches!(error, editor_core::repository::RepositoryError::Backend(_)),
+            "a foreign-key failure must not be reported as a conflict: {error}"
+        );
+        assert_eq!(count(&db, "drafts").await, 0);
+    }
+}

--- a/modules/editor/server/src/db/login_codes.rs
+++ b/modules/editor/server/src/db/login_codes.rs
@@ -1,0 +1,378 @@
+//! [`LoginCodeRepository`] against SQLite.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use editor_core::records::LoginCode;
+use editor_core::repository::{LoginCodeRepository, RepositoryError, Result};
+use rusqlite::{params, Row};
+use uuid::Uuid;
+
+use super::mapping::{counter, row_count, uuid_column, OptionalRow};
+use super::Database;
+
+const ENTITY: &str = "login code";
+
+const SELECT: &str = "SELECT id, user_id, code, attempts, created_at, expires_at, consumed_at FROM login_codes";
+
+fn map_row(row: &Row<'_>) -> rusqlite::Result<LoginCode> {
+    Ok(LoginCode {
+        id: uuid_column(row, 0)?,
+        user_id: uuid_column(row, 1)?,
+        code: row.get(2)?,
+        attempts: counter(row.get::<_, i64>(3)?),
+        created_at: row.get(4)?,
+        expires_at: row.get(5)?,
+        consumed_at: row.get(6)?,
+    })
+}
+
+#[async_trait]
+impl LoginCodeRepository for Database {
+    async fn create(&self, code: &LoginCode) -> Result<()> {
+        let code = code.clone();
+        self.write(move |tx| {
+            tx.execute(
+                "INSERT INTO login_codes (id, user_id, code, attempts, created_at, expires_at, consumed_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    code.id.to_string(),
+                    code.user_id.to_string(),
+                    code.code,
+                    i64::from(code.attempts),
+                    code.created_at,
+                    code.expires_at,
+                    code.consumed_at,
+                ],
+            )
+        })
+        .await
+        .map_err(|e| e.into_repository_error(ENTITY))?;
+        Ok(())
+    }
+
+    async fn find_active_for_user(&self, user_id: Uuid, now: DateTime<Utc>) -> Result<Option<LoginCode>> {
+        Ok(self
+            .read(move |conn| {
+                conn.query_row(
+                    &format!(
+                        "{SELECT} WHERE user_id = ?1 AND consumed_at IS NULL AND expires_at > ?2 \
+                         ORDER BY created_at DESC LIMIT 1"
+                    ),
+                    params![user_id.to_string(), now],
+                    map_row,
+                )
+                .optional_row()
+            })
+            .await?)
+    }
+
+    async fn find_latest_for_user(&self, user_id: Uuid) -> Result<Option<LoginCode>> {
+        // Whatever its state: the resend cooldown (REQ-6.5) is measured from the
+        // last code *issued*, not the last one still usable, or a user could
+        // defeat it by burning the code first.
+        Ok(self
+            .read(move |conn| {
+                conn.query_row(
+                    &format!("{SELECT} WHERE user_id = ?1 ORDER BY created_at DESC LIMIT 1"),
+                    params![user_id.to_string()],
+                    map_row,
+                )
+                .optional_row()
+            })
+            .await?)
+    }
+
+    async fn record_attempt(&self, id: Uuid) -> Result<u32> {
+        // Incremented and read back in one transaction, so parallel guesses
+        // cannot both read the old count and spend one strike between them.
+        let attempts = self
+            .write(move |tx| {
+                let updated = tx.execute(
+                    "UPDATE login_codes SET attempts = attempts + 1 WHERE id = ?1",
+                    params![id.to_string()],
+                )?;
+                if updated == 0 {
+                    return Ok(None);
+                }
+                let attempts: i64 = tx.query_row(
+                    "SELECT attempts FROM login_codes WHERE id = ?1",
+                    params![id.to_string()],
+                    |row| row.get(0),
+                )?;
+                Ok(Some(counter(attempts)))
+            })
+            .await?;
+        attempts.ok_or(RepositoryError::NotFound { entity: ENTITY })
+    }
+
+    async fn consume(&self, id: Uuid, at: DateTime<Utc>) -> Result<bool> {
+        // `consumed_at IS NULL` in the WHERE clause is what makes this
+        // single-use: a replay updates zero rows and gets `false`. Checking
+        // first and then updating would leave a window in which two requests
+        // both saw it unconsumed and both authenticated.
+        let consumed = self
+            .write(move |tx| {
+                tx.execute(
+                    "UPDATE login_codes SET consumed_at = ?2 WHERE id = ?1 AND consumed_at IS NULL",
+                    params![id.to_string(), at],
+                )
+            })
+            .await?;
+        Ok(consumed > 0)
+    }
+
+    async fn delete_for_user(&self, user_id: Uuid) -> Result<u64> {
+        let deleted = self
+            .write(move |tx| tx.execute("DELETE FROM login_codes WHERE user_id = ?1", params![user_id.to_string()]))
+            .await?;
+        Ok(deleted as u64)
+    }
+
+    async fn count_issued_since(&self, since: DateTime<Utc>) -> Result<u64> {
+        // Across all users: the cap exists because the relay quota is shared, so
+        // a per-user count would not see the loop that exhausts it.
+        let counted: i64 = self
+            .read(move |conn| {
+                conn.query_row(
+                    "SELECT count(*) FROM login_codes WHERE created_at >= ?1",
+                    params![since],
+                    |row| row.get(0),
+                )
+            })
+            .await?;
+        Ok(row_count(counted))
+    }
+
+    async fn delete_expired(&self, now: DateTime<Utc>) -> Result<u64> {
+        let deleted = self
+            .write(move |tx| tx.execute("DELETE FROM login_codes WHERE expires_at <= ?1", params![now]))
+            .await?;
+        Ok(deleted as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use editor_core::records::{Role, User};
+    use editor_core::repository::UserRepository;
+
+    use super::super::tests::{count, test_db};
+    use super::*;
+
+    fn at(hour: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 21, hour, 0, 0).unwrap()
+    }
+
+    async fn a_user(db: &Database, email: &str) -> Uuid {
+        let user = User {
+            id: Uuid::new_v4(),
+            email: email.to_string(),
+            name: "A".to_string(),
+            role: Role::Depositor,
+            shortcodes: vec![],
+            failed_logins: 0,
+            last_code_at: None,
+            created_at: at(9),
+        };
+        UserRepository::create(db, &user).await.unwrap();
+        user.id
+    }
+
+    fn code(user_id: Uuid, digits: &str, created: DateTime<Utc>, expires: DateTime<Utc>) -> LoginCode {
+        LoginCode {
+            id: Uuid::new_v4(),
+            user_id,
+            code: digits.to_string(),
+            attempts: 0,
+            created_at: created,
+            expires_at: expires,
+            consumed_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_then_find_round_trips_every_field() {
+        let db = test_db("codes-round-trip").await;
+        let user_id = a_user(&db, "a@x.test").await;
+        let code = code(user_id, "123456", at(10), at(11));
+        LoginCodeRepository::create(&db, &code).await.unwrap();
+
+        assert_eq!(db.find_active_for_user(user_id, at(10)).await.unwrap(), Some(code));
+    }
+
+    #[tokio::test]
+    async fn test_an_expired_code_is_not_active() {
+        // Ten minutes is the whole point of the expiry (REQ-6.1); a code that
+        // stayed active past it would be a standing credential in a mailbox.
+        let db = test_db("codes-expired").await;
+        let user_id = a_user(&db, "a@x.test").await;
+        LoginCodeRepository::create(&db, &code(user_id, "123456", at(10), at(11)))
+            .await
+            .unwrap();
+
+        assert!(
+            db.find_active_for_user(user_id, at(11)).await.unwrap().is_none(),
+            "the expiry instant is not active"
+        );
+        assert!(db.find_active_for_user(user_id, at(12)).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_a_consumed_code_is_not_active_and_cannot_be_consumed_twice() {
+        // Replay resistance (NIST SP 800-63B-4 §3.1.3.2). The single-use check
+        // is in the UPDATE's WHERE clause, so two simultaneous submissions of
+        // one code cannot both win.
+        let db = test_db("codes-consume").await;
+        let user_id = a_user(&db, "a@x.test").await;
+        let code = code(user_id, "123456", at(10), at(11));
+        LoginCodeRepository::create(&db, &code).await.unwrap();
+
+        assert!(db.consume(code.id, at(10)).await.unwrap(), "the first use succeeds");
+        assert!(!db.consume(code.id, at(10)).await.unwrap(), "the replay must be refused");
+        assert!(db.find_active_for_user(user_id, at(10)).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_only_one_of_many_concurrent_consumptions_wins() {
+        let db = test_db("codes-consume-race").await;
+        let user_id = a_user(&db, "a@x.test").await;
+        let code = code(user_id, "123456", at(10), at(11));
+        LoginCodeRepository::create(&db, &code).await.unwrap();
+
+        let mut handles = Vec::new();
+        for _ in 0..12 {
+            let db = db.clone();
+            let id = code.id;
+            handles.push(tokio::spawn(async move { db.consume(id, at(10)).await }));
+        }
+        let mut wins = 0;
+        for handle in handles {
+            if handle.await.unwrap().unwrap() {
+                wins += 1;
+            }
+        }
+        assert_eq!(wins, 1, "exactly one consumption may succeed");
+    }
+
+    #[tokio::test]
+    async fn test_record_attempt_counts_up_from_the_stored_value() {
+        // REQ-6.4's three strikes per code.
+        let db = test_db("codes-attempts").await;
+        let user_id = a_user(&db, "a@x.test").await;
+        let code = code(user_id, "123456", at(10), at(11));
+        LoginCodeRepository::create(&db, &code).await.unwrap();
+
+        assert_eq!(db.record_attempt(code.id).await.unwrap(), 1);
+        assert_eq!(db.record_attempt(code.id).await.unwrap(), 2);
+        assert_eq!(db.record_attempt(code.id).await.unwrap(), 3);
+        assert_eq!(db.find_active_for_user(user_id, at(10)).await.unwrap().unwrap().attempts, 3);
+    }
+
+    #[tokio::test]
+    async fn test_record_attempt_on_an_unknown_code_is_not_found() {
+        let db = test_db("codes-attempts-missing").await;
+        let error = db
+            .record_attempt(Uuid::new_v4())
+            .await
+            .expect_err("an unknown code must not count");
+        assert!(matches!(error, RepositoryError::NotFound { entity: "login code" }), "{error}");
+    }
+
+    #[tokio::test]
+    async fn test_find_active_returns_the_newest_when_several_are_outstanding() {
+        let db = test_db("codes-newest").await;
+        let user_id = a_user(&db, "a@x.test").await;
+        LoginCodeRepository::create(&db, &code(user_id, "111111", at(10), at(14)))
+            .await
+            .unwrap();
+        LoginCodeRepository::create(&db, &code(user_id, "222222", at(11), at(14)))
+            .await
+            .unwrap();
+
+        let active = db.find_active_for_user(user_id, at(12)).await.unwrap().unwrap();
+        assert_eq!(active.code, "222222");
+    }
+
+    #[tokio::test]
+    async fn test_find_latest_sees_a_consumed_code_so_the_cooldown_cannot_be_reset() {
+        // REQ-6.5. Measured from the last code issued: if the cooldown looked at
+        // active codes only, using a code would clear it and allow an immediate
+        // resend.
+        let db = test_db("codes-latest").await;
+        let user_id = a_user(&db, "a@x.test").await;
+        let code = code(user_id, "123456", at(10), at(11));
+        LoginCodeRepository::create(&db, &code).await.unwrap();
+        db.consume(code.id, at(10)).await.unwrap();
+
+        let latest = db
+            .find_latest_for_user(user_id)
+            .await
+            .unwrap()
+            .expect("the consumed code is still the latest");
+        assert_eq!(latest.created_at, at(10));
+        assert_eq!(latest.consumed_at, Some(at(10)));
+    }
+
+    #[tokio::test]
+    async fn test_count_issued_since_spans_every_user() {
+        // The global daily cap. A per-user count would miss the loop across
+        // addresses that exhausts the relay quota and locks everyone out.
+        let db = test_db("codes-daily-cap").await;
+        let first = a_user(&db, "a@x.test").await;
+        let second = a_user(&db, "b@x.test").await;
+        LoginCodeRepository::create(&db, &code(first, "111111", at(9), at(10)))
+            .await
+            .unwrap();
+        LoginCodeRepository::create(&db, &code(second, "222222", at(10), at(11)))
+            .await
+            .unwrap();
+        LoginCodeRepository::create(&db, &code(second, "333333", at(11), at(12)))
+            .await
+            .unwrap();
+
+        assert_eq!(db.count_issued_since(at(9)).await.unwrap(), 3);
+        assert_eq!(
+            db.count_issued_since(at(10)).await.unwrap(),
+            2,
+            "the window boundary is inclusive"
+        );
+        assert_eq!(db.count_issued_since(at(12)).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_delete_for_user_clears_that_users_codes_only() {
+        let db = test_db("codes-delete-for-user").await;
+        let first = a_user(&db, "a@x.test").await;
+        let second = a_user(&db, "b@x.test").await;
+        LoginCodeRepository::create(&db, &code(first, "111111", at(10), at(11)))
+            .await
+            .unwrap();
+        LoginCodeRepository::create(&db, &code(first, "222222", at(10), at(11)))
+            .await
+            .unwrap();
+        LoginCodeRepository::create(&db, &code(second, "333333", at(10), at(11)))
+            .await
+            .unwrap();
+
+        assert_eq!(LoginCodeRepository::delete_for_user(&db, first).await.unwrap(), 2);
+        assert_eq!(count(&db, "login_codes").await, 1);
+        assert!(db.find_active_for_user(second, at(10)).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_delete_expired_leaves_live_codes_alone() {
+        let db = test_db("codes-delete-expired").await;
+        let user_id = a_user(&db, "a@x.test").await;
+        LoginCodeRepository::create(&db, &code(user_id, "111111", at(9), at(10)))
+            .await
+            .unwrap();
+        LoginCodeRepository::create(&db, &code(user_id, "222222", at(11), at(14)))
+            .await
+            .unwrap();
+
+        assert_eq!(LoginCodeRepository::delete_expired(&db, at(12)).await.unwrap(), 1);
+        assert_eq!(count(&db, "login_codes").await, 1);
+        assert_eq!(db.find_active_for_user(user_id, at(12)).await.unwrap().unwrap().code, "222222");
+    }
+}

--- a/modules/editor/server/src/db/mapping.rs
+++ b/modules/editor/server/src/db/mapping.rs
@@ -1,0 +1,98 @@
+//! Column mapping shared by the repository implementations.
+//!
+//! Ids and enums are stored as TEXT (see the migration for why), so reading them
+//! back is a parse that can fail. These helpers turn that failure into a
+//! `rusqlite` error naming the column, rather than a panic or a silent default —
+//! a stored `role` the code does not recognise must not become `Depositor`.
+
+use std::str::FromStr;
+
+use rusqlite::types::Type;
+use rusqlite::Row;
+use uuid::Uuid;
+
+/// Read a TEXT column as a [`Uuid`].
+pub(super) fn uuid_column(row: &Row<'_>, index: usize) -> rusqlite::Result<Uuid> {
+    let raw: String = row.get(index)?;
+    Uuid::parse_str(&raw).map_err(|e| rusqlite::Error::FromSqlConversionFailure(index, Type::Text, Box::new(e)))
+}
+
+/// Read a nullable TEXT column as an optional [`Uuid`].
+pub(super) fn optional_uuid_column(row: &Row<'_>, index: usize) -> rusqlite::Result<Option<Uuid>> {
+    let raw: Option<String> = row.get(index)?;
+    raw.map(|raw| {
+        Uuid::parse_str(&raw).map_err(|e| rusqlite::Error::FromSqlConversionFailure(index, Type::Text, Box::new(e)))
+    })
+    .transpose()
+}
+
+/// Read a TEXT column through its [`FromStr`] — the stored form of `role` and
+/// `state`, both of which also carry a `CHECK` constraint in the schema.
+pub(super) fn parsed_column<T>(row: &Row<'_>, index: usize) -> rusqlite::Result<T>
+where
+    T: FromStr,
+    T::Err: std::error::Error + Send + Sync + 'static,
+{
+    let raw: String = row.get(index)?;
+    raw.parse()
+        .map_err(|e| rusqlite::Error::FromSqlConversionFailure(index, Type::Text, Box::new(e)))
+}
+
+/// A `count(*)`/`changes()` result as `u64`. SQLite counts are signed and never
+/// negative, so a negative value would mean the query was not a count.
+pub(super) fn row_count(counted: i64) -> u64 {
+    counted.max(0).unsigned_abs()
+}
+
+/// A stored non-negative counter as `u32`.
+pub(super) fn counter(stored: i64) -> u32 {
+    stored.clamp(0, i64::from(u32::MAX)) as u32
+}
+
+/// `query_row` reports an absent row as `QueryReturnedNoRows`, which every
+/// `find` in this layer wants as `Ok(None)` — a cookie for a session that has
+/// been deleted is the ordinary case, not an error.
+pub(super) trait OptionalRow<T> {
+    fn optional_row(self) -> rusqlite::Result<Option<T>>;
+}
+
+impl<T> OptionalRow<T> for rusqlite::Result<T> {
+    fn optional_row(self) -> rusqlite::Result<Option<T>> {
+        match self {
+            Ok(value) => Ok(Some(value)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(other) => Err(other),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_row_count_never_goes_negative() {
+        assert_eq!(row_count(0), 0);
+        assert_eq!(row_count(7), 7);
+        assert_eq!(row_count(-1), 0);
+    }
+
+    #[test]
+    fn test_optional_row_turns_a_missing_row_into_none() {
+        let missing: rusqlite::Result<i64> = Err(rusqlite::Error::QueryReturnedNoRows);
+        assert_eq!(missing.optional_row().unwrap(), None);
+        assert_eq!(Ok::<_, rusqlite::Error>(7).optional_row().unwrap(), Some(7));
+        // Any other error still has to surface.
+        let broken: rusqlite::Result<i64> = Err(rusqlite::Error::InvalidColumnIndex(3));
+        assert!(broken.optional_row().is_err());
+    }
+
+    #[test]
+    fn test_counter_saturates_instead_of_wrapping() {
+        // A wrapped counter would hand a locked-out account a fresh budget.
+        assert_eq!(counter(0), 0);
+        assert_eq!(counter(3), 3);
+        assert_eq!(counter(-5), 0);
+        assert_eq!(counter(i64::from(u32::MAX) + 10), u32::MAX);
+    }
+}

--- a/modules/editor/server/src/db/migrations/0001_initial.sql
+++ b/modules/editor/server/src/db/migrations/0001_initial.sql
@@ -1,0 +1,138 @@
+-- Migration 0001 — initial schema.
+--
+-- Applied inside one BEGIN IMMEDIATE transaction together with the
+-- `user_version` bump, so a crash part-way leaves the database at the previous
+-- version rather than half-migrated. Forward-only: once released, this file is
+-- never edited — a change is a new numbered file.
+--
+-- STRICT on every table. Without it SQLite accepts any value in any column and
+-- coerces silently, so a mapping bug surfaces as wrong data instead of an error.
+--
+-- Timestamps are TEXT in rusqlite's chrono format
+-- ("YYYY-MM-DD HH:MM:SS.SSS+00:00"): fixed-width and always UTC, so the
+-- lexicographic ordering SQLite gives TEXT is chronological ordering, and
+-- `expires_at > ?` works. Ids are TEXT in hyphenated UUID form rather than
+-- 16-byte blobs, so the database stays legible to an operator reading it by
+-- hand — which is the only way in, the image having no shell.
+--
+-- Every foreign key is indexed. Without an index on the child column, SQLite
+-- scans the whole child table for each parent row deleted, so `ON DELETE
+-- CASCADE` on `users` would degrade with the number of sessions.
+
+CREATE TABLE users (
+    id               TEXT    NOT NULL PRIMARY KEY,
+    -- As entered, plaintext (PRD Constraints: the app must decrypt to send, so
+    -- a key would sit beside the data).
+    email            TEXT    NOT NULL,
+    -- Lowercased. Carries the uniqueness constraint (REQ-7.4) and every lookup,
+    -- so `A@x.test` cannot shadow `a@x.test`.
+    email_normalized TEXT    NOT NULL UNIQUE,
+    name             TEXT    NOT NULL,
+    role             TEXT    NOT NULL CHECK (role IN ('depositor', 'rdu')),
+    -- Account-level consecutive failures. NIST SP 800-63B-4: a new secret SHALL
+    -- NOT reset the count, so it lives here and not on the code.
+    failed_logins    INTEGER NOT NULL DEFAULT 0 CHECK (failed_logins >= 0),
+    last_code_at     TEXT,
+    created_at       TEXT    NOT NULL
+) STRICT;
+
+-- Project assignments (REQ-1.2, REQ-7.3). A child table rather than a JSON
+-- column on `users`, so "who holds shortcode X" is answerable — needed when
+-- removing a shortcode from someone who has a draft on it.
+CREATE TABLE user_shortcodes (
+    user_id   TEXT NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    shortcode TEXT NOT NULL,
+    PRIMARY KEY (user_id, shortcode)
+) STRICT;
+
+CREATE INDEX user_shortcodes_shortcode ON user_shortcodes (shortcode);
+
+CREATE TABLE sessions (
+    -- The opaque token the cookie carries, not a UUID: how it is minted is the
+    -- auth layer's decision.
+    id           TEXT NOT NULL PRIMARY KEY,
+    user_id      TEXT NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    created_at   TEXT NOT NULL,
+    -- Advanced on use, for the idle timeout.
+    last_seen_at TEXT NOT NULL,
+    -- Absolute expiry, set at creation and never extended.
+    expires_at   TEXT NOT NULL
+) STRICT;
+
+CREATE INDEX sessions_user_id ON sessions (user_id);
+CREATE INDEX sessions_expires_at ON sessions (expires_at);
+
+CREATE TABLE login_codes (
+    id          TEXT    NOT NULL PRIMARY KEY,
+    user_id     TEXT    NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    -- Unhashed on purpose: it lives ten minutes, and anyone who can read this
+    -- table already holds `sessions` (PRD Constraints).
+    code        TEXT    NOT NULL,
+    -- Wrong entries against this code; three invalidates it (REQ-6.4).
+    attempts    INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+    created_at  TEXT    NOT NULL,
+    expires_at  TEXT    NOT NULL,
+    -- Set on acceptance. A code authenticates once (NIST §3.1.3.2).
+    consumed_at TEXT
+) STRICT;
+
+CREATE INDEX login_codes_user_id ON login_codes (user_id);
+-- The global daily send cap counts across all users over a time window.
+CREATE INDEX login_codes_created_at ON login_codes (created_at);
+
+-- One draft per project, not per user: per-user multiple drafts are out of
+-- scope and concurrency is last-write-wins.
+CREATE TABLE drafts (
+    shortcode  TEXT NOT NULL PRIMARY KEY,
+    -- JSON. The permissive draft representation is Phase 4's; this layer never
+    -- interprets the body.
+    payload    TEXT NOT NULL,
+    -- SET NULL, not CASCADE: removing an account must not destroy the project's
+    -- work. "Last editor" then reads as unknown rather than dangling.
+    updated_by TEXT REFERENCES users (id) ON DELETE SET NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+) STRICT;
+
+CREATE INDEX drafts_updated_by ON drafts (updated_by);
+CREATE INDEX drafts_updated_at ON drafts (updated_at);
+
+CREATE TABLE submissions (
+    id            TEXT NOT NULL PRIMARY KEY,
+    -- UNIQUE is PRD Constraints' "one pending submission per project", enforced
+    -- here rather than left as something handlers must remember.
+    shortcode     TEXT NOT NULL UNIQUE,
+    payload       TEXT NOT NULL,
+    -- REQ-2.1's Draft and Online are absent by design: a draft is a `drafts`
+    -- row, and Online is derived at startup, at which point the local record is
+    -- discarded (REQ-2.4).
+    state         TEXT NOT NULL CHECK (state IN ('submitted', 'in_review', 'approved')),
+    submitted_by  TEXT REFERENCES users (id) ON DELETE SET NULL,
+    submitted_at  TEXT NOT NULL,
+    reviewed_by   TEXT REFERENCES users (id) ON DELETE SET NULL,
+    reviewed_at   TEXT,
+    -- Carried back to the depositor when RDU requests changes (REQ-4.5).
+    reviewer_note TEXT
+) STRICT;
+
+-- The review queue is oldest first (REQ-4.1).
+CREATE INDEX submissions_submitted_at ON submissions (submitted_at);
+CREATE INDEX submissions_submitted_by ON submissions (submitted_by);
+CREATE INDEX submissions_reviewed_by ON submissions (reviewed_by);
+
+CREATE TABLE approved_records (
+    id           TEXT NOT NULL PRIMARY KEY,
+    shortcode    TEXT NOT NULL,
+    payload      TEXT NOT NULL,
+    approved_by  TEXT REFERENCES users (id) ON DELETE SET NULL,
+    approved_at  TEXT NOT NULL,
+    -- NULL while uncollected. A failed collection leaves it NULL, which is what
+    -- makes the next run retry it (REQ-5.7).
+    collected_at TEXT
+) STRICT;
+
+-- Partial index: the collection endpoint only ever asks for the uncollected
+-- ones, and collected rows stay out of the index entirely.
+CREATE INDEX approved_records_uncollected ON approved_records (approved_at) WHERE collected_at IS NULL;
+CREATE INDEX approved_records_shortcode ON approved_records (shortcode);
+CREATE INDEX approved_records_approved_by ON approved_records (approved_by);

--- a/modules/editor/server/src/db/mod.rs
+++ b/modules/editor/server/src/db/mod.rs
@@ -1,0 +1,798 @@
+//! SQLite persistence: the connection pools, the PRAGMAs, the schema, and the
+//! two entry points every query goes through.
+//!
+//! ## Why two pools
+//!
+//! [`Database`] holds a **writer** pool of exactly one connection and a
+//! **reader** pool of several. That split is what makes the two rules this
+//! layer must not get wrong structural rather than conventional:
+//!
+//! - Reader connections are opened with `query_only=ON` in the per-connection init hook, so a write
+//!   physically cannot go through [`Database::read`]. The only path that can write is
+//!   [`Database::write`], and that always opens `BEGIN IMMEDIATE`.
+//! - SQLite allows one writer at a time regardless. A second writer connection would not add
+//!   concurrency, it would move the queue from the pool (a bounded, observable wait) into SQLite
+//!   (`SQLITE_BUSY` once `busy_timeout` runs out). One writer connection means writes serialise in
+//!   the pool.
+//!
+//! ## Why `BEGIN IMMEDIATE` on every write
+//!
+//! Once `BEGIN IMMEDIATE` succeeds, SQLite guarantees nothing up to the
+//! matching `COMMIT` returns `SQLITE_BUSY`. A deferred `BEGIN` takes a read lock
+//! and tries to upgrade it at the first write, and that upgrade can fail — so
+//! the transaction dies part-way with `database is locked`. It only happens
+//! under concurrency, so it passes every test and then fails intermittently in
+//! production, where the error reads like tuning and the reflex is to raise
+//! `busy_timeout`, which cannot help: the lock is not being waited for, the
+//! upgrade is being refused. Django added `transaction_mode: IMMEDIATE` in 5.1
+//! for exactly this.
+//!
+//! ## Why every call goes through `interact`
+//!
+//! `rusqlite::Connection` is `!Sync`, so it cannot be shared behind an `Arc`,
+//! and putting it behind a `std::sync::Mutex` invites holding the guard across
+//! an `.await`, which stalls or deadlocks the executor. `deadpool-sqlite` keeps
+//! each connection on a thread of its own and hands it out only inside an
+//! `interact` closure, which is `FnOnce(&mut Connection) -> R + Send + 'static`
+//! — the connection cannot escape and no `.await` can happen while it is held.
+//! `pool.get()` is itself async, so nothing blocks a Tokio worker either.
+//!
+//! Long-lived read transactions are avoided the same way: a read is a closure
+//! that runs to completion on a blocking thread, so no read transaction can be
+//! left open across an `.await` to starve WAL checkpointing and let `-wal` grow
+//! without bound.
+
+mod approved_records;
+mod drafts;
+mod login_codes;
+mod mapping;
+mod schema;
+mod sessions;
+mod submissions;
+mod users;
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use deadpool_sqlite::{Config as PoolSource, Hook, HookError, Pool, PoolConfig, Runtime};
+use editor_core::repository::RepositoryError;
+use rusqlite::{Connection, Transaction, TransactionBehavior};
+
+/// The database file inside the mounted directory. Fixed rather than
+/// configurable, because config names the **directory**: SQLite needs to create
+/// `-wal` and `-shm` siblings next to the file, which it cannot do if the file
+/// itself is the mount point.
+const DATABASE_FILE_NAME: &str = "editor.sqlite3";
+
+/// How long `pool.get()` waits for a connection before giving up.
+///
+/// Deliberately longer than the SQLite `busy_timeout`, so a queue behind the
+/// single writer resolves as a slow request rather than an error, and shorter
+/// than forever, which is deadpool's default and would hang a request with no
+/// diagnostic.
+const POOL_WAIT_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Where the database lives.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Source {
+    /// A file in this directory. Production: a mount provided by Infra.
+    Directory(PathBuf),
+    /// A named, shared-cache, in-memory database.
+    ///
+    /// Never bare `:memory:`. Every `:memory:` database is distinct and visible
+    /// only to the connection that opened it, so each pooled connection would
+    /// get its own empty copy — and with a writer/reader split that is
+    /// unconditional: readers could never see anything the writer wrote. The
+    /// symptom is `no such table` that comes and goes with pool timing and test
+    /// order, which reads exactly like a migration bug; the usual "fix" of
+    /// migrating every connection hides it while making the tests prove nothing
+    /// about migration ordering.
+    Memory(String),
+}
+
+impl Source {
+    /// An in-memory database with a unique name, for one test.
+    ///
+    /// The name has to differ per test: shared-cache in-memory databases are
+    /// scoped to the process, so two tests using one name would share a database
+    /// across parallel `cargo test` threads.
+    #[cfg(test)]
+    pub(crate) fn memory_for_test(label: &str) -> Self {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        Self::Memory(format!("editor-test-{label}-{}-{n}", std::process::id()))
+    }
+
+    /// What is handed to `rusqlite::Connection::open`. For the in-memory
+    /// variant this is a URI, which works because rusqlite's default open flags
+    /// include `SQLITE_OPEN_URI`.
+    fn open_target(&self) -> PathBuf {
+        match self {
+            Self::Directory(dir) => dir.join(DATABASE_FILE_NAME),
+            Self::Memory(name) => PathBuf::from(format!("file:{name}?mode=memory&cache=shared")),
+        }
+    }
+
+    /// WAL is a file-database mode: an in-memory database supports only `memory`
+    /// and `off`, and asking for WAL there silently leaves it as it was.
+    fn uses_wal(&self) -> bool {
+        matches!(self, Self::Directory(_))
+    }
+
+    /// How this source appears in a log line.
+    fn describe(&self) -> String {
+        match self {
+            Self::Directory(_) => self.open_target().display().to_string(),
+            Self::Memory(name) => format!("in-memory ({name})"),
+        }
+    }
+}
+
+/// Startup and connection failures, each phrased to name the actual cause.
+///
+/// The wrong-permissions cases matter most: without the pre-flight they all
+/// surface as SQLite's `unable to open database file`, which reads like a bad
+/// mount path and sends the reader hunting for a typo in a path that is
+/// perfectly correct.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum DbError {
+    #[error(
+        "the database directory {path} does not exist. Docker Swarm does not create a missing bind-mount host \
+         directory the way `docker run -v` does, so it must exist, and be owned by uid 65532, before the stack starts"
+    )]
+    DirectoryMissing { path: PathBuf },
+
+    #[error(
+        "{path} is not a directory. EDITOR_DB_DIR names the directory that holds the database, not the database \
+         file: SQLite has to create `{DATABASE_FILE_NAME}-wal` and `{DATABASE_FILE_NAME}-shm` next to it, which is \
+         impossible if the file itself is the mount point"
+    )]
+    DirectoryNotADirectory { path: PathBuf },
+
+    #[error(
+        "the database directory {path} is not writable by this process. The image runs as uid 65532 (distroless \
+         `:nonroot`; 65534 is `nobody`, a different account), so the mounted directory must be owned by 65532 — a \
+         root-owned or 65534-owned mount fails here"
+    )]
+    DirectoryNotWritable {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to build the SQLite connection pool: {0}")]
+    Pool(String),
+
+    #[error("failed to check out a SQLite connection: {0}")]
+    Checkout(String),
+
+    #[error("the SQLite worker thread failed: {0}")]
+    Interact(String),
+
+    #[error(transparent)]
+    Sqlite(#[from] rusqlite::Error),
+}
+
+impl DbError {
+    /// Whether this is a **uniqueness** constraint rejecting the write.
+    ///
+    /// Matched on the extended result code, not `ErrorCode::ConstraintViolation`:
+    /// that covers `NOT NULL`, `CHECK` and `FOREIGN KEY` too, so a session
+    /// inserted for a user that no longer exists would be reported as "session
+    /// already exists" — a message that sends the reader looking for a duplicate
+    /// that is not there.
+    ///
+    /// Which unique index it was is not recoverable from the error, so the entity
+    /// name comes from the call site: each table that maps this to
+    /// [`RepositoryError::Conflict`] has exactly one — a duplicate address for
+    /// REQ-7.4, a second pending submission for one project.
+    fn is_unique_violation(&self) -> bool {
+        matches!(
+            self,
+            Self::Sqlite(rusqlite::Error::SqliteFailure(e, _))
+                if e.extended_code == rusqlite::ffi::SQLITE_CONSTRAINT_UNIQUE
+                    || e.extended_code == rusqlite::ffi::SQLITE_CONSTRAINT_PRIMARYKEY
+        )
+    }
+
+    /// Map to [`RepositoryError::Conflict`] when a unique index rejected the
+    /// write, and to a backend error otherwise.
+    fn into_repository_error(self, entity: &'static str) -> RepositoryError {
+        if self.is_unique_violation() {
+            RepositoryError::Conflict { entity }
+        } else {
+            RepositoryError::backend(self)
+        }
+    }
+}
+
+impl From<DbError> for RepositoryError {
+    fn from(error: DbError) -> Self {
+        Self::backend(error)
+    }
+}
+
+/// The persistence layer: two pools over one SQLite database.
+///
+/// Cheap to clone — both pools are handles.
+#[derive(Clone)]
+pub(crate) struct Database {
+    /// Exactly one connection, no `query_only`. See the module docs.
+    writer: Pool,
+    /// Several connections, all `query_only=ON`.
+    readers: Pool,
+    source: Source,
+}
+
+impl Database {
+    /// Open the database, run the write pre-flight, and apply any outstanding
+    /// migrations.
+    ///
+    /// Migrations run through the writer pool on purpose: it leaves one
+    /// connection open in that pool from here on, which the in-memory variant
+    /// depends on — a shared-cache in-memory database exists only while at least
+    /// one connection to it is open.
+    pub(crate) async fn open(source: Source, readers: usize, busy_timeout: Duration) -> Result<Self, DbError> {
+        if let Source::Directory(dir) = &source {
+            preflight(dir)?;
+        }
+
+        let target = source.open_target();
+        let writer = build_pool(&target, 1, busy_timeout, source.uses_wal(), false)?;
+        // `query_only` on every reader. Set here rather than toggled per call:
+        // a toggle has to be undone on every path including the error ones, and
+        // a missed reset leaves a pooled connection rejecting writes forever.
+        let readers = build_pool(&target, readers.max(1), busy_timeout, false, true)?;
+
+        let db = Self { writer, readers, source };
+        let applied = db.migrate().await?;
+        // The version is read back rather than reported from the constant, so the
+        // log line says what the database is at and not what this build believes.
+        tracing::info!(
+            database = %db.source.describe(),
+            schema_version = db.schema_version().await?,
+            migrations_applied = applied,
+            "SQLite ready"
+        );
+        Ok(db)
+    }
+
+    /// Read from the database.
+    ///
+    /// Runs on a reader connection, which is `query_only=ON` — an `INSERT` here
+    /// fails with `attempt to write a readonly database` rather than quietly
+    /// bypassing [`Self::write`]'s `BEGIN IMMEDIATE`.
+    pub(crate) async fn read<T, F>(&self, f: F) -> Result<T, DbError>
+    where
+        F: FnOnce(&Connection) -> rusqlite::Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let conn = self.readers.get().await.map_err(|e| DbError::Checkout(e.to_string()))?;
+        conn.interact(move |conn| f(conn))
+            .await
+            .map_err(|e| DbError::Interact(e.to_string()))?
+            .map_err(DbError::Sqlite)
+    }
+
+    /// Read from the database inside one read transaction, for a read that takes
+    /// more than one statement.
+    ///
+    /// In autocommit mode each statement gets its own implicit read transaction,
+    /// so another connection's commit can land between two of them and the pair
+    /// can disagree — a user read back with shortcode assignments it no longer
+    /// has. A deferred `BEGIN` gives both statements one snapshot.
+    ///
+    /// Still a reader connection, so it cannot write, and still one closure, so
+    /// the transaction cannot outlive the call and starve WAL checkpointing.
+    /// Routing these through [`Self::write`] instead would have been consistent
+    /// too, and would have put every authenticated request's user lookup behind
+    /// the single writer connection.
+    pub(crate) async fn read_tx<T, F>(&self, f: F) -> Result<T, DbError>
+    where
+        F: FnOnce(&Transaction<'_>) -> rusqlite::Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let conn = self.readers.get().await.map_err(|e| DbError::Checkout(e.to_string()))?;
+        conn.interact(move |conn| {
+            let tx = conn.transaction_with_behavior(TransactionBehavior::Deferred)?;
+            let out = f(&tx)?;
+            // A read transaction has nothing to commit; rolling back is the
+            // cheaper way to end it and cannot fail on a conflict.
+            tx.rollback()?;
+            Ok(out)
+        })
+        .await
+        .map_err(|e| DbError::Interact(e.to_string()))?
+        .map_err(DbError::Sqlite)
+    }
+
+    /// Write to the database inside `BEGIN IMMEDIATE`.
+    ///
+    /// The transaction commits when the closure returns `Ok` and rolls back when
+    /// it returns `Err` or panics. This is the only way to get a write handle,
+    /// which is what makes "`BEGIN IMMEDIATE` on every write path" a property of
+    /// the type rather than something each call site has to remember.
+    pub(crate) async fn write<T, F>(&self, f: F) -> Result<T, DbError>
+    where
+        F: FnOnce(&Transaction<'_>) -> rusqlite::Result<T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let conn = self.writer.get().await.map_err(|e| DbError::Checkout(e.to_string()))?;
+        conn.interact(move |conn| {
+            let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            let out = f(&tx)?;
+            tx.commit()?;
+            Ok(out)
+        })
+        .await
+        .map_err(|e| DbError::Interact(e.to_string()))?
+        .map_err(DbError::Sqlite)
+    }
+}
+
+/// Verify the directory exists, is a directory, and can be written to.
+///
+/// The probe file is the point: a directory can exist and be readable and still
+/// reject a write, and every one of those cases otherwise reaches the operator
+/// as `unable to open database file`.
+fn preflight(dir: &Path) -> Result<(), DbError> {
+    let metadata = std::fs::metadata(dir).map_err(|source| {
+        if source.kind() == std::io::ErrorKind::NotFound {
+            DbError::DirectoryMissing { path: dir.to_path_buf() }
+        } else {
+            DbError::DirectoryNotWritable { path: dir.to_path_buf(), source }
+        }
+    })?;
+    if !metadata.is_dir() {
+        return Err(DbError::DirectoryNotADirectory { path: dir.to_path_buf() });
+    }
+
+    // Named by process id so two processes sharing a directory cannot delete
+    // each other's probe.
+    let probe = dir.join(format!(".editor-write-probe-{}", std::process::id()));
+    std::fs::write(&probe, b"editor write probe")
+        .map_err(|source| DbError::DirectoryNotWritable { path: dir.to_path_buf(), source })?;
+    // Removal is checked too: a directory with the sticky bit set, or one on a
+    // filesystem mounted append-only, allows the create and refuses the unlink —
+    // which would leave a probe file behind on every restart.
+    std::fs::remove_file(&probe).map_err(|source| DbError::DirectoryNotWritable { path: dir.to_path_buf(), source })?;
+    Ok(())
+}
+
+/// Build one pool over `target`, with the PRAGMAs applied per connection.
+fn build_pool(
+    target: &Path,
+    max_size: usize,
+    busy_timeout: Duration,
+    journal_wal: bool,
+    query_only: bool,
+) -> Result<Pool, DbError> {
+    let mut pool_config = PoolConfig::new(max_size);
+    pool_config.timeouts.wait = Some(POOL_WAIT_TIMEOUT);
+    let mut source = PoolSource::new(target);
+    source.pool = Some(pool_config);
+
+    source
+        .builder(Runtime::Tokio1)
+        .map_err(|e| DbError::Pool(e.to_string()))?
+        // The PRAGMAs belong here, in the per-connection init hook, and not in a
+        // one-off after the pool is built. Everything except `journal_mode` is
+        // per-connection state, so central setup would leave every connection
+        // after the first at `busy_timeout=0` and `foreign_keys=OFF` while the
+        // code reads as though they were configured.
+        .post_create(Hook::async_fn(move |conn, _metrics| {
+            Box::pin(async move {
+                conn.interact(move |conn| init_connection(conn, busy_timeout, journal_wal, query_only))
+                    .await
+                    .map_err(|e| HookError::message(format!("SQLite connection init failed: {e}")))?
+                    .map_err(HookError::Backend)
+            })
+        }))
+        .build()
+        .map_err(|e| DbError::Pool(e.to_string()))
+}
+
+/// Apply the per-connection PRAGMAs.
+///
+/// Order matters twice over. `foreign_keys` must be set outside a transaction —
+/// inside one it is a documented silent no-op, and the failure is invisible:
+/// `ON DELETE CASCADE` never fires, orphaned `sessions` accumulate against
+/// deleted `users`, and an integrity check passes because the constraint was
+/// never enforced. And `query_only` goes last, because it would otherwise block
+/// the PRAGMAs before it.
+fn init_connection(
+    conn: &Connection,
+    busy_timeout: Duration,
+    journal_wal: bool,
+    query_only: bool,
+) -> rusqlite::Result<()> {
+    // Not inside a transaction: this runs on a freshly opened connection, before
+    // anything can have begun one.
+    debug_assert!(conn.is_autocommit(), "PRAGMAs must be applied outside a transaction");
+
+    if journal_wal {
+        // `PRAGMA journal_mode` returns the resulting mode, so it is a query,
+        // not a statement. Database-level and persistent, unlike everything else
+        // here, so re-asserting it per connection is a no-op after the first.
+        let mode: String = conn.pragma_update_and_check(None, "journal_mode", "WAL", |row| row.get(0))?;
+        if !mode.eq_ignore_ascii_case("wal") {
+            return Err(rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_MISUSE),
+                Some(format!("journal_mode=WAL was refused; the database is in {mode} mode")),
+            ));
+        }
+        // NORMAL rather than the FULL default: with WAL, a commit no longer
+        // fsyncs, so a power loss or OS crash can lose the last transactions —
+        // never corrupt the database, and never on an application crash. That
+        // trade is right here because git holds everything irreplaceable and the
+        // PRD makes backups optional; drafts and in-flight submissions are
+        // re-creatable.
+        conn.pragma_update(None, "synchronous", "NORMAL")?;
+    }
+
+    // Off by default in SQLite for backwards compatibility, whatever the build
+    // flags say. `bundled` happens to compile with
+    // -DSQLITE_DEFAULT_FOREIGN_KEYS=1, but that is a compile flag we do not
+    // control, and the whole point of the schema's `ON DELETE CASCADE` and
+    // `ON DELETE SET NULL` is that they fire.
+    conn.pragma_update(None, "foreign_keys", "ON")?;
+
+    // Per-connection, and zero by default: an unconfigured connection returns
+    // SQLITE_BUSY immediately rather than waiting for the writer.
+    conn.busy_timeout(busy_timeout)?;
+
+    if query_only {
+        conn.pragma_update(None, "query_only", "ON")?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A database for one test: in-memory, uniquely named, migrated.
+    pub(crate) async fn test_db(label: &str) -> Database {
+        Database::open(Source::memory_for_test(label), 4, Duration::from_secs(5))
+            .await
+            .expect("test database should open")
+    }
+
+    /// Row count of one table, so a test can assert on rows no repository method
+    /// returns — cascades, and what a rollback left behind.
+    pub(crate) async fn count(db: &Database, table: &'static str) -> u64 {
+        let counted: i64 = db
+            .read(move |conn| conn.query_row(&format!("SELECT count(*) FROM {table}"), [], |row| row.get(0)))
+            .await
+            .expect("counting rows should succeed");
+        super::mapping::row_count(counted)
+    }
+
+    #[tokio::test]
+    async fn test_in_memory_source_is_a_named_shared_cache_uri_not_bare_memory() {
+        let target = Source::Memory("editor".into()).open_target();
+        let target = target.to_string_lossy();
+        assert!(target.starts_with("file:"), "{target}");
+        assert!(target.contains("mode=memory"), "{target}");
+        assert!(target.contains("cache=shared"), "{target}");
+        assert_ne!(target, ":memory:");
+    }
+
+    #[tokio::test]
+    async fn test_writer_and_readers_see_one_shared_in_memory_database() {
+        // The trap the named shared-cache URI exists to avoid. With bare
+        // `:memory:` each pooled connection gets its own empty database, so a
+        // read after a write fails with `no such table` — intermittently, with
+        // pool timing and test order, reading exactly like a migration bug.
+        let db = test_db("shared-cache").await;
+        db.write(|tx| {
+            tx.execute(
+                "INSERT INTO users (id, email, email_normalized, name, role, created_at) \
+                 VALUES ('u1', 'a@x.test', 'a@x.test', 'A', 'depositor', '2026-08-21 10:00:00+00:00')",
+                [],
+            )
+        })
+        .await
+        .expect("write should succeed");
+
+        let count: i64 = db
+            .read(|conn| conn.query_row("SELECT count(*) FROM users", [], |row| row.get(0)))
+            .await
+            .expect("read should succeed");
+        assert_eq!(count, 1, "a reader connection must see what the writer wrote");
+    }
+
+    #[tokio::test]
+    async fn test_every_reader_connection_sees_the_schema() {
+        // Exercises more connections than one, so a per-connection database (the
+        // bare `:memory:` failure) shows up rather than hiding behind a single
+        // reader that happens to be reused.
+        let db = test_db("all-readers").await;
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let db = db.clone();
+            handles.push(tokio::spawn(async move {
+                db.read(|conn| conn.query_row("SELECT count(*) FROM submissions", [], |row| row.get::<_, i64>(0)))
+                    .await
+            }));
+        }
+        for handle in handles {
+            assert_eq!(handle.await.unwrap().expect("read should succeed"), 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_reader_connections_reject_writes() {
+        // The structural half of "BEGIN IMMEDIATE on every write path": if a
+        // reader could write, a caller could bypass `write()` and its
+        // `BEGIN IMMEDIATE` without anyone noticing at review time.
+        let db = test_db("query-only").await;
+        let result = db
+            .read(|conn| {
+                conn.execute(
+                    "INSERT INTO users (id, email, email_normalized, name, role, created_at) \
+                     VALUES ('u1', 'a@x.test', 'a@x.test', 'A', 'depositor', '2026-08-21 10:00:00+00:00')",
+                    [],
+                )
+            })
+            .await;
+        let error = result.expect_err("a write through read() must be refused").to_string();
+        assert!(error.contains("readonly"), "expected a readonly failure, got: {error}");
+    }
+
+    #[tokio::test]
+    async fn test_read_transactions_are_read_only_too() {
+        // `read_tx` exists so a multi-statement read sees one snapshot. It must
+        // not become a second write path in the process — that would put writes
+        // outside `write()` and its `BEGIN IMMEDIATE`.
+        let db = test_db("read-tx-query-only").await;
+        let result = db
+            .read_tx(|tx| {
+                tx.execute(
+                    "INSERT INTO users (id, email, email_normalized, name, role, created_at) \
+                     VALUES ('u1', 'a@x.test', 'a@x.test', 'A', 'depositor', '2026-08-21 10:00:00+00:00')",
+                    [],
+                )
+            })
+            .await;
+        let error = result.expect_err("a write through read_tx must be refused").to_string();
+        assert!(error.contains("readonly"), "expected a readonly failure, got: {error}");
+    }
+
+    #[tokio::test]
+    async fn test_a_read_transaction_does_not_block_writes() {
+        // A read transaction that outlived its call would starve WAL
+        // checkpointing and let `-wal` grow without bound. It cannot, because it
+        // begins and ends inside one `interact` closure — so a write straight
+        // after one goes through.
+        let db = test_db("read-tx-no-block").await;
+        let counted: i64 = db
+            .read_tx(|tx| tx.query_row("SELECT count(*) FROM users", [], |row| row.get(0)))
+            .await
+            .expect("read transaction should succeed");
+        assert_eq!(counted, 0);
+
+        db.write(|tx| {
+            tx.execute(
+                "INSERT INTO users (id, email, email_normalized, name, role, created_at) \
+                 VALUES ('u1', 'a@x.test', 'a@x.test', 'A', 'rdu', '2026-08-21 10:00:00+00:00')",
+                [],
+            )
+        })
+        .await
+        .expect("a write after a read transaction must not be blocked");
+    }
+
+    #[tokio::test]
+    async fn test_foreign_keys_are_enforced_on_every_connection() {
+        // `PRAGMA foreign_keys` is per-connection and a silent no-op inside a
+        // transaction. If it were applied centrally after the pool was built, or
+        // from inside the migration transaction, this insert would succeed and
+        // `ON DELETE CASCADE` would never fire anywhere.
+        let db = test_db("foreign-keys").await;
+        let result = db
+            .write(|tx| {
+                tx.execute(
+                    "INSERT INTO sessions (id, user_id, created_at, last_seen_at, expires_at) \
+                     VALUES ('s1', 'no-such-user', '2026-08-21 10:00:00+00:00', '2026-08-21 10:00:00+00:00', \
+                     '2026-08-21 11:00:00+00:00')",
+                    [],
+                )
+            })
+            .await;
+        assert!(result.is_err(), "a session for a nonexistent user must be rejected");
+
+        // And that it is on for readers too, so a reader cannot be the one
+        // connection that silently disagrees.
+        let on: i64 = db
+            .read(|conn| conn.query_row("PRAGMA foreign_keys", [], |row| row.get(0)))
+            .await
+            .expect("pragma read should succeed");
+        assert_eq!(on, 1);
+    }
+
+    #[tokio::test]
+    async fn test_busy_timeout_is_set_on_every_connection() {
+        // Per-connection and zero by default. A reader left at zero returns
+        // SQLITE_BUSY the moment the writer holds the lock, which is precisely
+        // the intermittent production failure this layer is built to avoid.
+        let db = test_db("busy-timeout").await;
+        // Concurrently, so more than one pooled connection is created and the
+        // assertion covers connections beyond the first.
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let db = db.clone();
+            handles.push(tokio::spawn(async move {
+                db.read(|conn| conn.query_row("PRAGMA busy_timeout", [], |row| row.get::<_, i64>(0)))
+                    .await
+            }));
+        }
+        for handle in handles {
+            assert_eq!(handle.await.unwrap().expect("pragma read should succeed"), 5000);
+        }
+
+        let writer_timeout: i64 = db
+            .write(|tx| tx.query_row("PRAGMA busy_timeout", [], |row| row.get(0)))
+            .await
+            .expect("pragma read should succeed");
+        assert_eq!(writer_timeout, 5000);
+    }
+
+    #[tokio::test]
+    async fn test_failed_write_rolls_back() {
+        let db = test_db("rollback").await;
+        let result: Result<(), DbError> = db
+            .write(|tx| {
+                tx.execute(
+                    "INSERT INTO users (id, email, email_normalized, name, role, created_at) \
+                     VALUES ('u1', 'a@x.test', 'a@x.test', 'A', 'depositor', '2026-08-21 10:00:00+00:00')",
+                    [],
+                )?;
+                // Same primary key: the statement fails, so the closure returns
+                // Err and the whole transaction must go, first insert included.
+                tx.execute(
+                    "INSERT INTO users (id, email, email_normalized, name, role, created_at) \
+                     VALUES ('u1', 'b@x.test', 'b@x.test', 'B', 'depositor', '2026-08-21 10:00:00+00:00')",
+                    [],
+                )?;
+                Ok(())
+            })
+            .await;
+        assert!(result.is_err());
+
+        let count: i64 = db
+            .read(|conn| conn.query_row("SELECT count(*) FROM users", [], |row| row.get(0)))
+            .await
+            .expect("read should succeed");
+        assert_eq!(count, 0, "the first insert must have been rolled back with the second");
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_writes_all_commit() {
+        // With a deferred BEGIN this is where `database is locked` appears: a
+        // read transaction that cannot be upgraded fails part-way. With
+        // BEGIN IMMEDIATE and one writer connection, they serialise and all
+        // commit.
+        let db = test_db("concurrent-writes").await;
+        let mut handles = Vec::new();
+        for i in 0..24 {
+            let db = db.clone();
+            handles.push(tokio::spawn(async move {
+                db.write(move |tx| {
+                    // A read followed by a write in one transaction — the shape
+                    // a deferred BEGIN cannot upgrade.
+                    let existing: i64 = tx.query_row("SELECT count(*) FROM users", [], |row| row.get(0))?;
+                    tx.execute(
+                        "INSERT INTO users (id, email, email_normalized, name, role, created_at) \
+                         VALUES (?1, ?2, ?2, ?3, 'depositor', '2026-08-21 10:00:00+00:00')",
+                        rusqlite::params![format!("u{i}"), format!("u{i}@x.test"), format!("User {existing}")],
+                    )
+                })
+                .await
+            }));
+        }
+        for handle in handles {
+            handle.await.unwrap().expect("every concurrent write must commit");
+        }
+
+        let count: i64 = db
+            .read(|conn| conn.query_row("SELECT count(*) FROM users", [], |row| row.get(0)))
+            .await
+            .expect("read should succeed");
+        assert_eq!(count, 24);
+    }
+
+    #[test]
+    fn test_preflight_reports_a_missing_directory_as_missing() {
+        let missing = std::env::temp_dir().join(format!("editor-db-missing-{}", std::process::id()));
+        let error = preflight(&missing).expect_err("a missing directory must fail the pre-flight");
+        assert!(matches!(error, DbError::DirectoryMissing { .. }), "{error}");
+        // The message has to name the cause, because SQLite's own wording for
+        // all of these is `unable to open database file`.
+        assert!(error.to_string().contains("does not exist"), "{error}");
+    }
+
+    #[test]
+    fn test_preflight_rejects_a_file_where_a_directory_is_expected() {
+        // The mount-the-directory-not-the-file mistake. Pointing at the file
+        // works right up to the first WAL write and then fails, so catching it
+        // at startup is the difference between a clear message and a corrupted
+        // deployment.
+        let file = std::env::temp_dir().join(format!("editor-db-file-{}.sqlite3", std::process::id()));
+        std::fs::write(&file, b"not a directory").unwrap();
+        let error = preflight(&file).expect_err("a file must fail the pre-flight");
+        assert!(matches!(error, DbError::DirectoryNotADirectory { .. }), "{error}");
+        assert!(error.to_string().contains("not a directory"), "{error}");
+        std::fs::remove_file(&file).ok();
+    }
+
+    #[test]
+    fn test_preflight_accepts_a_writable_directory_and_leaves_nothing_behind() {
+        let dir = std::env::temp_dir().join(format!("editor-db-ok-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        preflight(&dir).expect("a writable directory must pass");
+        let leftovers: Vec<_> = std::fs::read_dir(&dir).unwrap().flatten().map(|e| e.file_name()).collect();
+        assert!(leftovers.is_empty(), "the probe file must be removed: {leftovers:?}");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_preflight_reports_an_unwritable_directory_as_a_permissions_problem() {
+        // The uid-65532 case: the directory exists and is readable, and only the
+        // write fails.
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("editor-db-ro-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        let result = preflight(&dir);
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::remove_dir_all(&dir).ok();
+
+        // root ignores the mode bits, so the write succeeds and there is nothing
+        // to assert. Asserted rather than skipped when it does fail, because
+        // that is the case the message has to get right.
+        if let Err(error) = result {
+            assert!(matches!(error, DbError::DirectoryNotWritable { .. }), "{error}");
+            assert!(error.to_string().contains("65532"), "the message must name the uid: {error}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_file_database_uses_wal_and_creates_its_siblings_in_the_directory() {
+        // WAL is why the *directory* has to be writable rather than just the
+        // file: `-wal` and `-shm` are created next to the database.
+        let dir = std::env::temp_dir().join(format!("editor-db-wal-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let db = Database::open(Source::Directory(dir.clone()), 2, Duration::from_secs(5))
+            .await
+            .expect("a file database should open");
+        let mode: String = db
+            .read(|conn| conn.query_row("PRAGMA journal_mode", [], |row| row.get(0)))
+            .await
+            .expect("pragma read should succeed");
+        assert_eq!(mode.to_lowercase(), "wal");
+
+        db.write(|tx| {
+            tx.execute(
+                "INSERT INTO users (id, email, email_normalized, name, role, created_at) \
+                 VALUES ('u1', 'a@x.test', 'a@x.test', 'A', 'rdu', '2026-08-21 10:00:00+00:00')",
+                [],
+            )
+        })
+        .await
+        .expect("write should succeed");
+
+        assert!(dir.join(DATABASE_FILE_NAME).exists());
+        assert!(
+            dir.join(format!("{DATABASE_FILE_NAME}-wal")).exists(),
+            "the -wal sibling must be next to the file"
+        );
+
+        drop(db);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/modules/editor/server/src/db/schema.rs
+++ b/modules/editor/server/src/db/schema.rs
@@ -1,0 +1,231 @@
+//! The schema, as a forward-only ordered statement list guarded by
+//! `PRAGMA user_version`.
+//!
+//! No migration framework and no added dependency. What one would buy here is a
+//! version table, checksums and down-migrations; what this needs is "run the
+//! statements this database has not run yet", and SQLite already carries the
+//! counter for it in its own header.
+//!
+//! The rules that keep it honest:
+//!
+//! - [`MIGRATIONS`] is **append-only**. A released entry is never edited — every database that
+//!   already ran it would skip the edit, so the schema would differ by deployment age.
+//! - Everything runs inside one `BEGIN IMMEDIATE` transaction, the `user_version` bump included, so
+//!   a crash part-way leaves the database at the version it started from rather than half-migrated.
+//!   `BEGIN IMMEDIATE` also makes two processes starting at once safe: the second waits and then
+//!   finds nothing to do.
+//! - `PRAGMA foreign_keys` is **not** touched here. It is a documented silent no-op inside a
+//!   transaction, so a migration that set it would appear to work and leave every `ON DELETE
+//!   CASCADE` unenforced. It belongs to the per-connection init hook in [`super::init_connection`],
+//!   and this is the helper it would be tempting to share.
+
+use super::{Database, DbError};
+
+/// Ordered and append-only: index `i` is migration `i + 1`, and how many have
+/// been applied is `PRAGMA user_version`.
+const MIGRATIONS: &[&str] = &[include_str!("migrations/0001_initial.sql")];
+
+/// The version a fully migrated database reports.
+pub(crate) const SCHEMA_VERSION: u32 = MIGRATIONS.len() as u32;
+
+impl Database {
+    /// Apply every migration this database has not run, and return how many ran.
+    ///
+    /// Zero means the schema was already current, which is the normal case on
+    /// every restart after the first.
+    pub(super) async fn migrate(&self) -> Result<u32, DbError> {
+        self.write(|tx| {
+            let current: u32 = tx.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))?.max(0) as u32;
+
+            // A database from a newer release. Continuing would run application
+            // code against a schema it does not know, so stop — with the two
+            // numbers in the message, because the cause is a rollback to an
+            // older image and nothing about SQLite's own errors would say so.
+            if current > SCHEMA_VERSION {
+                return Err(rusqlite::Error::SqliteFailure(
+                    rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_MISUSE),
+                    Some(format!(
+                        "the database is at schema version {current}, but this build only knows {SCHEMA_VERSION} — it \
+                         was written by a newer release of editor-server"
+                    )),
+                ));
+            }
+
+            let mut applied = 0;
+            for (index, statements) in MIGRATIONS.iter().enumerate().skip(current as usize) {
+                let version = index as u32 + 1;
+                tx.execute_batch(statements)?;
+                // Not a bind parameter: PRAGMA values cannot be parameterised.
+                // `version` is derived from a slice index, so there is nothing to
+                // inject.
+                tx.pragma_update(None, "user_version", version)?;
+                applied += 1;
+            }
+            Ok(applied)
+        })
+        .await
+    }
+
+    /// The schema version this database reports.
+    pub(crate) async fn schema_version(&self) -> Result<u32, DbError> {
+        let version: i64 = self
+            .read(|conn| conn.pragma_query_value(None, "user_version", |row| row.get(0)))
+            .await?;
+        Ok(version.max(0) as u32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::super::tests::test_db;
+    use super::*;
+    use crate::db::Source;
+
+    /// Every table the persistence layer is responsible for.
+    const EXPECTED_TABLES: &[&str] = &[
+        "approved_records",
+        "drafts",
+        "login_codes",
+        "sessions",
+        "submissions",
+        "user_shortcodes",
+        "users",
+    ];
+
+    #[tokio::test]
+    async fn test_migrations_apply_to_an_empty_database() {
+        let db = test_db("migrate-empty").await;
+        assert_eq!(db.schema_version().await.unwrap(), SCHEMA_VERSION);
+
+        let mut tables: Vec<String> = db
+            .read(|conn| {
+                let mut stmt = conn.prepare(
+                    "SELECT name FROM sqlite_schema WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+                )?;
+                let rows = stmt.query_map([], |row| row.get(0))?;
+                rows.collect()
+            })
+            .await
+            .expect("reading the schema should succeed");
+        tables.sort();
+        assert_eq!(tables, EXPECTED_TABLES);
+    }
+
+    #[tokio::test]
+    async fn test_migrations_are_idempotent_on_re_run() {
+        // The property `user_version` exists to give: a second run finds nothing
+        // to do. Without the guard the CREATE TABLEs would fail on every restart
+        // after the first.
+        let db = test_db("migrate-idempotent").await;
+        assert_eq!(db.migrate().await.unwrap(), 0, "a re-run must apply nothing");
+        assert_eq!(db.migrate().await.unwrap(), 0);
+        assert_eq!(db.schema_version().await.unwrap(), SCHEMA_VERSION);
+    }
+
+    #[tokio::test]
+    async fn test_open_applies_exactly_the_outstanding_migrations() {
+        let db = test_db("migrate-count").await;
+        // `open` already migrated, so the fresh count is observable only through
+        // the version it left behind.
+        assert_eq!(db.schema_version().await.unwrap(), SCHEMA_VERSION);
+        assert!(SCHEMA_VERSION >= 1, "there is at least one migration");
+    }
+
+    #[tokio::test]
+    async fn test_reopening_a_file_database_keeps_its_data_and_does_not_re_migrate() {
+        // The restart path. Reopening must find the schema current and leave the
+        // rows alone — a migration that re-ran would drop or duplicate them.
+        let dir = std::env::temp_dir().join(format!("editor-db-reopen-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let first = Database::open(Source::Directory(dir.clone()), 2, Duration::from_secs(5))
+            .await
+            .expect("first open should succeed");
+        first
+            .write(|tx| {
+                tx.execute(
+                    "INSERT INTO users (id, email, email_normalized, name, role, created_at) \
+                     VALUES ('u1', 'a@x.test', 'a@x.test', 'A', 'rdu', '2026-08-21 10:00:00+00:00')",
+                    [],
+                )
+            })
+            .await
+            .expect("write should succeed");
+        drop(first);
+
+        let second = Database::open(Source::Directory(dir.clone()), 2, Duration::from_secs(5))
+            .await
+            .expect("reopen should succeed");
+        assert_eq!(second.migrate().await.unwrap(), 0, "a reopened database must not re-migrate");
+        let count: i64 = second
+            .read(|conn| conn.query_row("SELECT count(*) FROM users", [], |row| row.get(0)))
+            .await
+            .expect("read should succeed");
+        assert_eq!(count, 1);
+
+        drop(second);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn test_a_database_from_a_newer_release_is_refused() {
+        // The rollback case: an older image against a newer schema. Running the
+        // application anyway would query columns that do not exist yet, one
+        // handler at a time; failing at startup makes it one clear error.
+        let db = test_db("migrate-future").await;
+        db.write(|tx| tx.pragma_update(None, "user_version", SCHEMA_VERSION + 5))
+            .await
+            .expect("bumping the version should succeed");
+
+        let error = db
+            .migrate()
+            .await
+            .expect_err("a future schema version must be refused")
+            .to_string();
+        assert!(error.contains("newer release"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn test_timestamp_columns_order_chronologically_as_text() {
+        // Timestamps are TEXT, so `expires_at > ?` is a string comparison.
+        // rusqlite's chrono format is fixed-width and always UTC, which is what
+        // makes that comparison chronological — a mixed-offset or variable-width
+        // format would sort wrongly and silently accept expired sessions.
+        use chrono::{TimeZone, Utc};
+
+        let db = test_db("timestamp-order").await;
+        let base = Utc.with_ymd_and_hms(2026, 8, 21, 10, 0, 0).unwrap();
+        let later = Utc.with_ymd_and_hms(2026, 8, 21, 11, 0, 0).unwrap();
+        let much_later = Utc.with_ymd_and_hms(2026, 12, 1, 9, 0, 0).unwrap();
+
+        db.write(move |tx| {
+            tx.execute(
+                "INSERT INTO users (id, email, email_normalized, name, role, created_at) \
+                 VALUES ('u1', 'a@x.test', 'a@x.test', 'A', 'rdu', ?1)",
+                rusqlite::params![base],
+            )?;
+            for (id, expires) in [("s1", base), ("s2", later), ("s3", much_later)] {
+                tx.execute(
+                    "INSERT INTO sessions (id, user_id, created_at, last_seen_at, expires_at) \
+                     VALUES (?1, 'u1', ?2, ?2, ?3)",
+                    rusqlite::params![id, base, expires],
+                )?;
+            }
+            Ok(())
+        })
+        .await
+        .expect("write should succeed");
+
+        let live: Vec<String> = db
+            .read(move |conn| {
+                let mut stmt = conn.prepare("SELECT id FROM sessions WHERE expires_at > ?1 ORDER BY expires_at")?;
+                let rows = stmt.query_map(rusqlite::params![later], |row| row.get(0))?;
+                rows.collect()
+            })
+            .await
+            .expect("read should succeed");
+        assert_eq!(live, vec!["s3".to_string()], "only the session past `later` is live");
+    }
+}

--- a/modules/editor/server/src/db/sessions.rs
+++ b/modules/editor/server/src/db/sessions.rs
@@ -1,0 +1,261 @@
+//! [`SessionRepository`] against SQLite.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use editor_core::records::Session;
+use editor_core::repository::{RepositoryError, Result, SessionRepository};
+use rusqlite::{params, Row};
+use uuid::Uuid;
+
+use super::mapping::{uuid_column, OptionalRow};
+use super::Database;
+
+const ENTITY: &str = "session";
+
+const SELECT: &str = "SELECT id, user_id, created_at, last_seen_at, expires_at FROM sessions";
+
+fn map_row(row: &Row<'_>) -> rusqlite::Result<Session> {
+    Ok(Session {
+        id: row.get(0)?,
+        user_id: uuid_column(row, 1)?,
+        created_at: row.get(2)?,
+        last_seen_at: row.get(3)?,
+        expires_at: row.get(4)?,
+    })
+}
+
+#[async_trait]
+impl SessionRepository for Database {
+    async fn create(&self, session: &Session) -> Result<()> {
+        let session = session.clone();
+        self.write(move |tx| {
+            tx.execute(
+                "INSERT INTO sessions (id, user_id, created_at, last_seen_at, expires_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![
+                    session.id,
+                    session.user_id.to_string(),
+                    session.created_at,
+                    session.last_seen_at,
+                    session.expires_at,
+                ],
+            )
+        })
+        .await
+        .map_err(|e| e.into_repository_error(ENTITY))?;
+        Ok(())
+    }
+
+    async fn find(&self, id: &str) -> Result<Option<Session>> {
+        let id = id.to_string();
+        Ok(self
+            .read(move |conn| {
+                conn.query_row(&format!("{SELECT} WHERE id = ?1"), params![id], map_row)
+                    .optional_row()
+            })
+            .await?)
+    }
+
+    async fn touch(&self, id: &str, at: DateTime<Utc>) -> Result<()> {
+        let id = id.to_string();
+        let updated = self
+            .write(move |tx| tx.execute("UPDATE sessions SET last_seen_at = ?2 WHERE id = ?1", params![id, at]))
+            .await?;
+        if updated == 0 {
+            return Err(RepositoryError::NotFound { entity: ENTITY });
+        }
+        Ok(())
+    }
+
+    async fn delete(&self, id: &str) -> Result<bool> {
+        let id = id.to_string();
+        let deleted = self
+            .write(move |tx| tx.execute("DELETE FROM sessions WHERE id = ?1", params![id]))
+            .await?;
+        Ok(deleted > 0)
+    }
+
+    async fn delete_for_user(&self, user_id: Uuid) -> Result<u64> {
+        let deleted = self
+            .write(move |tx| tx.execute("DELETE FROM sessions WHERE user_id = ?1", params![user_id.to_string()]))
+            .await?;
+        Ok(deleted as u64)
+    }
+
+    async fn delete_expired(&self, now: DateTime<Utc>) -> Result<u64> {
+        let deleted = self
+            .write(move |tx| tx.execute("DELETE FROM sessions WHERE expires_at <= ?1", params![now]))
+            .await?;
+        Ok(deleted as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use editor_core::records::{Role, User};
+    use editor_core::repository::UserRepository;
+
+    use super::super::tests::{count, test_db};
+    use super::*;
+
+    fn at(hour: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 21, hour, 0, 0).unwrap()
+    }
+
+    async fn a_user(db: &Database) -> Uuid {
+        let user = User {
+            id: Uuid::new_v4(),
+            email: "a@x.test".to_string(),
+            name: "A".to_string(),
+            role: Role::Depositor,
+            shortcodes: vec![],
+            failed_logins: 0,
+            last_code_at: None,
+            created_at: at(9),
+        };
+        UserRepository::create(db, &user).await.unwrap();
+        user.id
+    }
+
+    fn session(id: &str, user_id: Uuid, expires: DateTime<Utc>) -> Session {
+        Session {
+            id: id.to_string(),
+            user_id,
+            created_at: at(10),
+            last_seen_at: at(10),
+            expires_at: expires,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_then_find_round_trips_every_field() {
+        let db = test_db("sessions-round-trip").await;
+        let user_id = a_user(&db).await;
+        let session = session("token-1", user_id, at(18));
+        SessionRepository::create(&db, &session).await.unwrap();
+
+        assert_eq!(db.find("token-1").await.unwrap(), Some(session));
+    }
+
+    #[tokio::test]
+    async fn test_find_of_an_unknown_token_is_none_not_an_error() {
+        // The common case on any request carrying a stale cookie, so it must not
+        // be an error path.
+        let db = test_db("sessions-find-missing").await;
+        assert_eq!(db.find("no-such-token").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_touch_advances_last_seen_without_moving_the_absolute_expiry() {
+        // The idle timeout advances; the absolute expiry does not. If `touch`
+        // moved `expires_at` too, a session in continuous use would never expire.
+        let db = test_db("sessions-touch").await;
+        let user_id = a_user(&db).await;
+        SessionRepository::create(&db, &session("token-1", user_id, at(18)))
+            .await
+            .unwrap();
+
+        db.touch("token-1", at(14)).await.unwrap();
+
+        let found = db.find("token-1").await.unwrap().unwrap();
+        assert_eq!(found.last_seen_at, at(14));
+        assert_eq!(found.expires_at, at(18));
+    }
+
+    #[tokio::test]
+    async fn test_touch_of_an_unknown_token_is_not_found() {
+        let db = test_db("sessions-touch-missing").await;
+        let error = db
+            .touch("no-such-token", at(14))
+            .await
+            .expect_err("touching a gone session must fail");
+        assert!(matches!(error, RepositoryError::NotFound { entity: "session" }), "{error}");
+    }
+
+    #[tokio::test]
+    async fn test_delete_reports_whether_there_was_anything_to_delete() {
+        let db = test_db("sessions-delete").await;
+        let user_id = a_user(&db).await;
+        SessionRepository::create(&db, &session("token-1", user_id, at(18)))
+            .await
+            .unwrap();
+
+        assert!(
+            SessionRepository::delete(&db, "token-1").await.unwrap(),
+            "the first delete removes it"
+        );
+        assert!(
+            !SessionRepository::delete(&db, "token-1").await.unwrap(),
+            "the second finds nothing"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_for_user_clears_every_session_of_that_user_only() {
+        // Session rotation on login depends on this, and so does logging out
+        // everywhere. Taking another user's sessions with it would log out
+        // bystanders.
+        let db = test_db("sessions-delete-for-user").await;
+        let first = a_user(&db).await;
+        let second = {
+            let user = User {
+                id: Uuid::new_v4(),
+                email: "b@x.test".to_string(),
+                name: "B".to_string(),
+                role: Role::Depositor,
+                shortcodes: vec![],
+                failed_logins: 0,
+                last_code_at: None,
+                created_at: at(9),
+            };
+            UserRepository::create(&db, &user).await.unwrap();
+            user.id
+        };
+        SessionRepository::create(&db, &session("a-1", first, at(18))).await.unwrap();
+        SessionRepository::create(&db, &session("a-2", first, at(18))).await.unwrap();
+        SessionRepository::create(&db, &session("b-1", second, at(18))).await.unwrap();
+
+        assert_eq!(db.delete_for_user(first).await.unwrap(), 2);
+        assert_eq!(count(&db, "sessions").await, 1);
+        assert!(db.find("b-1").await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_delete_expired_takes_only_sessions_past_their_absolute_expiry() {
+        // `expires_at` is TEXT, so this is a string comparison; it is
+        // chronological only because the stored format is fixed-width UTC.
+        let db = test_db("sessions-delete-expired").await;
+        let user_id = a_user(&db).await;
+        SessionRepository::create(&db, &session("expired", user_id, at(11)))
+            .await
+            .unwrap();
+        SessionRepository::create(&db, &session("boundary", user_id, at(12)))
+            .await
+            .unwrap();
+        SessionRepository::create(&db, &session("live", user_id, at(13))).await.unwrap();
+
+        assert_eq!(db.delete_expired(at(12)).await.unwrap(), 2, "the boundary counts as expired");
+        assert!(db.find("expired").await.unwrap().is_none());
+        assert!(db.find("boundary").await.unwrap().is_none());
+        assert!(db.find("live").await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_a_session_for_an_unknown_user_is_refused() {
+        // The foreign key, observable. Without it an orphaned session would
+        // authenticate a request against a user row that does not exist.
+        let db = test_db("sessions-orphan").await;
+        let error = SessionRepository::create(&db, &session("token-1", Uuid::new_v4(), at(18)))
+            .await
+            .expect_err("a session for an unknown user must be refused");
+        // A foreign-key failure is not a duplicate. Reported as `Conflict` it
+        // would read as "session already exists" and send the reader looking for
+        // a second row that is not there, so only unique and primary-key
+        // violations map to `Conflict`.
+        assert!(
+            matches!(error, RepositoryError::Backend(_)),
+            "a foreign-key failure must not be reported as a conflict: {error}"
+        );
+        assert_eq!(count(&db, "sessions").await, 0);
+    }
+}

--- a/modules/editor/server/src/db/submissions.rs
+++ b/modules/editor/server/src/db/submissions.rs
@@ -1,0 +1,303 @@
+//! [`SubmissionRepository`] against SQLite.
+
+use async_trait::async_trait;
+use editor_core::records::{Submission, SubmissionState};
+use editor_core::repository::{RepositoryError, Result, SubmissionRepository};
+use rusqlite::{params, Row};
+use uuid::Uuid;
+
+use super::mapping::{optional_uuid_column, parsed_column, uuid_column, OptionalRow};
+use super::Database;
+
+const ENTITY: &str = "submission";
+
+const SELECT: &str = "SELECT id, shortcode, payload, state, submitted_by, submitted_at, reviewed_by, reviewed_at, \
+                      reviewer_note FROM submissions";
+
+fn map_row(row: &Row<'_>) -> rusqlite::Result<Submission> {
+    Ok(Submission {
+        id: uuid_column(row, 0)?,
+        shortcode: row.get(1)?,
+        payload: row.get(2)?,
+        state: parsed_column::<SubmissionState>(row, 3)?,
+        submitted_by: optional_uuid_column(row, 4)?,
+        submitted_at: row.get(5)?,
+        reviewed_by: optional_uuid_column(row, 6)?,
+        reviewed_at: row.get(7)?,
+        reviewer_note: row.get(8)?,
+    })
+}
+
+#[async_trait]
+impl SubmissionRepository for Database {
+    async fn create(&self, submission: &Submission) -> Result<()> {
+        let submission = submission.clone();
+        self.write(move |tx| {
+            tx.execute(
+                "INSERT INTO submissions (id, shortcode, payload, state, submitted_by, submitted_at, reviewed_by, \
+                 reviewed_at, reviewer_note) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                params![
+                    submission.id.to_string(),
+                    submission.shortcode,
+                    submission.payload,
+                    submission.state.as_str(),
+                    submission.submitted_by.map(|id| id.to_string()),
+                    submission.submitted_at,
+                    submission.reviewed_by.map(|id| id.to_string()),
+                    submission.reviewed_at,
+                    submission.reviewer_note,
+                ],
+            )
+        })
+        .await
+        // `shortcode` is the only unique index here, so a constraint violation
+        // is a second pending submission for one project — PRD Constraints'
+        // "one pending submission per project", reported rather than silently
+        // replacing the first.
+        .map_err(|e| e.into_repository_error(ENTITY))?;
+        Ok(())
+    }
+
+    async fn update(&self, submission: &Submission) -> Result<()> {
+        let submission = submission.clone();
+        let updated = self
+            .write(move |tx| {
+                tx.execute(
+                    "UPDATE submissions SET payload = ?2, state = ?3, reviewed_by = ?4, reviewed_at = ?5, \
+                     reviewer_note = ?6 WHERE id = ?1",
+                    params![
+                        submission.id.to_string(),
+                        submission.payload,
+                        submission.state.as_str(),
+                        submission.reviewed_by.map(|id| id.to_string()),
+                        submission.reviewed_at,
+                        submission.reviewer_note,
+                    ],
+                )
+            })
+            .await
+            .map_err(|e| e.into_repository_error(ENTITY))?;
+        if updated == 0 {
+            return Err(RepositoryError::NotFound { entity: ENTITY });
+        }
+        Ok(())
+    }
+
+    async fn find(&self, id: Uuid) -> Result<Option<Submission>> {
+        Ok(self
+            .read(move |conn| {
+                conn.query_row(&format!("{SELECT} WHERE id = ?1"), params![id.to_string()], map_row)
+                    .optional_row()
+            })
+            .await?)
+    }
+
+    async fn find_by_shortcode(&self, shortcode: &str) -> Result<Option<Submission>> {
+        let shortcode = shortcode.to_string();
+        Ok(self
+            .read(move |conn| {
+                conn.query_row(&format!("{SELECT} WHERE shortcode = ?1"), params![shortcode], map_row)
+                    .optional_row()
+            })
+            .await?)
+    }
+
+    async fn list(&self) -> Result<Vec<Submission>> {
+        Ok(self
+            .read(|conn| {
+                // Oldest first (REQ-4.1), with the shortcode breaking ties so two
+                // submissions made in the same instant have a stable order.
+                let mut stmt = conn.prepare(&format!("{SELECT} ORDER BY submitted_at, shortcode"))?;
+                let rows = stmt.query_map([], map_row)?;
+                rows.collect()
+            })
+            .await?)
+    }
+
+    async fn delete(&self, id: Uuid) -> Result<bool> {
+        let deleted = self
+            .write(move |tx| tx.execute("DELETE FROM submissions WHERE id = ?1", params![id.to_string()]))
+            .await?;
+        Ok(deleted > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{DateTime, TimeZone, Utc};
+    use editor_core::records::{Role, User};
+    use editor_core::repository::UserRepository;
+
+    use super::super::tests::{count, test_db};
+    use super::*;
+
+    fn at(hour: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 21, hour, 0, 0).unwrap()
+    }
+
+    async fn a_user(db: &Database, email: &str, role: Role) -> Uuid {
+        let user = User {
+            id: Uuid::new_v4(),
+            email: email.to_string(),
+            name: "A".to_string(),
+            role,
+            shortcodes: vec![],
+            failed_logins: 0,
+            last_code_at: None,
+            created_at: at(9),
+        };
+        UserRepository::create(db, &user).await.unwrap();
+        user.id
+    }
+
+    fn submission(shortcode: &str, author: Option<Uuid>, submitted: DateTime<Utc>) -> Submission {
+        Submission {
+            id: Uuid::new_v4(),
+            shortcode: shortcode.to_string(),
+            payload: r#"{"name":"submitted"}"#.to_string(),
+            state: SubmissionState::Submitted,
+            submitted_by: author,
+            submitted_at: submitted,
+            reviewed_by: None,
+            reviewed_at: None,
+            reviewer_note: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_then_find_round_trips_every_field() {
+        let db = test_db("submissions-round-trip").await;
+        let author = a_user(&db, "a@x.test", Role::Depositor).await;
+        let submission = submission("0801", Some(author), at(11));
+        SubmissionRepository::create(&db, &submission).await.unwrap();
+
+        assert_eq!(
+            SubmissionRepository::find(&db, submission.id).await.unwrap(),
+            Some(submission.clone())
+        );
+        assert_eq!(db.find_by_shortcode("0801").await.unwrap(), Some(submission));
+    }
+
+    #[tokio::test]
+    async fn test_a_second_pending_submission_for_one_project_is_a_conflict() {
+        // PRD Constraints: one pending submission per project. Enforced by the
+        // unique index rather than by handlers remembering to check, so a race
+        // between two submits cannot produce two rows.
+        let db = test_db("submissions-conflict").await;
+        let author = a_user(&db, "a@x.test", Role::Depositor).await;
+        SubmissionRepository::create(&db, &submission("0801", Some(author), at(11)))
+            .await
+            .unwrap();
+
+        let error = SubmissionRepository::create(&db, &submission("0801", Some(author), at(12)))
+            .await
+            .expect_err("a second submission for one project must be refused");
+        assert!(matches!(error, RepositoryError::Conflict { entity: "submission" }), "{error}");
+        assert_eq!(count(&db, "submissions").await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_update_records_the_review_without_moving_the_submission_time() {
+        // `submitted_at` orders the review queue; a review that reset it would
+        // send the submission to the back.
+        let db = test_db("submissions-update").await;
+        let author = a_user(&db, "a@x.test", Role::Depositor).await;
+        let reviewer = a_user(&db, "rdu@x.test", Role::Rdu).await;
+        let mut submission = submission("0801", Some(author), at(11));
+        SubmissionRepository::create(&db, &submission).await.unwrap();
+
+        submission.state = SubmissionState::Approved;
+        submission.reviewed_by = Some(reviewer);
+        submission.reviewed_at = Some(at(14));
+        submission.reviewer_note = Some("Looks right.".to_string());
+        SubmissionRepository::update(&db, &submission).await.unwrap();
+
+        let found = SubmissionRepository::find(&db, submission.id).await.unwrap().unwrap();
+        assert_eq!(found.state, SubmissionState::Approved);
+        assert_eq!(found.reviewed_by, Some(reviewer));
+        assert_eq!(found.reviewer_note.as_deref(), Some("Looks right."));
+        assert_eq!(found.submitted_at, at(11));
+    }
+
+    #[tokio::test]
+    async fn test_update_of_an_unknown_submission_is_not_found() {
+        let db = test_db("submissions-update-missing").await;
+        let error = SubmissionRepository::update(&db, &submission("0801", None, at(11)))
+            .await
+            .expect_err("an unknown submission must not update");
+        assert!(matches!(error, RepositoryError::NotFound { entity: "submission" }), "{error}");
+    }
+
+    #[tokio::test]
+    async fn test_list_is_oldest_first() {
+        // REQ-4.1's review queue order.
+        let db = test_db("submissions-list").await;
+        SubmissionRepository::create(&db, &submission("0803", None, at(13)))
+            .await
+            .unwrap();
+        SubmissionRepository::create(&db, &submission("0801", None, at(11)))
+            .await
+            .unwrap();
+        SubmissionRepository::create(&db, &submission("0805", None, at(12)))
+            .await
+            .unwrap();
+
+        let shortcodes: Vec<_> = SubmissionRepository::list(&db)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|s| s.shortcode)
+            .collect();
+        assert_eq!(shortcodes, vec!["0801".to_string(), "0805".to_string(), "0803".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_delete_frees_the_project_for_a_new_submission() {
+        // Reject (REQ-4.6) and depositor discard (REQ-4.7) both delete, and the
+        // depositor must then be able to submit again.
+        let db = test_db("submissions-delete").await;
+        let first = submission("0801", None, at(11));
+        SubmissionRepository::create(&db, &first).await.unwrap();
+
+        assert!(SubmissionRepository::delete(&db, first.id).await.unwrap());
+        assert!(!SubmissionRepository::delete(&db, first.id).await.unwrap());
+        SubmissionRepository::create(&db, &submission("0801", None, at(12)))
+            .await
+            .unwrap();
+        assert_eq!(count(&db, "submissions").await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_removing_the_submitter_leaves_the_submission_with_no_author() {
+        // ON DELETE SET NULL. The review queue's "last editor" reads as unknown;
+        // the submission itself is not destroyed by an account removal.
+        let db = test_db("submissions-author-removed").await;
+        let author = a_user(&db, "a@x.test", Role::Depositor).await;
+        let submission = submission("0801", Some(author), at(11));
+        SubmissionRepository::create(&db, &submission).await.unwrap();
+
+        UserRepository::delete(&db, author).await.unwrap();
+
+        let found = SubmissionRepository::find(&db, submission.id).await.unwrap().unwrap();
+        assert_eq!(found.submitted_by, None);
+        assert_eq!(found.payload, submission.payload);
+    }
+
+    #[tokio::test]
+    async fn test_an_unknown_state_in_the_database_is_refused_by_the_check_constraint() {
+        // The CHECK constraint and the `FromStr` mapping have to agree. If the
+        // constraint let an unknown state in, reading it back would fail at a
+        // handler instead of at the write.
+        let db = test_db("submissions-state-check").await;
+        let result = db
+            .write(|tx| {
+                tx.execute(
+                    "INSERT INTO submissions (id, shortcode, payload, state, submitted_at) \
+                     VALUES ('s1', '0801', '{}', 'rejected', '2026-08-21 11:00:00+00:00')",
+                    [],
+                )
+            })
+            .await;
+        assert!(result.is_err(), "an unknown state must be rejected at the write");
+    }
+}

--- a/modules/editor/server/src/db/users.rs
+++ b/modules/editor/server/src/db/users.rs
@@ -1,0 +1,458 @@
+//! [`UserRepository`] against SQLite.
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use editor_core::records::{Role, User};
+use editor_core::repository::{Result, UserRepository};
+use rusqlite::{params, Row, Transaction};
+use uuid::Uuid;
+
+use super::mapping::{counter, parsed_column, uuid_column};
+use super::Database;
+
+const ENTITY: &str = "user";
+
+const SELECT: &str = "SELECT id, email, name, role, failed_logins, last_code_at, created_at FROM users";
+
+fn map_row(row: &Row<'_>) -> rusqlite::Result<User> {
+    Ok(User {
+        id: uuid_column(row, 0)?,
+        email: row.get(1)?,
+        name: row.get(2)?,
+        role: parsed_column::<Role>(row, 3)?,
+        // Filled in by the caller: the shortcodes live in a child table, and
+        // joining them into this row would repeat every user column per
+        // assignment.
+        shortcodes: Vec::new(),
+        failed_logins: counter(row.get::<_, i64>(4)?),
+        last_code_at: row.get(5)?,
+        created_at: row.get(6)?,
+    })
+}
+
+/// Read one user's shortcode assignments.
+fn shortcodes_of(tx: &Transaction<'_>, user_id: Uuid) -> rusqlite::Result<Vec<String>> {
+    let mut stmt = tx.prepare("SELECT shortcode FROM user_shortcodes WHERE user_id = ?1 ORDER BY shortcode")?;
+    let rows = stmt.query_map(params![user_id.to_string()], |row| row.get(0))?;
+    rows.collect()
+}
+
+/// Replace a user's shortcode assignments with `shortcodes`.
+///
+/// Delete-then-insert rather than a diff: the set is a handful of entries, and a
+/// diff would have to be right about both directions to avoid leaving an
+/// assignment behind.
+fn replace_shortcodes(tx: &Transaction<'_>, user_id: Uuid, shortcodes: &[String]) -> rusqlite::Result<()> {
+    tx.execute("DELETE FROM user_shortcodes WHERE user_id = ?1", params![user_id.to_string()])?;
+    let mut stmt = tx.prepare("INSERT INTO user_shortcodes (user_id, shortcode) VALUES (?1, ?2)")?;
+    for shortcode in shortcodes {
+        stmt.execute(params![user_id.to_string(), shortcode])?;
+    }
+    Ok(())
+}
+
+#[async_trait]
+impl UserRepository for Database {
+    async fn create(&self, user: &User) -> Result<()> {
+        let user = user.clone();
+        let email_normalized = user.email_normalized();
+        self.write(move |tx| {
+            tx.execute(
+                "INSERT INTO users (id, email, email_normalized, name, role, failed_logins, last_code_at, \
+                 created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                params![
+                    user.id.to_string(),
+                    user.email,
+                    email_normalized,
+                    user.name,
+                    user.role.as_str(),
+                    i64::from(user.failed_logins),
+                    user.last_code_at,
+                    user.created_at,
+                ],
+            )?;
+            replace_shortcodes(tx, user.id, &user.shortcodes)
+        })
+        .await
+        // `email_normalized` is the only unique index on this table, so a
+        // constraint violation here is REQ-7.4's duplicate address.
+        .map_err(|e| e.into_repository_error(ENTITY))
+    }
+
+    async fn update(&self, user: &User) -> Result<()> {
+        let user = user.clone();
+        let email_normalized = user.email_normalized();
+        let updated = self
+            .write(move |tx| {
+                let updated = tx.execute(
+                    "UPDATE users SET email = ?2, email_normalized = ?3, name = ?4, role = ?5 WHERE id = ?1",
+                    params![
+                        user.id.to_string(),
+                        user.email,
+                        email_normalized,
+                        user.name,
+                        user.role.as_str()
+                    ],
+                )?;
+                if updated > 0 {
+                    replace_shortcodes(tx, user.id, &user.shortcodes)?;
+                }
+                Ok(updated)
+            })
+            .await
+            .map_err(|e| e.into_repository_error(ENTITY))?;
+
+        // Deliberately not silent. An update that matched nothing means the
+        // account was removed underneath the form, and reporting success would
+        // tell RDU the change landed.
+        if updated == 0 {
+            return Err(editor_core::repository::RepositoryError::NotFound { entity: ENTITY });
+        }
+        Ok(())
+    }
+
+    async fn delete(&self, id: Uuid) -> Result<()> {
+        // Sessions, codes and shortcode assignments go with it via
+        // `ON DELETE CASCADE` (REQ-7.5) — which only fires because
+        // `PRAGMA foreign_keys` is set per connection outside any transaction.
+        let deleted = self
+            .write(move |tx| tx.execute("DELETE FROM users WHERE id = ?1", params![id.to_string()]))
+            .await?;
+        if deleted == 0 {
+            return Err(editor_core::repository::RepositoryError::NotFound { entity: ENTITY });
+        }
+        Ok(())
+    }
+
+    async fn find_by_id(&self, id: Uuid) -> Result<Option<User>> {
+        // `read_tx`, not `read`: the shortcodes come from a second query and both
+        // have to see one snapshot, or an assignment change landing between them
+        // returns a user with shortcodes it no longer has. Not `write` either —
+        // every authenticated request looks a user up, and routing those through
+        // the single writer connection would serialise all of them.
+        Ok(self
+            .read_tx(move |tx| {
+                let mut stmt = tx.prepare(&format!("{SELECT} WHERE id = ?1"))?;
+                let mut rows = stmt.query_map(params![id.to_string()], map_row)?;
+                let Some(user) = rows.next().transpose()? else {
+                    return Ok(None);
+                };
+                drop(rows);
+                drop(stmt);
+                Ok(Some(User { shortcodes: shortcodes_of(tx, user.id)?, ..user }))
+            })
+            .await?)
+    }
+
+    async fn find_by_email(&self, email: &str) -> Result<Option<User>> {
+        // Normalized here, so callers pass whatever the user typed and REQ-6.2's
+        // anti-enumeration lookup cannot be defeated by capitalisation.
+        let normalized = User::normalize_email(email);
+        Ok(self
+            .read_tx(move |tx| {
+                let mut stmt = tx.prepare(&format!("{SELECT} WHERE email_normalized = ?1"))?;
+                let mut rows = stmt.query_map(params![normalized], map_row)?;
+                let Some(user) = rows.next().transpose()? else {
+                    return Ok(None);
+                };
+                drop(rows);
+                drop(stmt);
+                Ok(Some(User { shortcodes: shortcodes_of(tx, user.id)?, ..user }))
+            })
+            .await?)
+    }
+
+    async fn list(&self) -> Result<Vec<User>> {
+        Ok(self
+            .read_tx(|tx| {
+                let mut users = {
+                    let mut stmt = tx.prepare(&format!("{SELECT} ORDER BY email_normalized"))?;
+                    let rows = stmt.query_map([], map_row)?;
+                    rows.collect::<rusqlite::Result<Vec<User>>>()?
+                };
+                // One query for every assignment rather than one per user, so
+                // the depositor list does not scale in queries with its length.
+                let mut stmt = tx.prepare("SELECT user_id, shortcode FROM user_shortcodes ORDER BY shortcode")?;
+                let assignments = stmt
+                    .query_map([], |row| Ok((uuid_column(row, 0)?, row.get::<_, String>(1)?)))?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                for (user_id, shortcode) in assignments {
+                    if let Some(user) = users.iter_mut().find(|u| u.id == user_id) {
+                        user.shortcodes.push(shortcode);
+                    }
+                }
+                Ok(users)
+            })
+            .await?)
+    }
+
+    async fn record_failed_login(&self, id: Uuid) -> Result<u32> {
+        // Incremented and read back in one transaction, so two simultaneous wrong
+        // codes cannot both read the old value and count as one.
+        let failed = self
+            .write(move |tx| {
+                let updated = tx.execute(
+                    "UPDATE users SET failed_logins = failed_logins + 1 WHERE id = ?1",
+                    params![id.to_string()],
+                )?;
+                if updated == 0 {
+                    return Ok(None);
+                }
+                let count: i64 = tx.query_row(
+                    "SELECT failed_logins FROM users WHERE id = ?1",
+                    params![id.to_string()],
+                    |row| row.get(0),
+                )?;
+                Ok(Some(counter(count)))
+            })
+            .await?;
+        failed.ok_or(editor_core::repository::RepositoryError::NotFound { entity: ENTITY })
+    }
+
+    async fn clear_failed_logins(&self, id: Uuid) -> Result<()> {
+        let cleared = self
+            .write(move |tx| tx.execute("UPDATE users SET failed_logins = 0 WHERE id = ?1", params![id.to_string()]))
+            .await?;
+        if cleared == 0 {
+            return Err(editor_core::repository::RepositoryError::NotFound { entity: ENTITY });
+        }
+        Ok(())
+    }
+
+    async fn record_code_issued(&self, id: Uuid, at: DateTime<Utc>) -> Result<()> {
+        let updated = self
+            .write(move |tx| {
+                tx.execute("UPDATE users SET last_code_at = ?2 WHERE id = ?1", params![id.to_string(), at])
+            })
+            .await?;
+        if updated == 0 {
+            return Err(editor_core::repository::RepositoryError::NotFound { entity: ENTITY });
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use editor_core::repository::RepositoryError;
+
+    use super::super::tests::{count, test_db};
+    use super::*;
+
+    fn at(hour: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 8, 21, hour, 0, 0).unwrap()
+    }
+
+    fn depositor(email: &str, shortcodes: &[&str]) -> User {
+        User {
+            id: Uuid::new_v4(),
+            email: email.to_string(),
+            name: "A Depositor".to_string(),
+            role: Role::Depositor,
+            shortcodes: shortcodes.iter().map(|s| (*s).to_string()).collect(),
+            failed_logins: 0,
+            last_code_at: None,
+            created_at: at(10),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_then_find_round_trips_every_field() {
+        let db = test_db("users-round-trip").await;
+        let user = depositor("A.User@Example.TEST", &["0801", "0803"]);
+        db.create(&user).await.unwrap();
+
+        let found = db.find_by_id(user.id).await.unwrap().expect("the user should be found");
+        assert_eq!(found, user, "every field, shortcodes included, must survive the round trip");
+    }
+
+    #[tokio::test]
+    async fn test_create_rejects_a_duplicate_address_case_insensitively() {
+        // REQ-7.4. Folding case matters: without it `A@x.test` would be accepted
+        // alongside `a@x.test` and both would receive login codes.
+        let db = test_db("users-duplicate").await;
+        db.create(&depositor("a@x.test", &[])).await.unwrap();
+
+        let error = db
+            .create(&depositor("A@X.test", &[]))
+            .await
+            .expect_err("a duplicate must be rejected");
+        assert!(matches!(error, RepositoryError::Conflict { entity: "user" }), "{error}");
+        assert_eq!(count(&db, "users").await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_find_by_email_ignores_case_and_surrounding_space() {
+        let db = test_db("users-find-email").await;
+        let user = depositor("a.user@x.test", &["0801"]);
+        db.create(&user).await.unwrap();
+
+        for typed in ["a.user@x.test", "A.User@X.TEST", "  a.user@x.test  "] {
+            let found = db.find_by_email(typed).await.unwrap();
+            assert_eq!(found.map(|u| u.id), Some(user.id), "lookup of {typed:?} should match");
+        }
+        assert!(db.find_by_email("nobody@x.test").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_update_replaces_shortcodes_rather_than_adding_to_them() {
+        // Removing an assignment has to actually remove it — a depositor who
+        // keeps a shortcode after RDU takes it away keeps access to that project.
+        let db = test_db("users-update").await;
+        let mut user = depositor("a@x.test", &["0801", "0803"]);
+        db.create(&user).await.unwrap();
+
+        user.name = "Renamed".to_string();
+        user.shortcodes = vec!["0803".to_string(), "0805".to_string()];
+        db.update(&user).await.unwrap();
+
+        let found = db.find_by_id(user.id).await.unwrap().unwrap();
+        assert_eq!(found.name, "Renamed");
+        assert_eq!(found.shortcodes, vec!["0803".to_string(), "0805".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_update_of_an_unknown_user_is_not_found_not_success() {
+        let db = test_db("users-update-missing").await;
+        let error = db
+            .update(&depositor("a@x.test", &[]))
+            .await
+            .expect_err("an unknown user must not update");
+        assert!(matches!(error, RepositoryError::NotFound { entity: "user" }), "{error}");
+    }
+
+    #[tokio::test]
+    async fn test_delete_takes_sessions_codes_and_assignments_with_it() {
+        // REQ-7.5, and the observable proof that `PRAGMA foreign_keys` is on:
+        // without it the cascade silently does nothing and orphaned sessions
+        // accumulate against a deleted account.
+        let db = test_db("users-delete-cascade").await;
+        let user = depositor("a@x.test", &["0801"]);
+        db.create(&user).await.unwrap();
+        let user_id = user.id.to_string();
+        db.write(move |tx| {
+            tx.execute(
+                "INSERT INTO sessions (id, user_id, created_at, last_seen_at, expires_at) \
+                 VALUES ('s1', ?1, ?2, ?2, ?3)",
+                params![user_id, at(10), at(12)],
+            )?;
+            tx.execute(
+                "INSERT INTO login_codes (id, user_id, code, created_at, expires_at) VALUES (?1, ?2, '123456', ?3, ?4)",
+                params![Uuid::new_v4().to_string(), user_id, at(10), at(11)],
+            )
+        })
+        .await
+        .unwrap();
+
+        db.delete(user.id).await.unwrap();
+
+        assert_eq!(count(&db, "users").await, 0);
+        assert_eq!(count(&db, "sessions").await, 0, "sessions must cascade");
+        assert_eq!(count(&db, "login_codes").await, 0, "codes must cascade");
+        assert_eq!(count(&db, "user_shortcodes").await, 0, "assignments must cascade");
+    }
+
+    #[tokio::test]
+    async fn test_delete_leaves_drafts_and_submissions_with_a_null_author() {
+        // ON DELETE SET NULL, not CASCADE: removing an account must not destroy
+        // the project's work, and "last editor" then reads as unknown rather
+        // than pointing at a row that is gone.
+        let db = test_db("users-delete-set-null").await;
+        let user = depositor("a@x.test", &[]);
+        db.create(&user).await.unwrap();
+        let user_id = user.id.to_string();
+        db.write(move |tx| {
+            tx.execute(
+                "INSERT INTO drafts (shortcode, payload, updated_by, created_at, updated_at) \
+                 VALUES ('0801', '{}', ?1, ?2, ?2)",
+                params![user_id, at(10)],
+            )
+        })
+        .await
+        .unwrap();
+
+        db.delete(user.id).await.unwrap();
+
+        let author: Option<String> = db
+            .read(|conn| conn.query_row("SELECT updated_by FROM drafts WHERE shortcode = '0801'", [], |row| row.get(0)))
+            .await
+            .unwrap();
+        assert_eq!(author, None);
+        assert_eq!(count(&db, "drafts").await, 1, "the draft itself must survive");
+    }
+
+    #[tokio::test]
+    async fn test_failed_login_counter_survives_and_only_a_success_clears_it() {
+        // NIST SP 800-63B-4: "Generating a new authentication secret SHALL NOT
+        // reset the failed authentication count." The counter lives on the user
+        // for exactly this reason — a per-code counter hands out a fresh budget
+        // on every resend.
+        let db = test_db("users-failed-logins").await;
+        let user = depositor("a@x.test", &[]);
+        db.create(&user).await.unwrap();
+
+        assert_eq!(db.record_failed_login(user.id).await.unwrap(), 1);
+        assert_eq!(db.record_failed_login(user.id).await.unwrap(), 2);
+
+        // Issuing a new code must not touch it.
+        db.record_code_issued(user.id, at(11)).await.unwrap();
+        assert_eq!(db.find_by_id(user.id).await.unwrap().unwrap().failed_logins, 2);
+
+        db.clear_failed_logins(user.id).await.unwrap();
+        assert_eq!(db.find_by_id(user.id).await.unwrap().unwrap().failed_logins, 0);
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_failed_logins_are_all_counted() {
+        // Read-modify-write in one transaction. Two simultaneous wrong codes
+        // must count as two, or the lockout can be outrun by parallel guessing.
+        let db = test_db("users-failed-concurrent").await;
+        let user = depositor("a@x.test", &[]);
+        db.create(&user).await.unwrap();
+
+        let mut handles = Vec::new();
+        for _ in 0..16 {
+            let db = db.clone();
+            let id = user.id;
+            handles.push(tokio::spawn(async move { db.record_failed_login(id).await }));
+        }
+        for handle in handles {
+            handle.await.unwrap().unwrap();
+        }
+        assert_eq!(db.find_by_id(user.id).await.unwrap().unwrap().failed_logins, 16);
+    }
+
+    #[tokio::test]
+    async fn test_record_code_issued_stamps_the_time_for_rdu_diagnosis() {
+        let db = test_db("users-last-code").await;
+        let user = depositor("a@x.test", &[]);
+        db.create(&user).await.unwrap();
+        assert_eq!(db.find_by_id(user.id).await.unwrap().unwrap().last_code_at, None);
+
+        db.record_code_issued(user.id, at(11)).await.unwrap();
+        assert_eq!(db.find_by_id(user.id).await.unwrap().unwrap().last_code_at, Some(at(11)));
+    }
+
+    #[tokio::test]
+    async fn test_list_returns_every_user_with_its_own_assignments() {
+        let db = test_db("users-list").await;
+        db.create(&depositor("b@x.test", &["0803"])).await.unwrap();
+        db.create(&depositor("a@x.test", &["0801", "0802"])).await.unwrap();
+        db.create(&User { role: Role::Rdu, ..depositor("c@x.test", &[]) })
+            .await
+            .unwrap();
+
+        let users = db.list().await.unwrap();
+        let listed: Vec<_> = users.iter().map(|u| (u.email.as_str(), u.shortcodes.clone())).collect();
+        assert_eq!(
+            listed,
+            vec![
+                ("a@x.test", vec!["0801".to_string(), "0802".to_string()]),
+                ("b@x.test", vec!["0803".to_string()]),
+                ("c@x.test", vec![]),
+            ],
+            "assignments must not leak between users"
+        );
+    }
+}

--- a/modules/editor/server/src/main.rs
+++ b/modules/editor/server/src/main.rs
@@ -13,6 +13,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use clap::{Parser, Subcommand};
 
 mod config;
+mod db;
 mod page_url;
 mod router;
 mod traceparent;
@@ -225,12 +226,39 @@ async fn serve() -> ExitCode {
         .data_dir
         .as_deref()
         .map_or_else(|| "<unset>".to_string(), |path| path.display().to_string());
+    let db_dir = config
+        .db_dir
+        .as_deref()
+        .map_or_else(|| "<unset, in-memory>".to_string(), |path| path.display().to_string());
     tracing::info!(
         env = %config.env,
         public_dir = %config.public_dir.display(),
         data_dir = %data_dir,
+        db_dir = %db_dir,
         "editor configuration loaded"
     );
+
+    // Persistence. Opened before the listener binds, so a bad mount or a
+    // wrong-uid directory stops the process with a message naming the cause
+    // rather than answering requests that fail one query at a time.
+    //
+    // Reported rather than panicked for the same reason as the config load: the
+    // likely failures here are operational (a missing or wrongly-owned mount),
+    // and `DbError`'s messages already say what to do about them, which a panic
+    // would bury under a backtrace.
+    //
+    // Bound with a leading underscore because nothing reads it yet — the handlers
+    // that will take it as state land with authentication. The binding keeps the
+    // pools alive for the life of the process, which the in-memory variant needs:
+    // a shared-cache in-memory database exists only while a connection to it is
+    // open.
+    let _db = match db::Database::open(config.db_source(), config.db_readers, config.db_busy_timeout()).await {
+        Ok(db) => db,
+        Err(e) => {
+            tracing::error!(error = %e, "failed to open the database");
+            return ExitCode::FAILURE;
+        }
+    };
 
     let addr: std::net::SocketAddr = config
         .site_addr


### PR DESCRIPTION
[DEV-6908](https://linear.app/dasch/issue/DEV-6908)

Fixes DEV-6908

## Motivation

Phase 2 of the [Metadata Editor v1 plan](https://github.com/dasch-swiss/dasch-specs/pull/168). The editor holds users, sessions, one-time codes, drafts, submissions and approved-but-uncollected records, and nothing in `dsp-repository` persists anything today — there is no SQLite, `sqlx` or `rusqlite` anywhere, so there was no in-repo pattern to copy. Everything Phase 3 onwards writes depends on this layer existing and on it being right about concurrency.

## Summary

- One SQLite database behind six repository ports, with `rusqlite` (`bundled`) and `deadpool-sqlite`.
- The five failure modes the issue enumerates are designed out structurally rather than documented as rules to remember.
- In-memory is the default, so tests, `just dev-editor` and the publicly reachable Cloud Run preview all need no volume and cannot accumulate state.

## Key Changes

### `editor-core` — the contract
- `records.rs`: `User`, `Role`, `Session`, `LoginCode`, `DraftRecord`, `Submission`, `SubmissionState`, `ApprovedRecord`. Framework-free — no Axum, Maud or driver dependency.
- `repository.rs`: one trait per aggregate plus `RepositoryError`. Handlers depend on these, not on `rusqlite`.
- Drafts, submissions and approved records carry their body as an opaque JSON `payload: String`. The permissive draft representation is Phase 4's work; typing it later changes those three structs and nothing else.

### `editor-server/src/db/` — the SQLite implementation
- `mod.rs`: the two pools, `read` / `read_tx` / `write`, the PRAGMA init hook, and the startup pre-flight.
- `schema.rs` + `migrations/0001_initial.sql`: forward-only statement list guarded by `PRAGMA user_version`.
- `mapping.rs`: id and enum column mapping, so an unrecognised stored value is an error and not a default.
- `users.rs`, `sessions.rs`, `login_codes.rs`, `drafts.rs`, `submissions.rs`, `approved_records.rs`: the six trait impls.

### Configuration
- `EDITOR_DB_DIR` (no default — unset means in-memory), `EDITOR_DB_READERS` (4), `EDITOR_DB_BUSY_TIMEOUT_MS` (5000).
- `serve()` opens the database before binding the listener, so a bad mount stops the process instead of failing one query at a time.

### Documentation
- `docs/src/editor/architecture.md`: a Persistence section covering the pool split, the PRAGMA placement, the schema mechanism and the in-memory variant.
- `docs/src/editor/operations.md`: a Database section — the in-memory default and why it is preview safety, the volume rules, the pre-flight, storage type, and the backup/`synchronous=NORMAL` trade.
- `modules/editor/Dockerfile`: records why the image deliberately leaves `EDITOR_DB_DIR` unset.

## Challenges and Decisions

### `rusqlite` 0.40 and `deadpool-sqlite` cannot coexist

**Problem:** the issue specifies `rusqlite` 0.40.1 *and* `deadpool-sqlite`. They are not jointly satisfiable. `deadpool-sqlite` 0.13.0 (latest, Feb 2026) requires `rusqlite ^0.38`; `rusqlite` 0.40 needs `libsqlite3-sys ^0.38` against 0.38's `^0.36`. Both `libsqlite3-sys` versions declare `links = "sqlite3"`, so cargo refuses to link both — a hard build error, not a warning.

**Tried:** `r2d2_sqlite` 0.35 does track `rusqlite ^0.40`, but r2d2 is a blocking pool — `get()` parks a Tokio worker, so the whole acquire-and-query has to sit inside `spawn_blocking`. That is the weakest fit for the issue's "structurally, not by convention" requirement. Building our own manager over `deadpool` + `deadpool-sync` (what `deadpool-sqlite` is a thin wrapper around) also works and keeps 0.40, at the cost of owning ~50 lines of pool plumbing permanently.

**Solution:** pin `rusqlite` to 0.38 and keep `deadpool-sqlite`. The pool is the load-bearing half — `interact()` is what keeps a `!Sync` connection from ever crossing an `.await` — while the driver minor has no named consequence for this service. Recorded in the workspace `Cargo.toml` and in the architecture doc; bump both together once `deadpool-sqlite` tracks 0.40.

### Making `BEGIN IMMEDIATE` structural rather than a rule

**Problem:** "open every write with `BEGIN IMMEDIATE`" is exactly the kind of rule that holds until someone adds a write somewhere else. Its failure mode is invisible in review and in tests: a deferred `BEGIN` takes a read lock and can fail to upgrade it at the first write, which happens only under concurrency, surfaces as `database is locked`, and reads like something `busy_timeout` should fix.

**Solution:** two pools. Readers carry `query_only=ON`, set once per connection in `post_create`, so a write through `read`/`read_tx` fails with `attempt to write a readonly database`. The only handle that can write comes from `write()`, which always opens `BEGIN IMMEDIATE`, commits on `Ok` and rolls back on `Err` or panic. The writer pool holds exactly one connection — SQLite allows one writer anyway, so a second would only move the queue out of the pool and into SQLite. Both properties have tests.

`query_only` was originally going to be toggled per call, which is worse: the reset has to happen on every path including the error ones, and a missed reset leaves a pooled connection rejecting writes for the rest of the process's life.

### A read that needs two statements

**Problem:** a user and its shortcode assignments live in two tables. Read in autocommit mode, each statement gets its own implicit read transaction, so a concurrent assignment change between them returns a user carrying shortcodes it no longer has.

**Tried:** routing those reads through `write()`, which is consistent — and puts every authenticated request's user lookup behind the single writer connection, serialising all of them.

**Solution:** `read_tx()`, a deferred read transaction on a reader connection. One snapshot, no writer contention, still `query_only`, and still confined to one `interact` closure so it cannot outlive the call and starve WAL checkpointing.

### A foreign-key failure is not a duplicate

**Problem:** the first version mapped `ErrorCode::ConstraintViolation` to `RepositoryError::Conflict`. That code also covers `NOT NULL`, `CHECK` and `FOREIGN KEY`, so a session created for a user deleted underneath it would have been reported as "session already exists" — sending the reader looking for a second row that does not exist.

**Solution:** match the extended result code, `SQLITE_CONSTRAINT_UNIQUE` / `SQLITE_CONSTRAINT_PRIMARYKEY` only. Everything else stays a backend error. Pinned by tests in `sessions.rs` and `drafts.rs`.

### The musl `bundled` check could not run locally

**Problem:** the issue calls the musl verification the first deliverable. macOS has no musl cross-linker, so it runs inside a container — and container egress on the dev machine is down: `deb.debian.org` and `registry-1.docker.io` both time out from inside a container (bridge *and* `--network host`) while the host reaches both fine. A Docker Desktop restart did not fix it, and `just build-docker-editor` needs `apt-get install musl-tools clang` before it can compile.

**Solution:** CI is the check. The `Build editor` job runs exactly `cargo build -p editor-server --release --target x86_64-unknown-linux-musl` on the target that ships, and the Cloud Run preview then runs the resulting distroless image with `EDITOR_DB_DIR` unset — so a preview that serves `/` has opened SQLite and applied migrations under musl. **Both must be green before merge.** What was verified locally is in the Test Plan.

## Gotchas

- **`migrations/0001_initial.sql` is append-only.** Never edit a released entry: databases that already ran it skip the edit, so the schema would differ by deployment age. A change is a new numbered file.
- **Never set `PRAGMA foreign_keys` from a migration.** It is a documented silent no-op inside a transaction, and the failure is invisible — `ON DELETE CASCADE` never fires, orphaned `sessions` accumulate against deleted `users`, and an integrity check passes because the constraint was never enforced. It belongs in `init_connection`, and that is the helper it would be tempting to share.
- **Add new PRAGMAs to `init_connection`, not to a one-off after the pool is built.** Everything except `journal_mode` is per-connection state, so central setup leaves every connection after the first at `busy_timeout=0` while the code reads as configured.
- **`EDITOR_DB_DIR` names the directory, not the file.** The filename is fixed at `editor.sqlite3` so SQLite can create `-wal` and `-shm` next to it. Pointing at a file now fails at startup with a message saying so, instead of at the first WAL write.
- **The image deliberately does not set `EDITOR_DB_DIR`.** Previews run this image, publicly reachable and with no volume; a default path would let them accumulate login codes, sessions and drafts. Production sets it through the deployment.
- **In-memory means a named shared-cache URI, never `:memory:`.** Bare `:memory:` gives every pooled connection its own empty database, and with a reader/writer split readers would never see the writer's rows. Tests use a distinct name each, because shared-cache in-memory databases are process-scoped and `cargo test` runs them in parallel threads.
- **`locking_mode=EXCLUSIVE` is documented, not configurable.** It is the escape hatch if virtiofs `mmap` ever misbehaves; a config knob for a path nothing exercises is worse than a one-line change in `init_connection`.
- **`user_shortcodes` is a seventh table**, beyond the six the issue names. It is part of the `users` aggregate — a child table rather than a JSON column, so "who holds shortcode X" is answerable when RDU takes an assignment away from someone holding a draft on it.
- **`ON DELETE SET NULL`, not `CASCADE`, for authorship.** Removing an account takes its sessions, codes and assignments (REQ-7.5) but leaves drafts, submissions and approved records with a null author. Which of keep-or-delete is right for a removed depositor's work is still open in the plan; this is the reversible half.

## Test Plan

- [x] `just check` — clippy `-D warnings`, `cargo +nightly fmt --check`, `maudfmt`, `just --fmt`, `cargo machete`
- [x] `just test` — full workspace suite green; 111 in `editor-server`, 60 of them new
- [x] `just commit-lint` — one commit, message rules pass
- [x] Reader connections reject writes; `foreign_keys` and `busy_timeout` asserted on connections beyond the first
- [x] 24 concurrent writes all commit; 16 concurrent failed-login increments all counted; exactly one of 12 concurrent consumptions of one code wins
- [x] A failed write rolls back the whole transaction, first statement included
- [x] Migrations apply to an empty database, are idempotent on re-run, survive a reopen without re-migrating, and a database from a newer release is refused
- [x] Timestamp TEXT columns order chronologically, so `expires_at > ?` is correct
- [x] Cascades and set-nulls verified through the repositories, not just the schema
- [x] Pre-flight: missing directory, file-instead-of-directory, unwritable directory, and no probe file left behind
- [x] Release binary (lto, `opt-level=z`) starts, opens the in-memory database, applies migration 1, serves `/` and `/healthz`
- [x] Release binary against a real directory: `editor.sqlite3` + `-wal` + `-shm` created, `journal_mode=wal`, `user_version=1`
- [x] Both pre-flight failures produce their intended operator-facing message from the real binary
- [x] **CI `Build editor`** — the static musl build with `bundled` passes (3m29s). Could not run locally; see Challenges.
- [x] **Cloud Run preview serves** — `GET /` returns 200 and renders the shell at `editor-pr-334-pbjdzenira-oa.a.run.app`. `Database::open` runs before the listener binds and exits non-zero on any failure, so a preview that answers has opened the in-memory database and applied migration 1 under musl, inside the distroless image. (`/healthz` still 404s on previews — a pre-existing proxy quirk, see `operations.md`.)

## Commit hygiene

- [x] I have reviewed and cleaned up the branch history (squashed working commits, clear messages) so it reads well on `main`
- [ ] allow-many-commits — tick only if this PR is genuinely several independent, self-contained changes that each deserve their own line in `main`'s history
