### PR TITLE
chore(ci): bound job runtime and harden network fetches

### DIFF
--- a/.github/actions/build-dpe/action.yml
+++ b/.github/actions/build-dpe/action.yml
@@ -11,7 +11,9 @@ runs:
 
     - name: Install system dependencies
       shell: bash
-      run: sudo apt-get update -y && sudo apt-get install -y --no-install-recommends musl-tools clang
+      run: >-
+        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 update -y &&
+        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 install -y --no-install-recommends musl-tools clang
 
     - name: Add build target
       shell: bash

--- a/.github/actions/build-editor/action.yml
+++ b/.github/actions/build-editor/action.yml
@@ -11,7 +11,9 @@ runs:
 
     - name: Install system dependencies
       shell: bash
-      run: sudo apt-get update -y && sudo apt-get install -y --no-install-recommends musl-tools clang
+      run: >-
+        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 update -y &&
+        sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 install -y --no-install-recommends musl-tools clang
 
     - name: Add build target
       shell: bash

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,6 +28,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     name: check
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:
@@ -51,6 +52,7 @@ jobs:
     # API be documented as only available in some specific platforms.
     runs-on: ubuntu-latest
     name: check / rustdoc / nightly
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:
@@ -67,6 +69,7 @@ jobs:
     # which is required for feature unification
     runs-on: ubuntu-latest
     name: check / hack / ubuntu / stable / features
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:
@@ -83,6 +86,7 @@ jobs:
   lint-e2e:
     runs-on: ubuntu-latest
     name: check / biome / e2e
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -96,6 +100,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     name: check / docs / stable
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/cloud-run-dpe-pull-request.yml
+++ b/.github/workflows/cloud-run-dpe-pull-request.yml
@@ -35,6 +35,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:
@@ -55,6 +56,7 @@ jobs:
     name: Deploy DPE preview
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -133,6 +135,7 @@ jobs:
     # Dependabot PRs never deploy a preview, so there is nothing to clean up.
     if: github.event.action == 'closed' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2

--- a/.github/workflows/cloud-run-editor-pull-request.yml
+++ b/.github/workflows/cloud-run-editor-pull-request.yml
@@ -38,6 +38,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:
@@ -58,6 +59,7 @@ jobs:
     name: Deploy editor preview
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -136,6 +138,7 @@ jobs:
     # Dependabot PRs never deploy a preview, so there is nothing to clean up.
     if: github.event.action == 'closed' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2

--- a/.github/workflows/dpe-docker-publish.yml
+++ b/.github/workflows/dpe-docker-publish.yml
@@ -16,6 +16,7 @@ jobs:
   build:
     name: Build DPE
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
@@ -40,6 +41,7 @@ jobs:
     name: Publish DPE image
     runs-on: ubuntu-latest
     needs: build
+    timeout-minutes: 20
     outputs:
       tag: ${{ needs.build.outputs.tag }}
     steps:
@@ -62,6 +64,7 @@ jobs:
     name: Trigger deployment to DEV
     runs-on: ubuntu-latest
     needs: publish
+    timeout-minutes: 20
     steps:
       - name: Trigger deployment to DEV
         env:

--- a/.github/workflows/editor-docker-publish.yml
+++ b/.github/workflows/editor-docker-publish.yml
@@ -16,6 +16,7 @@ jobs:
   build:
     name: Build editor
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
@@ -40,6 +41,7 @@ jobs:
     name: Publish editor image
     runs-on: ubuntu-latest
     needs: build
+    timeout-minutes: 20
     outputs:
       tag: ${{ needs.build.outputs.tag }}
     steps:
@@ -62,6 +64,7 @@ jobs:
     name: Trigger deployment to DEV
     runs-on: ubuntu-latest
     needs: publish
+    timeout-minutes: 20
     # TOLERATED FAILURE, TO BE REMOVED. The editor is not registered as a
     # deployable service in Jenkins yet — that lands with the deployment work,
     # along with its inventory host and playbook. Until then the webhook rejects

--- a/.github/workflows/scout-dpe.yml
+++ b/.github/workflows/scout-dpe.yml
@@ -24,6 +24,7 @@ jobs:
       github.actor != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/scout-editor.yml
+++ b/.github/workflows/scout-editor.yml
@@ -26,6 +26,7 @@ jobs:
       github.actor != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
   required:
     runs-on: ubuntu-latest
     name: test / ubuntu / ${{ matrix.toolchain }}
+    timeout-minutes: 20
     strategy:
       matrix:
         # run on stable and beta to ensure that tests won't break on the next version of the rust
@@ -32,7 +33,7 @@ jobs:
           key: ${{ matrix.toolchain }}
       - uses: taiki-e/install-action@nextest
       - name: Install xmllint
-        run: sudo apt-get install -y libxml2-utils
+        run: sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 install -y libxml2-utils
       - name: cargo nextest run
         run: cargo nextest run --locked --all-features --all-targets
         env:
@@ -43,6 +44,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     name: test / coverage
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - name: Install stable
@@ -54,7 +56,7 @@ jobs:
           key: coverage
       - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Install xmllint
-        run: sudo apt-get install -y libxml2-utils
+        run: sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 install -y libxml2-utils
       - name: Generate coverage
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info
       - name: Upload to Codecov

--- a/justfile
+++ b/justfile
@@ -259,7 +259,7 @@ _tailwind-bin:
         mkdir -p target/tailwind
         url="https://github.com/tailwindlabs/tailwindcss/releases/download/v$ver/tailwindcss-$os-$arch"
         echo "fetching Tailwind standalone CLI: $url" >&2
-        curl -fsSL -o "$bin" "$url"
+        curl -fsSL --connect-timeout 10 --max-time 60 --retry 3 -o "$bin" "$url"
         chmod +x "$bin"
     fi
     echo "$bin"


### PR DESCRIPTION
Fixes DEV-7001

## Motivation
On PR #329, two workflows (`Cloud Run PR Preview for editor` and `Scout / editor`) hung for 66 minutes and had to be cancelled by hand. Both stalled on the same `apt-get` step in `build-editor/action.yml`, where an Azure Ubuntu mirror failed and the fallback fetch to `archive.ubuntu.com` never completed. No workflow in this repo sets `timeout-minutes` (except `claude.yml`), so a hung job runs to GitHub's 6-hour default — the only reason this was "just" 66 minutes is that someone noticed and cancelled it. `gh run list` history shows this failure class has already recurred unnoticed: multi-hour stalls on `scout-dpe.yml` (973m, 182m) and `check.yml` (179m).

## Summary
- Add `timeout-minutes: 20` to every job that builds, publishes, previews, scans, checks, or tests the editor/DPE images — 20m gives ~3x headroom over the slowest observed legitimate run (7m) across every job in scope.
- Add apt-get retry/timeout flags (`-o Acquire::Retries=3 -o Acquire::http::Timeout=30`) to the four apt-get call sites, and curl retry/timeout flags to the Tailwind CLI fetch in `justfile`.

## Key Changes
### `timeout-minutes: 20`
- `cloud-run-editor-pull-request.yml` / `cloud-run-dpe-pull-request.yml`: `build`, `deploy-preview`, `cleanup-preview`
- `scout-editor.yml` / `scout-dpe.yml`: `scan`
- `editor-docker-publish.yml` / `dpe-docker-publish.yml`: `build`, `publish`, `trigger-dev-deployment`
- `check.yml`: `check`, `rustdoc`, `hack`, `lint-e2e`, `docs`
- `test.yml`: `required`, `coverage`

### Network hardening
- `build-editor/action.yml:14`, `build-dpe/action.yml:14`: `apt-get update`/`install` retry + timeout flags
- `test.yml:35`, `test.yml:57`: `apt-get install libxml2-utils` retry + timeout flags
- `justfile:262`: `curl` fetch of the Tailwind standalone CLI gets `--connect-timeout 10 --max-time 60 --retry 3`

## Challenges and Decisions
### Picking the timeout ceiling
**Problem:** the issue asked for a ceiling "from observed durations with headroom" rather than naming a number.
**Solution:** pulled `gh run list --json createdAt,updatedAt` (last ~50 runs) for every affected workflow. Every legitimate run across build/preview/scout/check/test completes in 2–7 minutes; the only outliers are pathological stalls (66–75m, and previously-unnoticed 179–973m runs on `scout-dpe.yml`/`check.yml`). Picked a uniform 20 minutes — matches the issue's own suggested ceiling for the editor preview, gives ~3x headroom over the slowest genuine run, and avoids per-job tuning that would need its own maintenance.

### Extending beyond the issue's literal scope
**Problem:** the issue enumerated 4 apt call sites + 1 curl site + "build/preview/Scout/check/test jobs," but review turned up 4 more jobs with the identical gap: `cleanup-preview` in both `cloud-run-*-pull-request.yml` (same files this PR already touches) and all three jobs in both `*-docker-publish.yml` (direct consumers of the now-hardened `build-editor`/`build-dpe` composite actions, running on every push to `main`).
**Solution:** included these four — same failure class as the incident, one-line-each, and leaving them out would mean "bound job runtime" was only half-applied to the very actions this PR hardens. Deferred a fifth finding (Mosaic playground's own Dockerfile/CI, a different module entirely) to a follow-up issue rather than growing this diff further.

## Gotchas
- `cleanup-preview` jobs fire unattended on PR close — a timeout there matters even though nobody is watching, unlike the build/preview jobs someone might notice hung.
- The Mosaic playground module (`modules/mosaic/playground/Dockerfile`, `scout-mosaic-playground.yml`, `cloud-run-mosaic-pull-request.yml`) has the same missing-hardening pattern (unguarded `curl` for the same Tailwind CLI, no `timeout-minutes` anywhere) but was left out of this PR — file a follow-up issue before assuming it's covered.
- `justfile`'s `build-docker-editor` recipe still runs the un-hardened `apt-get` locally (comment says it mirrors `build-editor/action.yml` "exactly") — low priority since it's local-only and never runs unattended, but worth a follow-up if it becomes annoying.

## Test Plan
- [x] `actionlint` (full-repo discovery, so composite actions parse correctly) — zero new findings; the two pre-existing findings in `gh-pages.yml` are unrelated and untouched by this diff
- [x] `just check` — passes (no Rust/build-system code touched)
- [x] `just commit-lint` — one commit, valid `chore(ci)` type/scope
- [x] Adversarial review (devops-reviewer, consistency-reviewer, dune-reviewer + independent refutation pass) on the diff — 12 of 13 raw findings survived verification; the 4 in-scope ones are folded into this PR, the Mosaic one deferred to follow-up
- [ ] CI green on this PR (workflows affected: `check`, `test`, `cloud-run-editor-pull-request`, `cloud-run-dpe-pull-request`, `scout-editor`, `scout-dpe`)

## Commit hygiene
- [x] I have reviewed and cleaned up the branch history (squashed working commits, clear messages) so it reads well on `main`
- [ ] allow-many-commits — tick only if this PR is genuinely several independent, self-contained changes that each deserve their own line in `main`'s history
